### PR TITLE
fix: init python-app errors on Windows

### DIFF
--- a/templates/python-app/.hooks.sscaff.js
+++ b/templates/python-app/.hooks.sscaff.js
@@ -35,7 +35,7 @@ exports.post = options => {
   chmodSync('main.py', '700');
 
   execSync(`node "${cli}" import k8s -l python`);
-  execSync(`pipenv run ./main.py`);
+  execSync(`pipenv run python main.py`);
 
   console.log(readFileSync('./help', 'utf-8'));
 };

--- a/templates/python-app/cdk8s.yaml
+++ b/templates/python-app/cdk8s.yaml
@@ -1,4 +1,4 @@
 language: python
-app: pipenv run ./main.py
+app: pipenv run python main.py
 imports:
   - k8s


### PR DESCRIPTION
Windows does not have native shebang support, so we must explicitly call the files using python. Tested on Windows Server 2016.

Related to https://github.com/cdk8s-team/cdk8s/issues/422
Needed for https://github.com/cdk8s-team/cdk8s/pull/669