### PR TITLE
chore: typescript-app init test fails during release

### DIFF
--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -55,10 +55,10 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: .upgrade.tmp.patch
-          path: .upgrade.tmp.patch
+          path: ${{ runner.temp }}
       - name: Apply patch
-        run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo "Empty
-          patch. Skipping."'
+        run: '[ -s ${{ runner.temp }}/.upgrade.tmp.patch ] && git apply ${{ runner.temp
+          }}/.upgrade.tmp.patch || echo "Empty patch. Skipping."'
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/upgrade-projen.yml
+++ b/.github/workflows/upgrade-projen.yml
@@ -55,10 +55,10 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: .upgrade.tmp.patch
-          path: .upgrade.tmp.patch
+          path: ${{ runner.temp }}
       - name: Apply patch
-        run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo "Empty
-          patch. Skipping."'
+        run: '[ -s ${{ runner.temp }}/.upgrade.tmp.patch ] && git apply ${{ runner.temp
+          }}/.upgrade.tmp.patch || echo "Empty patch. Skipping."'
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v3

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -67,7 +67,7 @@
     },
     {
       "name": "projen",
-      "version": "^0.20.8",
+      "version": "^0.20.10",
       "type": "build"
     },
     {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jest-junit": "^12",
     "json-schema": "^0.3.0",
     "npm-check-updates": "^11",
-    "projen": "^0.20.8",
+    "projen": "^0.20.10",
     "standard-version": "^9",
     "ts-jest": "^26.5.6",
     "typescript": "~3.9.9"

--- a/src/cli/cmds/init.ts
+++ b/src/cli/cmds/init.ts
@@ -13,6 +13,7 @@ const constructsVersion = pkg.dependencies.constructs.replace('^', '');
 const templatesDir = path.join(pkgroot, 'templates');
 const availableTemplates = fs.readdirSync(templatesDir).filter(x => !x.startsWith('.'));
 
+export const IS_TEST = 'CDK8S_TEST';
 
 class Command implements yargs.CommandModule {
   public readonly command = 'init TYPE';
@@ -47,7 +48,6 @@ async function determineDeps(): Promise<Deps> {
 
   return {
     npm_cdk8s: cdk8s.npmDependency,
-    npm_cdk8s_cli: cdk8sCli.npmDependency,
     npm_cdk8s_plus: cdk8sPlus17.npmDependency,
     pypi_cdk8s: cdk8s.pypiDependency,
     pypi_cdk8s_plus: cdk8sPlus17.pypiDependency,
@@ -56,12 +56,15 @@ async function determineDeps(): Promise<Deps> {
     cdk8s_core_version: cdk8s.version,
     cdk8s_plus_version: cdk8sPlus17.version,
     constructs_version: constructsVersion,
+
+    // do not attempt to install cdk8s cli if we are running in a test context
+    npm_cdk8s_cli: process.env[IS_TEST] ? undefined : cdk8sCli.npmDependency,
   };
 }
 
 interface Deps {
   npm_cdk8s: string;
-  npm_cdk8s_cli: string;
+  npm_cdk8s_cli?: string;
   npm_cdk8s_plus: string;
   pypi_cdk8s: string;
   pypi_cdk8s_plus: string;

--- a/test/init/init.test.ts
+++ b/test/init/init.test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'child_process';
 import { mkdtempSync, readdirSync, statSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { IS_TEST } from '../../src/cli/cmds/init';
 
 const cli = require.resolve('../../lib/cli/index');
 
@@ -15,5 +16,11 @@ for (const file of readdirSync(tdir)) {
 
 test.each(templates)('%s', name => {
   const workdir = mkdtempSync(join(tmpdir(), 'cdk8s-init-test-'));
-  execFileSync(process.execPath, [cli, 'init', name], { cwd: workdir });
+  execFileSync(process.execPath, [cli, 'init', name], {
+    cwd: workdir,
+    env: {
+      ...process.env,
+      [IS_TEST]: 'true', // indicates that we run in test context
+    },
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5613,10 +5613,10 @@ progress@^2.0.0, progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projen@^0.20.8:
-  version "0.20.8"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.20.8.tgz#5f26fd742ebb6c5bfd2f7cd06494bdacf5d42fbd"
-  integrity sha512-kYxKr4YOH4Yh4gyW04ZjPuKMulwU1EnyxxbfmAetAx3+2zJZ0Xf5QAOCsRBKYVH2Ct6dMyliWwh60XFkqfg6gw==
+projen@^0.20.10:
+  version "0.20.10"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.20.10.tgz#a80fbb4d4c4434b822a962a12af340e086ab5a79"
+  integrity sha512-TrBBYhF7qcNtPrNECmi0YHie9M90/eGmLbT0nYJNTDUiuqlEF2tivydSGclH884hTBtoFHiB7QuE7y8DuAp/Sw==
   dependencies:
     "@iarna/toml" "^2.2.5"
     chalk "^4.1.1"


### PR DESCRIPTION
The typescript-app template installs the cdk8s-cli in the project as a dev dependency. In non-release builds, the module version is `0.0.0` and sadly we actually published a `0.0.0` once, so this is the version being installed.

In release builds, the version is bumped to a new, non-released version, and then `cdk8s init` fails.

To address this, an environment flag was added `CDK8S_TEST` which is set to true during this test which causes the `cdk8s init` to use the executing cli instead of installing it through npm.

Also: upgrade projen.