### PR TITLE
fix(init): python and java init is broken due to invalid versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,5 @@ jobs:
           status="completed" -F conclusion="success"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    container:
+      image: jsii/superchain

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - run: pip3 install pipenv
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         run: |-
           git config user.name "Automation"
           git config user.email "github-actions@github.com"
+      - run: pip3 install pipenv
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
         with:
           name: dist
           path: dist
+    container:
+      image: jsii/superchain
   release_npm:
     name: Release to NPM
     needs: release

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - run: pip3 install pipenv
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
@@ -31,12 +32,14 @@ jobs:
       - name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > ${{ runner.temp }}/upgrade.patch
+          git diff --patch --staged > .upgrade.tmp.patch
       - name: Upload patch
         uses: actions/upload-artifact@v2
         with:
-          name: upgrade.patch
-          path: ${{ runner.temp }}/upgrade.patch
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
+    container:
+      image: jsii/superchain
   pr:
     name: Create Pull Request
     needs: upgrade
@@ -51,16 +54,16 @@ jobs:
       - name: Download patch
         uses: actions/download-artifact@v2
         with:
-          name: upgrade.patch
-          path: ${{ runner.temp }}
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
       - name: Apply patch
-        run: '[ -s ${{ runner.temp }}/upgrade.patch ] && git apply ${{ runner.temp
-          }}/upgrade.patch || echo "Empty patch. Skipping."'
+        run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo "Empty
+          patch. Skipping."'
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: >-
             chore(deps): upgrade dependencies
 

--- a/.github/workflows/upgrade-projen.yml
+++ b/.github/workflows/upgrade-projen.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - run: pip3 install pipenv
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
@@ -31,12 +32,14 @@ jobs:
       - name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > ${{ runner.temp }}/upgrade.patch
+          git diff --patch --staged > .upgrade.tmp.patch
       - name: Upload patch
         uses: actions/upload-artifact@v2
         with:
-          name: upgrade.patch
-          path: ${{ runner.temp }}/upgrade.patch
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
+    container:
+      image: jsii/superchain
   pr:
     name: Create Pull Request
     needs: upgrade
@@ -51,11 +54,11 @@ jobs:
       - name: Download patch
         uses: actions/download-artifact@v2
         with:
-          name: upgrade.patch
-          path: ${{ runner.temp }}
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
       - name: Apply patch
