### PR TITLE
feat: use cdk8s-plus-22 for all new projects

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -103,7 +103,7 @@
       "type": "runtime"
     },
     {
-      "name": "cdk8s-plus-17",
+      "name": "cdk8s-plus-22",
       "type": "runtime"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -21,7 +21,7 @@ const project = new TypeScriptProject({
   },
   deps: [
     'cdk8s',
-    'cdk8s-plus-17',
+    'cdk8s-plus-22',
     'codemaker',
     'constructs',
     'fs-extra@^8',

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/node": "^12.13.0",
     "ajv": "^8.6.3",
     "cdk8s": "1.0.0-beta.46",
-    "cdk8s-plus-17": "1.0.0-beta.74",
+    "cdk8s-plus-22": "^1.0.0-beta.0",
     "codemaker": "^1.34.0",
     "colors": "^1.4.0",
     "constructs": "^3.3.147",

--- a/src/cli/cmds/init.ts
+++ b/src/cli/cmds/init.ts
@@ -42,19 +42,19 @@ class Command implements yargs.CommandModule {
 
 async function determineDeps(): Promise<Deps> {
   const cdk8s = new ModuleVersion('cdk8s', { jsii: true });
-  const cdk8sPlus17 = new ModuleVersion('cdk8s-plus-17', { jsii: true });
+  const cdk8sPlus = new ModuleVersion('cdk8s-plus-22', { jsii: true });
   const cdk8sCli = new ModuleVersion('cdk8s-cli');
   const jsii = new ModuleVersion('jsii');
 
   return {
     npm_cdk8s: cdk8s.npmDependency,
-    npm_cdk8s_plus: cdk8sPlus17.npmDependency,
+    npm_cdk8s_plus: cdk8sPlus.npmDependency,
     pypi_cdk8s: cdk8s.pypiDependency,
-    pypi_cdk8s_plus: cdk8sPlus17.pypiDependency,
+    pypi_cdk8s_plus: cdk8sPlus.pypiDependency,
     mvn_cdk8s: cdk8s.mavenDependency,
-    mvn_cdk8s_plus: cdk8sPlus17.mavenDependency,
+    mvn_cdk8s_plus: cdk8sPlus.mavenDependency,
     cdk8s_core_version: cdk8s.version,
-    cdk8s_plus_version: cdk8sPlus17.version,
+    cdk8s_plus_version: cdk8sPlus.version,
     constructs_version: constructsVersion,
     jsii_version: jsii.version,
 

--- a/templates/go-app/go.mod
+++ b/templates/go-app/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/aws/constructs-go/constructs/v3 v{{ constructs_version }}
 	github.com/aws/jsii-runtime-go v{{ jsii_version }}
 	github.com/cdk8s-team/cdk8s-core-go/cdk8s v{{ cdk8s_core_version }}
+	github.com/cdk8s-team/cdk8s-plus-go/cdk8splus22 v{{ cdk8s_plus_version }}
 )

--- a/templates/java-app/.hooks.sscaff.js
+++ b/templates/java-app/.hooks.sscaff.js
@@ -31,7 +31,7 @@ exports.post = options => {
   }
 
   if (mvn_cdk8s_plus.endsWith('.jar')) {
-    execSync(`mvn install:install-file -Dfile=${mvn_cdk8s_plus} -DgroupId=org.cdk8s -DartifactId=cdk8s-plus-17 -Dversion=${cdk8s_plus_version} -Dpackaging=jar`)
+    execSync(`mvn install:install-file -Dfile=${mvn_cdk8s_plus} -DgroupId=org.cdk8s -DartifactId=cdk8s-plus-22 -Dversion=${cdk8s_plus_version} -Dpackaging=jar`)
   }
 
   execSync(`mvn install`);

--- a/templates/java-app/pom.xml
+++ b/templates/java-app/pom.xml
@@ -15,7 +15,7 @@
     </dependency>
     <dependency>
       <groupId>org.cdk8s</groupId>
-      <artifactId>cdk8s-plus-17</artifactId>
+      <artifactId>cdk8s-plus-22</artifactId>
       <version>{{ cdk8s_plus_version }}</version>
     </dependency>
     <dependency>

--- a/test/import/import-k8s.test.ts
+++ b/test/import/import-k8s.test.ts
@@ -4,7 +4,7 @@ import { testImportMatchSnapshot } from './util';
 const k8s = (v: string) =>
   testImportMatchSnapshot(`k8s@${v}`, async () => new ImportKubernetesApi({ apiVersion: v }));
 
-k8s('1.14.0');
-k8s('1.15.0');
-k8s('1.16.0');
 k8s('1.17.0');
+k8s('1.20.0');
+k8s('1.21.0');
+k8s('1.22.0');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1484,10 +1484,10 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-cdk8s-plus-17@1.0.0-beta.74:
-  version "1.0.0-beta.74"
-  resolved "https://registry.yarnpkg.com/cdk8s-plus-17/-/cdk8s-plus-17-1.0.0-beta.74.tgz#f1f6a46b7b6d05f6160e76e2827995edce4244f0"
-  integrity sha512-+7+iKqt9Ump9DUm91VouW2H9R7H7cBvbb/hPu8zRflC4OwvSZJb1ONzdUDLahqzFp+l2VQ0zcGMFfD8ONlFMjA==
+cdk8s-plus-22@^1.0.0-beta.0:
+  version "1.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/cdk8s-plus-22/-/cdk8s-plus-22-1.0.0-beta.0.tgz#10f328d64e9c60415fbec8ebf3ec8459190372ad"
+  integrity sha512-CC0gDC7pUfh1cqaGciTohyBrISJy7X0lPn9NRNRF2nW/i0Ls2a9HtxZb0VCdq0rm8P+IAVC9vHpYF02j7rgK6A==
   dependencies:
     minimatch "^3.0.4"
 


### PR DESCRIPTION
Part of https://github.com/cdk8s-team/cdk8s/issues/682

Updates the k8s versions we test the "imports" for to v1.17, v1.20, v1.21, v1.22 since those are the most common versions our users will likely be using.