### PR TITLE
fix: imports strip out enums with spaces

### DIFF
--- a/src/reviver.ts
+++ b/src/reviver.ts
@@ -35,16 +35,18 @@ export class SafeReviver {
       throw new Error(`Expected key (${key}) to be of type 'string', but got '${typeof(key)}'`);
     }
 
-    // . | used in resource fqn which servers as a key (e.g io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup)
-    // / | used in $ref to point to a definition (e.g #/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery)
-    // - | used in annotation keys (e.g x-kubernetes-group-version-kind)
-    // # | used in $ref to point to a definition (e.g #/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery)
-    // , | used in values that represent a list (e.g merge,retainKeys)
-    const legal = /^(\w|\.|\/|-|#|,)*$/;
+    // .       | used in resource fqn which servers as a key (e.g io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup)
+    // /       | used in $ref to point to a definition (e.g #/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery)
+    // -       | used in annotation keys (e.g x-kubernetes-group-version-kind)
+    // #       | used in $ref to point to a definition (e.g #/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery)
+    // ,       | used in values that represent a list (e.g merge,retainKeys)
+    // <space> | used in enum values with spaces
+    const legalKey = /^(\w|\.|\/|-|#|,)*$/;
+    const legalValue = /^(\w| |\.|\/|-|#|,)*$/;
 
-    if (!this.allowlistedKeys.includes(key) && !key.match(legal)) {
+    if (!this.allowlistedKeys.includes(key) && !key.match(legalKey)) {
       // keys cannot be stripped so we have to throw - thats ok, we don't want to parse such docs at all
-      throw new Error(`Key '${key}' contains non standard characters (Must match regex '${legal}')`);
+      throw new Error(`Key '${key}' contains non standard characters (Must match regex '${legalKey}')`);
     }
 
     if (typeof(value) === 'string') {
@@ -56,7 +58,7 @@ export class SafeReviver {
         return sanitizer(value);
       }
 
-      if (!value.match(legal)) {
+      if (!value.match(legalValue)) {
         // otherwise strip illegal values.
         // we shouldn't be using these values anyway.
         // the reason we don't throw is because sometimes these type of values exist in

--- a/test/import/__snapshots__/import-crds-dev.test.ts.snap
+++ b/test/import/__snapshots__/import-crds-dev.test.ts.snap
@@ -203,6 +203,7 @@ Object {
           },
         },
       ],
+      "symbolId": "meta.pkg.crossplane.io:Configuration",
     },
     "metapkgcrossplaneio.ConfigurationProps": Object {
       "assembly": "metapkgcrossplaneio",
@@ -258,6 +259,7 @@ Object {
           },
         },
       ],
+      "symbolId": "meta.pkg.crossplane.io:ConfigurationProps",
     },
     "metapkgcrossplaneio.ConfigurationSpec": Object {
       "assembly": "metapkgcrossplaneio",
@@ -320,6 +322,7 @@ Object {
           },
         },
       ],
+      "symbolId": "meta.pkg.crossplane.io:ConfigurationSpec",
     },
     "metapkgcrossplaneio.ConfigurationSpecCrossplane": Object {
       "assembly": "metapkgcrossplaneio",
@@ -357,6 +360,7 @@ Object {
           },
         },
       ],
+      "symbolId": "meta.pkg.crossplane.io:ConfigurationSpecCrossplane",
     },
     "metapkgcrossplaneio.ConfigurationSpecDependsOn": Object {
       "assembly": "metapkgcrossplaneio",
@@ -433,6 +437,7 @@ Object {
           },
         },
       ],
+      "symbolId": "meta.pkg.crossplane.io:ConfigurationSpecDependsOn",
     },
   },
   "version": "0.0.0",

--- a/test/import/__snapshots__/import-crds-dev.test.ts.snap
+++ b/test/import/__snapshots__/import-crds-dev.test.ts.snap
@@ -203,7 +203,6 @@ Object {
           },
         },
       ],
-      "symbolId": "meta.pkg.crossplane.io:Configuration",
     },
     "metapkgcrossplaneio.ConfigurationProps": Object {
       "assembly": "metapkgcrossplaneio",
@@ -259,7 +258,6 @@ Object {
           },
         },
       ],
-      "symbolId": "meta.pkg.crossplane.io:ConfigurationProps",
     },
     "metapkgcrossplaneio.ConfigurationSpec": Object {
       "assembly": "metapkgcrossplaneio",
@@ -322,7 +320,6 @@ Object {
           },
         },
       ],
-      "symbolId": "meta.pkg.crossplane.io:ConfigurationSpec",
     },
     "metapkgcrossplaneio.ConfigurationSpecCrossplane": Object {
       "assembly": "metapkgcrossplaneio",
@@ -360,7 +357,6 @@ Object {
           },
         },
       ],
-      "symbolId": "meta.pkg.crossplane.io:ConfigurationSpecCrossplane",
     },
     "metapkgcrossplaneio.ConfigurationSpecDependsOn": Object {
       "assembly": "metapkgcrossplaneio",
@@ -437,7 +433,6 @@ Object {
           },
         },
       ],
