### PR TITLE
fix: missing API versions in k8s imports

### DIFF
--- a/src/import/codegen.ts
+++ b/src/import/codegen.ts
@@ -28,6 +28,12 @@ export interface ApiObjectDefinition {
   readonly prefix?: string;
 }
 
+export function getCanonicalName(fqn: string, version: string) {
+  const postfix = version === 'v1' ? '' : toPascalCase(version);
+  const root = fqn.split('.').pop();
+  return TypeGenerator.normalizeTypeName(`${root}${postfix}`);
+}
+
 /**
  * Emits the header for a generated imports file.
  *

--- a/src/import/k8s.ts
+++ b/src/import/k8s.ts
@@ -82,7 +82,7 @@ export class ImportKubernetesApi extends ImportBase {
       } else {
         // rename struct types from their original names to ensure that
         // differently-versioned but identically-named resources
-        // are generated as distinct interfaces (differentiated by
+        // are generated as distinct types (differentiated by
         // their version).
         const { fullVersion } = parseApiTypeName(fqn);
         const canonicalName = getCanonicalName(fqn, fullVersion === '' ? 'v1' : fullVersion);

--- a/test/import/import-k8s-util.test.ts
+++ b/test/import/import-k8s-util.test.ts
@@ -1,8 +1,9 @@
 import { parseApiTypeName } from '../../src/import/k8s-util';
 
 test('parseApiTypeName', () => {
-  expect(parseApiTypeName('io.k8s.api.extensions.v1.Deployment')).toStrictEqual({ basename: 'Deployment', fullname: 'io.k8s.api.extensions.v1.Deployment', level: 'stable', namespace: 'io.k8s.api.extensions', subversion: 0, version: 1 });
-  expect(parseApiTypeName('io.k8s.api.extensions.v1beta1.Deployment')).toStrictEqual({ basename: 'Deployment', fullname: 'io.k8s.api.extensions.v1beta1.Deployment', level: 'beta', namespace: 'io.k8s.api.extensions', subversion: 1, version: 1 });
-  expect(parseApiTypeName('io.k8s.api.extensions.v2.Deployment')).toStrictEqual({ basename: 'Deployment', fullname: 'io.k8s.api.extensions.v2.Deployment', level: 'stable', namespace: 'io.k8s.api.extensions', subversion: 0, version: 2 });
-  expect(parseApiTypeName('io.v2alpha2.Deployment')).toStrictEqual({ basename: 'Deployment', fullname: 'io.v2alpha2.Deployment', level: 'alpha', namespace: 'io', subversion: 2, version: 2 });
+  expect(parseApiTypeName('io.k8s.api.extensions.v1.Deployment')).toStrictEqual({ basename: 'Deployment', fullname: 'io.k8s.api.extensions.v1.Deployment', stability: 'stable', namespace: 'io.k8s.api.extensions', minor: 0, major: 1, fullVersion: 'v1' });
+  expect(parseApiTypeName('io.k8s.api.extensions.v1beta1.Deployment')).toStrictEqual({ basename: 'Deployment', fullname: 'io.k8s.api.extensions.v1beta1.Deployment', stability: 'beta', namespace: 'io.k8s.api.extensions', minor: 1, major: 1, fullVersion: 'v1beta1' });
+  expect(parseApiTypeName('io.k8s.api.extensions.v2.Deployment')).toStrictEqual({ basename: 'Deployment', fullname: 'io.k8s.api.extensions.v2.Deployment', stability: 'stable', namespace: 'io.k8s.api.extensions', minor: 0, major: 2, fullVersion: 'v2' });
+  expect(parseApiTypeName('io.v2alpha2.Deployment')).toStrictEqual({ basename: 'Deployment', fullname: 'io.v2alpha2.Deployment', stability: 'alpha', namespace: 'io', minor: 2, major: 2, fullVersion: 'v2alpha2' });
+  expect(parseApiTypeName('io.k8s.apimachinery.pkg.api.resource.Quantity')).toStrictEqual({ basename: 'Quantity', fullname: 'io.k8s.apimachinery.pkg.api.resource.Quantity', stability: 'stable', namespace: 'io.k8s.apimachinery.pkg.api.resource', minor: 0, major: 0, fullVersion: '' });
 });


### PR DESCRIPTION
Fixes #45 

The high-level strategy behind this fix is described here: https://github.com/cdk8s-team/cdk8s-cli/issues/45#issuecomment-887753986

I tested this by running `cdk8s import` in a separate project. The main difference in the generated `k8s.ts` file is that multiple versioned interfaces are generated for non-top-level definitions that have identical names but different resources. By non-top-level definitions, we mean the generated types that don't subclass from `ApiObject`, such as `XxxSpec`.

So now as an example, `KubeDeploymentV1Beta1Props` refers to `DeploymentSpecV1Beta1` instead of `DeploymentSpec`, and `DeploymentSpecV1Beta1` is generated in addition to `DeploymentSpec` (whereas it was previously omitted). If a spec is versioned at v1, then the version postfix is implicitly omitted.

The only minor regression caused by this fix is that the "schema" values associated with these types are all overwritten, as visible in the diff:

```diff
       "datatype": true,
       "docs": Object {
         "custom": Object {
-          "schema": "io.k8s.api.rbac.v1beta1.AggregationRule",
+          "schema": "AggregationRule",
         },
         "summary": "AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole.",
       },
```