-        run: '[ -s ${{ runner.temp }}/upgrade.patch ] && git apply ${{ runner.temp
-          }}/upgrade.patch || echo "Empty patch. Skipping."'
+        run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo "Empty
+          patch. Skipping."'
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v3

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -67,7 +67,7 @@
     },
     {
       "name": "projen",
-      "version": "^0.20.2",
+      "version": "^0.20.8",
       "type": "build"
     },
     {

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -93,6 +93,10 @@
       "type": "runtime"
     },
     {
+      "name": "cdk8s-plus-17",
+      "type": "runtime"
+    },
+    {
       "name": "codemaker",
       "type": "runtime"
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -59,9 +59,6 @@
       "description": "Run tests",
       "steps": [
         {
-          "exec": "rm -fr lib/"
-        },
-        {
           "spawn": "test:compile"
         },
         {
@@ -81,10 +78,10 @@
           "exec": "npx projen"
         },
         {
-          "spawn": "test"
+          "spawn": "compile"
         },
         {
-          "spawn": "compile"
+          "spawn": "test"
         },
         {
           "spawn": "package"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -10,7 +10,11 @@ const project = new TypeScriptProject({
   authorUrl: 'https://aws.amazon.com',
   minNodeVersion: '10.17.0',
   defaultReleaseBranch: 'main',
-  workflowContainerImage: 'jsii/superchain', // needed for "cdk init" tests to work in all languages
+
+  // needed for "cdk init" tests to work in all languages
+  workflowContainerImage: 'jsii/superchain',
+  workflowBootstrapSteps: [{ run: 'pip3 install pipenv' }],
+
   releaseToNpm: true,
   bin: {
     cdk8s: 'bin/cdk8s',

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -36,6 +36,9 @@ const project = new TypeScriptProject({
     '@types/fs-extra@^8',
     '@types/json-schema',
   ],
+
+  // we need the compiled .js files for the init tests (we run the cli in there)
+  compileBeforeTest: true,
 });
 
 project.synth();

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -10,6 +10,7 @@ const project = new TypeScriptProject({
   authorUrl: 'https://aws.amazon.com',
   minNodeVersion: '10.17.0',
   defaultReleaseBranch: 'main',
+  workflowContainerImage: 'jsii/superchain', // needed for "cdk init" tests to work in all languages
   releaseToNpm: true,
   bin: {
     cdk8s: 'bin/cdk8s',

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -16,6 +16,7 @@ const project = new TypeScriptProject({
   },
   deps: [
     'cdk8s',
+    'cdk8s-plus-17',
     'codemaker',
     'constructs',
     'fs-extra@^8',

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jest-junit": "^12",
     "json-schema": "^0.3.0",
     "npm-check-updates": "^11",
-    "projen": "^0.20.2",
+    "projen": "^0.20.8",
     "standard-version": "^9",
     "ts-jest": "^26.5.6",
     "typescript": "~3.9.9"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@types/node": "^10.17.0",
     "cdk8s": "1.0.0-beta.14",
+    "cdk8s-plus-17": "1.0.0-beta.18",
     "codemaker": "^1.30.0",
     "colors": "^1.4.0",
     "constructs": "^3.3.75",

--- a/templates/java-app/.hooks.sscaff.js
+++ b/templates/java-app/.hooks.sscaff.js
@@ -15,7 +15,7 @@ exports.pre = (variables) => {
 };
 
 exports.post = options => {
-  const { mvn_cdk8s, mvn_cdk8s_plus, cdk8s_version } = options;
+  const { mvn_cdk8s, mvn_cdk8s_plus, cdk8s_core_version, cdk8s_plus_version } = options;
   if (!mvn_cdk8s) {
     throw new Error(`missing context "mvn_cdk8s"`);
   }
@@ -27,11 +27,11 @@ exports.post = options => {
   // This is used for installing artifacts that are local (not from Maven)
   // https://maven.apache.org/plugins/maven-install-plugin/usage.html
   if (mvn_cdk8s.endsWith('.jar')) {
-    execSync(`mvn install:install-file -Dfile=${mvn_cdk8s} -DgroupId=org.cdk8s -DartifactId=cdk8s -Dversion=${cdk8s_version} -Dpackaging=jar`)
+    execSync(`mvn install:install-file -Dfile=${mvn_cdk8s} -DgroupId=org.cdk8s -DartifactId=cdk8s -Dversion=${cdk8s_core_version} -Dpackaging=jar`)
   }
 
   if (mvn_cdk8s_plus.endsWith('.jar')) {
-    execSync(`mvn install:install-file -Dfile=${mvn_cdk8s_plus} -DgroupId=org.cdk8s -DartifactId=cdk8s-plus-17 -Dversion=${cdk8s_version} -Dpackaging=jar`)
+    execSync(`mvn install:install-file -Dfile=${mvn_cdk8s_plus} -DgroupId=org.cdk8s -DartifactId=cdk8s-plus-17 -Dversion=${cdk8s_plus_version} -Dpackaging=jar`)
   }
 
   execSync(`mvn install`);

--- a/templates/java-app/pom.xml
+++ b/templates/java-app/pom.xml
@@ -11,12 +11,12 @@
     <dependency>
       <groupId>org.cdk8s</groupId>
       <artifactId>cdk8s</artifactId>
-      <version>{{ cdk8s_version }}</version>
+      <version>{{ cdk8s_core_version }}</version>
     </dependency>
     <dependency>
       <groupId>org.cdk8s</groupId>
       <artifactId>cdk8s-plus-17</artifactId>
-      <version>{{ cdk8s_version }}</version>
+      <version>{{ cdk8s_plus_version }}</version>
     </dependency>
     <dependency>
       <groupId>software.constructs</groupId>

--- a/templates/python-app/.hooks.sscaff.js
+++ b/templates/python-app/.hooks.sscaff.js
@@ -23,27 +23,14 @@ exports.post = options => {
     throw new Error(`missing context "pypi_cdk8s_plus"`);
   }
 
-  const flags = [];
-
-  if (options.dist) {
-    // https://github.com/awslabs/cdk8s/pull/399
-    flags.push('--skip-lock');
-  }
-
-  if (options.pre) {
-    flags.push('--pre');
-  }
-
-  const args = flags.join(' ');
-
   execSync('pipenv lock --clear')
 
   // this installs the libraries in the Pipfile we provide
   execSync('pipenv install', { stdio: 'inherit' });
 
   // these are more akward to put in the Pipfile since they can be local wheel files
-  execSync(`pipenv install ${args} ${pypi_cdk8s}`, { stdio: 'inherit' });
-  execSync(`pipenv install ${args} ${pypi_cdk8s_plus}`, { stdio: 'inherit' });
+  execSync(`pipenv install --pre ${pypi_cdk8s}`, { stdio: 'inherit' });
+  execSync(`pipenv install --pre ${pypi_cdk8s_plus}`, { stdio: 'inherit' });
 
   chmodSync('main.py', '700');
 

--- a/test/init/init.test.ts
+++ b/test/init/init.test.ts
@@ -1,0 +1,19 @@
+import { execFileSync } from 'child_process';
+import { mkdtempSync, readdirSync, statSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const cli = require.resolve('../../lib/cli/index');
+
+const templates = [];
+const tdir = join(__dirname, '..', '..', 'templates');
+for (const file of readdirSync(tdir)) {
+  if (statSync(join(tdir, file)).isDirectory()) {
+    templates.push(file);
+  }
+}
+
+test.each(templates)('%s', name => {
+  const workdir = mkdtempSync(join(tmpdir(), 'cdk8s-init-test-'));
+  execFileSync(process.execPath, [cli, 'init', name], { cwd: workdir });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5613,10 +5613,10 @@ progress@^2.0.0, progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projen@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.20.2.tgz#e68fb5fa71c58800e60e8271c896657c37c369ff"
-  integrity sha512-31aC6crFj6s4eJn92uu1VjWiABtDgZmV7MuW8ioALH10HACgFYr6rMy7jWOvT6JX2bEMfs5Uyr3Oyf521RocOQ==
+projen@^0.20.8:
+  version "0.20.8"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.20.8.tgz#5f26fd742ebb6c5bfd2f7cd06494bdacf5d42fbd"
+  integrity sha512-kYxKr4YOH4Yh4gyW04ZjPuKMulwU1EnyxxbfmAetAx3+2zJZ0Xf5QAOCsRBKYVH2Ct6dMyliWwh60XFkqfg6gw==
   dependencies:
     "@iarna/toml" "^2.2.5"
     chalk "^4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,6 +1406,13 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+cdk8s-plus-17@1.0.0-beta.18:
+  version "1.0.0-beta.18"
+  resolved "https://registry.yarnpkg.com/cdk8s-plus-17/-/cdk8s-plus-17-1.0.0-beta.18.tgz#b7a7ebdadcf3a75618e719d5764344b515006f59"
+  integrity sha512-7TIYXo9fIdj8kawpiIaGNlhxewE2KbundrZDMMLSchsb9QtJBYQEj8a00kUBonPMpftwZCQY36RANEThq16BRQ==
+  dependencies:
+    minimatch "^3.0.4"
+
 cdk8s@1.0.0-beta.14:
   version "1.0.0-beta.14"
   resolved "https://registry.yarnpkg.com/cdk8s/-/cdk8s-1.0.0-beta.14.tgz#39c506e8d6440ff8b5b11066eb94174446055acd"


### PR DESCRIPTION
Now that we have decoupled the various modules in the CDK8s, we need to use a module-specific version instead of a uniform version.

Added an integration test which runs `cdk8s init TEMPLATE` for each template.

