### PR TITLE
chore: deprecate node v10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 10.17.0
+          node-version: 12.13.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 10.17.0
+          node-version: 12.13.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 10.17.0
+          node-version: 12.13.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^10.17.0",
+      "version": "^12.13.0",
       "type": "build"
     },
     {
@@ -87,7 +87,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^10.17.0",
+      "version": "^12.13.0",
       "type": "runtime"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -8,7 +8,7 @@ const project = new TypeScriptProject({
   projenUpgradeSecret: 'PROJEN_GITHUB_TOKEN',
   authorName: 'Amazon Web Services',
   authorUrl: 'https://aws.amazon.com',
-  minNodeVersion: '10.17.0',
+  minNodeVersion: '12.13.0',
   defaultReleaseBranch: 'main',
 
   // needed for "cdk init" tests to work in all languages
@@ -35,7 +35,7 @@ const project = new TypeScriptProject({
 
     // add @types/node as a regular dependency since it's needed to during "import"
     // to compile the generated jsii code.
-    '@types/node@^10.17.0',
+    '@types/node@^12.13.0',
   ],
   devDeps: [
     '@types/fs-extra@^8',

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/glob": "^7.1.4",
     "@types/jest": "^26.0.24",
     "@types/json-schema": "^7.0.9",
-    "@types/node": "^10.17.0",
+    "@types/node": "^12.13.0",
     "@typescript-eslint/eslint-plugin": "^4.29.3",
     "@typescript-eslint/parser": "^4.29.3",
     "eslint": "^6.8.0",
@@ -52,7 +52,7 @@
     "typescript": "~3.9.10"
   },
   "dependencies": {
-    "@types/node": "^10.17.0",
+    "@types/node": "^12.13.0",
     "cdk8s": "1.0.0-beta.30",
     "cdk8s-plus-17": "1.0.0-beta.57",
     "codemaker": "^1.33.0",
@@ -68,7 +68,7 @@
   },
   "bundledDependencies": [],
   "engines": {
-    "node": ">= 10.17.0"
+    "node": ">= 12.13.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,7 +11,7 @@ export async function shell(program: string, args: string[] = [], options: Spawn
   return new Promise((ok, ko) => {
     const child = spawn(program, args, { stdio: ['inherit', 'pipe', 'inherit'], ...options });
     const data = new Array<Buffer>();
-    child.stdout.on('data', chunk => data.push(chunk));
+    child.stdout?.on('data', chunk => data.push(chunk));
 
     child.once('error', err => ko(new Error(`command ${command} failed: ${err}`)));
     child.once('exit', code => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -750,10 +750,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.1.tgz#c6b9198178da504dfca1fd0be9b2e1002f1586f0"
   integrity sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==
 
-"@types/node@^10.17.0":
-  version "10.17.60"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
-  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
+"@types/node@^12.13.0":
+  version "12.20.24"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.24.tgz#c37ac69cb2948afb4cef95f424fa0037971a9a5c"
+  integrity sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
Node v10 is now deprecated and is no longer being maintained. This should unblock the failing upgrade-dependencies workflow (https://github.com/cdk8s-team/cdk8s-cli/actions/runs/1207548727).