### PR TITLE
feat: go project template and imports

### DIFF
--- a/src/cli/cmds/import.ts
+++ b/src/cli/cmds/import.ts
@@ -5,7 +5,7 @@ import { importDispatch } from '../../import/dispatch';
 const config = readConfigSync();
 
 const DEFAULT_OUTDIR = 'imports';
-const LANGUAGES = ['typescript', 'python', 'java'];
+const LANGUAGES = ['typescript', 'python', 'java', 'go'];
 
 class Command implements yargs.CommandModule {
   public readonly command = 'import [SPEC]';

--- a/src/cli/cmds/init.ts
+++ b/src/cli/cmds/init.ts
@@ -43,6 +43,7 @@ async function determineDeps(): Promise<Deps> {
   const cdk8s = new ModuleVersion('cdk8s', { jsii: true });
   const cdk8sPlus17 = new ModuleVersion('cdk8s-plus-17', { jsii: true });
   const cdk8sCli = new ModuleVersion('cdk8s-cli');
+  const jsii = new ModuleVersion('jsii');
 
   return {
     npm_cdk8s: cdk8s.npmDependency,
@@ -54,6 +55,7 @@ async function determineDeps(): Promise<Deps> {
     cdk8s_core_version: cdk8s.version,
     cdk8s_plus_version: cdk8sPlus17.version,
     constructs_version: constructsVersion,
+    jsii_version: jsii.version,
 
     // do not attempt to install cdk8s cli if we are running in a test context
     npm_cdk8s_cli: process.env.CDK8S_TEST ? undefined : cdk8sCli.npmDependency,
@@ -71,6 +73,7 @@ interface Deps {
   cdk8s_core_version: string;
   cdk8s_plus_version: string;
   constructs_version: string;
+  jsii_version: string;
 }
 
 class ModuleVersion {

--- a/src/import/base.ts
+++ b/src/import/base.ts
@@ -137,7 +137,7 @@ export abstract class ImportBase {
             const importModuleName = module.name.split('.')[0].replace(/[^A-Za-z0-9]/g, '').toLocaleLowerCase();
 
             opts.golang = {
-              outdir: 'imports',
+              outdir: outdir,
               moduleName: `${userModuleName}/imports`,
               packageName: moduleNamePrefix ? moduleNamePrefix + '_' + importModuleName : importModuleName,
             };

--- a/templates/go-app/.hooks.sscaff.js
+++ b/templates/go-app/.hooks.sscaff.js
@@ -1,0 +1,26 @@
+const { execSync } = require('child_process');
+const { readFileSync } = require('fs');
+const { platform } = require('os');
+
+const cli = require.resolve('../../bin/cdk8s');
+
+exports.pre = () => {
+  try {
+    execSync(`${platform() === 'win32' ? 'where' : 'which'} go`);
+  } catch {
+    console.error(`Unable to find "go". Install from https://golang.org/`);
+    process.exit(1);
+  }
+};
+
+exports.post = options => {
+  execSync(`${cli} import k8s -l go`);
+
+  // used to generate go.sum file which tracks hashes of all dependencies
+  execSync('go mod tidy');
+
+  execSync('go run .');
+
+  console.log(readFileSync('./help', 'utf-8'));
+};
+

--- a/templates/go-app/cdk8s.yaml
+++ b/templates/go-app/cdk8s.yaml
@@ -1,4 +1,4 @@
-language: python
+language: go
 app: go run main.go
 imports:
   - k8s

--- a/templates/go-app/cdk8s.yaml
+++ b/templates/go-app/cdk8s.yaml
@@ -1,0 +1,4 @@
+language: python
+app: go run main.go
+imports:
+  - k8s

--- a/templates/go-app/cdk8s.yaml
+++ b/templates/go-app/cdk8s.yaml
@@ -1,4 +1,4 @@
 language: go
-app: go run main.go
+app: go run .
 imports:
   - k8s

--- a/templates/go-app/go.mod
+++ b/templates/go-app/go.mod
@@ -4,6 +4,6 @@ go 1.16
 
 require (
 	github.com/aws/constructs-go/constructs/v3 v{{ constructs_version }}
-  github.com/aws/jsii-runtime-go v{{ jsii_version }}
+	github.com/aws/jsii-runtime-go v{{ jsii_version }}
 	github.com/cdk8s-team/cdk8s-core-go/cdk8s v{{ cdk8s_core_version }}
 )

--- a/templates/go-app/go.mod
+++ b/templates/go-app/go.mod
@@ -1,0 +1,9 @@
+module example.com/{{ $base }}
+
+go 1.16
+
+require (
+	github.com/aws/constructs-go/constructs/v3 v{{ constructs_version }}
+  github.com/aws/jsii-runtime-go v{{ jsii_version }}
+	github.com/cdk8s-team/cdk8s-core-go/cdk8s v{{ cdk8s_core_version }}
+)

--- a/templates/go-app/help
+++ b/templates/go-app/help
@@ -1,0 +1,12 @@
+========================================================================================================
+
+ Your cdk8s Go project is ready!
+
+   cat help      Prints this message  
+   cdk8s synth   Synthesize k8s manifests to dist/
+   cdk8s import  Imports k8s API objects to "imports/k8s"
+
+  Deploy:
+   kubectl apply -f dist/
+
+========================================================================================================

--- a/templates/go-app/main.go
+++ b/templates/go-app/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/aws/constructs-go/constructs/v3"
+	"github.com/cdk8s-team/cdk8s-core-go/cdk8s"
+)
+
+type MyChartProps struct {
+	cdk8s.ChartProps
+}
+
+func NewMyChart(scope constructs.Construct, id string, props *MyChartProps) cdk8s.Chart {
+	var sprops cdk8s.ChartProps
+	if props != nil {
+		sprops = props.ChartProps
+	}
+	chart := cdk8s.NewChart(scope, &id, &sprops)
+
+	// define resources here
+
+	return chart
+}
+
+func main() {
+	app := cdk8s.NewApp(nil)
+	NewMyChart(app, "{{ $base }}", nil)
+	app.Synth()
+}

--- a/templates/go-app/main.go
+++ b/templates/go-app/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/aws/constructs-go/constructs/v3"
+	"github.com/aws/jsii-runtime-go"
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s"
 )
 
@@ -10,11 +11,11 @@ type MyChartProps struct {
 }
 
 func NewMyChart(scope constructs.Construct, id string, props *MyChartProps) cdk8s.Chart {
-	var sprops cdk8s.ChartProps
+	var cprops cdk8s.ChartProps
 	if props != nil {
-		sprops = props.ChartProps
+		cprops = props.ChartProps
 	}
-	chart := cdk8s.NewChart(scope, &id, &sprops)
+	chart := cdk8s.NewChart(scope, jsii.String(id), &cprops)
 
 	// define resources here
 

--- a/test/import/util.ts
+++ b/test/import/util.ts
@@ -1,6 +1,6 @@
-import { promises as fs, readFileSync } from 'fs';
 import * as path from 'path';
 import { promisify } from 'util';
+import * as fs from 'fs-extra';
 import * as glob from 'glob';
 import { ImportBase, ImportOptions, Language } from '../../src/import/base';
 import { mkdtemp } from '../../src/util';
@@ -23,6 +23,10 @@ export async function expectImportMatchSnapshot(fn: () => ImportBase, options?: 
 
     for (const lang of languages) {
       const jsiiPath = lang === Language.TYPESCRIPT ? path.join(workdir, '.jsii') : undefined;
+
+      if (lang === Language.GO) {
+        fs.writeFileSync(path.join(workdir, 'go.mod'), 'module integtest');
+      }
 
       await importer.import({
         outdir: workdir,
@@ -48,7 +52,7 @@ export async function expectImportMatchSnapshot(fn: () => ImportBase, options?: 
 
       const map: Record<string, string> = {};
       for (const file of files) {
-        const source = readFileSync(path.join(workdir, file), 'utf-8');
+        const source = fs.readFileSync(path.join(workdir, file), 'utf-8');
         map[file] = source;
       }
 


### PR DESCRIPTION
Resolves #26 
Resolves #27

`cdk8s init go-app` now initializes a Go app with k8s imports. When run in a directory named "my-app", the following files will be generated:

```
├── cdk8s.yaml
├── dist
│   └── my-app.k8s.yaml
├── go.mod
├── go.sum
├── help
├── imports
│   └── k8s
│       ├── internal
│       │   └── types.go
│       ├── jsii
│       │   ├── jsii.go
│       │   └── k8s-0.0.0.tgz
│       ├── k8s.go
│       ├── k8s.init.go
│       └── version
└── main.go
```

`cdk8s import <spec> --language go` now imports the k8s spec or custom resource definitions in Go. Each CRD generates a package in an "imports" directory, and package names are generated based on Go idiomatic naming conventions. 

Tested on golang v1.16. 