### PR TITLE
Feat: Add support for HTTP(S) proxy set via environmental variables

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -32,6 +32,8 @@ const project = new TypeScriptProject({
     'yargs@^15',
     'json2jsii',
     'colors',
+    'http-proxy-agent',
+    'https-proxy-agent',
 
     // add @types/node as a regular dependency since it's needed to during "import"
     // to compile the generated jsii code.


### PR DESCRIPTION
Fixes #15
Use environmental variables `http_proxy`, `https_proxy `and `no_proxy` to determine behaviour of `util.ts`. Additionally it's necessary to set proxy configurations for other tools, eg. `~/.m2/settings.xml` for Maven.

Original pull request: https://github.com/cdk8s-team/cdk8s/pull/572

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license