### PR TITLE
fix: unquoted paths cannot be executed on windows

### DIFF
--- a/templates/go-app/.hooks.sscaff.js
+++ b/templates/go-app/.hooks.sscaff.js
@@ -14,7 +14,7 @@ exports.pre = () => {
 };
 
 exports.post = options => {
-  execSync(`${cli} import k8s -l go`);
+  execSync(`node "${cli}" import k8s -l go`);
 
   // used to generate go.sum file which tracks hashes of all dependencies
   execSync('go mod tidy');

--- a/templates/java-app/.hooks.sscaff.js
+++ b/templates/java-app/.hooks.sscaff.js
@@ -35,7 +35,7 @@ exports.post = options => {
   }
 
   execSync(`mvn install`);
-  execSync(`${cli} import k8s -l java`);
+  execSync(`node "${cli}" import k8s -l java`);
   execSync(`mvn compile`);
   execSync(`mvn exec:java -Dexec.mainClass="com.mycompany.app.Main"`);
 

--- a/templates/python-app/.hooks.sscaff.js
+++ b/templates/python-app/.hooks.sscaff.js
@@ -34,7 +34,7 @@ exports.post = options => {
 
   chmodSync('main.py', '700');
 
-  execSync(`${cli} import k8s -l python`);
+  execSync(`node "${cli}" import k8s -l python`);
   execSync(`pipenv run ./main.py`);
 
   console.log(readFileSync('./help', 'utf-8'));


### PR DESCRIPTION
When running `cdk8s init` on windows, the logic that generates k8s imports fails because of how paths are handled on windows. Here is a run showing where the error fails: https://github.com/cdk8s-team/cdk8s/pull/669/checks?check_run_id=3488953237

To fix this we need to quote the path, and also we run the CLI binary directly with "node" (without this, it gives an error saying that `"D:\path\to\cdk8s-cli\bin\cdk8s" is not recognized as an internal or external command, operable program or batch file`).

Necessary for https://github.com/cdk8s-team/cdk8s/issues/422