### PR TITLE
feat: include CLI information for long import times

### DIFF
--- a/src/import/dispatch.ts
+++ b/src/import/dispatch.ts
@@ -12,6 +12,8 @@ export async function importDispatch(imports: ImportSpec[], argv: any, options: 
       throw new Error(`unable to determine import type for "${importSpec}"`);
     }
 
+    console.error('Importing resources, this may take a few moments...');
+
     await importer.import({
       moduleNamePrefix: importSpec.moduleNamePrefix,
       ...options,


### PR DESCRIPTION
I noticed that imports in non-typescript languages sometimes take a long time (upwards of a minute). There's nothing in the CLI that tells you this operation should be long, and almost nothing is output in terms of progress by the jsii transpiler currently, so adding this message might improve the user experience a little bit.