### PR TITLE
feat: default k8s import version to 1.22.0

### DIFF
--- a/src/cli/cmds/import.ts
+++ b/src/cli/cmds/import.ts
@@ -1,6 +1,7 @@
 import * as yargs from 'yargs';
 import { readConfigSync, ImportSpec } from '../../config';
 import { importDispatch } from '../../import/dispatch';
+import { DEFAULT_API_VERSION } from '../../import/k8s';
 
 const config = readConfigSync();
 
@@ -14,7 +15,7 @@ class Command implements yargs.CommandModule {
 
   public readonly builder = (args: yargs.Argv) => args
     .positional('SPEC', { default: config.imports, desc: 'import spec with the syntax [NAME:=]SPEC where NAME is an optional module name and supported SPEC are: k8s, crd.yaml, https://domain/crd.yaml, github:account/repo[@VERSION]).', array: true })
-    .example('cdk8s import k8s', 'Imports Kubernetes API objects to imports/k8s.ts')
+    .example('cdk8s import k8s', `Imports Kubernetes API objects to imports/k8s.ts. Defaults to ${DEFAULT_API_VERSION}`)
     .example('cdk8s import k8s --no-class-prefix', 'Imports Kubernetes API objects without the "Kube" prefix')
     .example('cdk8s import k8s@1.13.0', 'Imports a specific version of the Kubernetes API')
     .example('cdk8s import jenkins.io_jenkins_crd.yaml', 'Imports constructs for the Jenkins custom resource definition from a file')

--- a/src/import/k8s.ts
+++ b/src/import/k8s.ts
@@ -12,7 +12,8 @@ import { ApiObjectDefinition, emitHeader, generateConstruct, getPropsTypeName, g
 import { parseApiTypeName, safeParseJsonSchema } from './k8s-util';
 
 
-const DEFAULT_API_VERSION = '1.22.0';
+export const DEFAULT_API_VERSION = '1.22.0';
+
 const DEFAULT_CLASS_NAME_PREFIX = 'Kube';
 
 export interface ImportKubernetesApiOptions {
@@ -37,8 +38,12 @@ export class ImportKubernetesApi extends ImportBase {
       return undefined;
     }
 
+    let k8sVersion = source.split('@')[1];
+
+    console.error(`Importing k8s v${k8sVersion}...`);
+
     return {
-      apiVersion: source.split('@')[1] ?? DEFAULT_API_VERSION,
+      apiVersion: k8sVersion,
       exclude: argv.exclude,
     };
   }

--- a/src/import/k8s.ts
+++ b/src/import/k8s.ts
@@ -12,7 +12,7 @@ import { ApiObjectDefinition, emitHeader, generateConstruct, getPropsTypeName, g
 import { parseApiTypeName, safeParseJsonSchema } from './k8s-util';
 
 
-const DEFAULT_API_VERSION = '1.15.0';
+const DEFAULT_API_VERSION = '1.22.0';
 const DEFAULT_CLASS_NAME_PREFIX = 'Kube';
 
 export interface ImportKubernetesApiOptions {

--- a/src/import/k8s.ts
+++ b/src/import/k8s.ts
@@ -38,7 +38,7 @@ export class ImportKubernetesApi extends ImportBase {
       return undefined;
     }
 
-    let k8sVersion = source.split('@')[1];
+    let k8sVersion = source.split('@')[1] ?? DEFAULT_API_VERSION;
 
     console.error(`Importing k8s v${k8sVersion}...`);
 


### PR DESCRIPTION
Currently running k8s import on a new project (without specifying a version) generates imports for k8s v1.15.0. These are over two years old and do not support many update APIs so we are upgrading the default to v1.22.0.