### PR TITLE
fix kubectl apply -f example in template

### DIFF
--- a/templates/java-app/help
+++ b/templates/java-app/help
@@ -8,6 +8,6 @@
    mvn compile   Compiles your java packages
 
   Deploy:
-   kubectl apply -f dist/*.k8s.yaml
+   kubectl apply -f dist/
 
 ========================================================================================================

--- a/templates/python-app/help
+++ b/templates/python-app/help
@@ -7,6 +7,6 @@
    cdk8s import  Imports k8s API objects to "imports/k8s"
 
   Deploy:
-   kubectl apply -f dist/*.k8s.yaml
+   kubectl apply -f dist/
 
 ========================================================================================================

--- a/templates/typescript-app/help
+++ b/templates/typescript-app/help
@@ -13,7 +13,7 @@
    npm run synth       Synthesize k8s manifests from charts to dist/ (ready for 'kubectl apply -f')
 
  Deploy:
-   kubectl apply -f dist/*.k8s.yaml
+   kubectl apply -f dist/
 
  Upgrades:
    npm run import        Import/update k8s apis (you should check-in this directory)


### PR DESCRIPTION
 - `kubectl apply -f` takes either a file or a path as argument
 - wildcard argument `dist/*.k8s.yaml` fails with multiple files in `dist/`
 - replaced wildcard argument with path

Fixes #