-      "symbolId": "meta.pkg.crossplane.io:ConfigurationSpecDependsOn",
     },
   },
   "version": "0.0.0",

--- a/test/import/import-crd.test.ts
+++ b/test/import/import-crd.test.ts
@@ -274,6 +274,71 @@ describe('safe parsing', () => {
     });
   });
 
+  test('does not error for enums with spaces', async () => {
+
+    const crd: ManifestObjectDefinition = {
+      apiVersion: 'apiextensions.k8s.io/v1beta1',
+      kind: 'CustomResourceDefinition',
+      metadata: {
+        name: 'testMetadata',
+      },
+      spec: {
+        version: 'v1',
+        group: 'testGroup',
+        names: {
+          kind: 'testNameKind',
+        },
+        validation: {
+          openAPIV3Schema: {
+            properties: {
+              usages: {
+                description: 'Usages is the set of x509 usages that are requested for the certificate. Defaults to `digital signature` and `key encipherment` if not specified.',
+                type: 'array',
+                items: {
+                  description: '\'KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: "signing", "digital signature", "content commitment", "key encipherment", "key agreement", "data encipherment", "cert sign", "crl sign", "encipher only", "decipher only", "any", "server auth", "client auth", "code signing", "email protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec user", "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"\'',
+                  type: 'string',
+                  enum: [
+                    'signing',
+                    'digital signature',
+                    'content commitment',
+                    'key encipherment',
+                    'key agreement',
+                    'data encipherment',
+                    'cert sign',
+                    'crl sign',
+                    'encipher only',
+                    'decipher only',
+                    'any',
+                    'server auth',
+                    'client auth',
+                    'code signing',
+                    'email protection',
+                    's/mime',
+                    'ipsec end system',
+                    'ipsec tunnel',
+                    'ipsec user',
+                    'timestamping',
+                    'ocsp signing',
+                    'microsoft sgc',
+                    'netscape sgc',
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    await withTempFixture(crd, async (fixture: string, cwd: string) => {
+      const importer = await ImportCustomResourceDefinition.fromSpec({ source: fixture });
+      await importer.import({ targetLanguage: Language.TYPESCRIPT, outdir: cwd });
+      const output = fs.readFileSync(path.join(cwd, 'testGroup.ts'), { encoding: 'utf8' });
+      expect(output).toMatchSnapshot();
+      expect(output).not.toContain('STRIPPED_BY_CDK8S');
+    });
+  });
+
   test('throws when key is illegal', async () => {
 
     const crd: ManifestObjectDefinition = {
@@ -314,11 +379,11 @@ describe('safe parsing', () => {
         version: 'v1',
         group: 'testGroup',
         names: {
-          kind: 'its not ok to have spaces here',
+          kind: 'its not ok to have tabs\there',
         },
         validation: {
           openAPIV3Schema: {
-            description: 'Its ok to have spaces here',
+            description: 'Its ok to have tabs\there',
           },
         },
       },
@@ -346,7 +411,7 @@ describe('safe parsing', () => {
         },
         validation: {
           openAPIV3Schema: {
-            description: 'Its ok to have spaces here',
+            description: 'Its ok to have tabs\there',
           },
         },
       },

--- a/test/import/import-crd.test.ts
+++ b/test/import/import-crd.test.ts
@@ -379,11 +379,11 @@ describe('safe parsing', () => {
         version: 'v1',
         group: 'testGroup',
         names: {
-          kind: 'its not ok to have tabs\there',
+          kind: 'its not ok to have spaces here',
         },
         validation: {
           openAPIV3Schema: {
-            description: 'Its ok to have tabs\there',
+            description: 'Its ok to have spaces here',
           },
         },
       },
@@ -411,7 +411,7 @@ describe('safe parsing', () => {
         },
         validation: {
           openAPIV3Schema: {
-            description: 'Its ok to have tabs\there',
+            description: 'Its ok to have spaces here',
           },
         },
       },

--- a/test/import/import-k8s-util.test.ts
+++ b/test/import/import-k8s-util.test.ts
@@ -114,7 +114,7 @@ describe('safeParseJsonSchema', () => {
             sideEffects: {
               description: 'some normal description',
               type: 'string',
-              somethingElse: 'not a word',
+              somethingElse: 'invalid\tvalue',
             },
           },
           required: [
@@ -142,7 +142,7 @@ describe('safeParseJsonSchema', () => {
             },
           },
           required: [
-            'sideEffects', 'not a word',
+            'sideEffects', 'invalid\tvalue',
           ],
           type: 'object',
         },

--- a/test/import/import-k8s-util.test.ts
+++ b/test/import/import-k8s-util.test.ts
@@ -114,7 +114,7 @@ describe('safeParseJsonSchema', () => {
             sideEffects: {
               description: 'some normal description',
               type: 'string',
-              somethingElse: 'invalid\tvalue',
+              somethingElse: 'not a word',
             },
           },
           required: [


### PR DESCRIPTION
Fixes #108

When importing some CRDs, it's possible for enums to have spaces, which are currently getting stripped to minimize the potential security risks for code that is parsing and manipulating manifest definitions. To minimize the scope of the changes, I only allow-listed spaces (and not all kinds of whitespace characters), and only allow-listed them within values (and not in keys).