### PR TITLE
Allow @ in key name

### DIFF
--- a/src/reviver.ts
+++ b/src/reviver.ts
@@ -40,7 +40,7 @@ export class SafeReviver {
     // - | used in annotation keys (e.g x-kubernetes-group-version-kind)
     // # | used in $ref to point to a definition (e.g #/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery)
     // , | used in values that represent a list (e.g merge,retainKeys)
-    const legal = /^(\w|\.|\/|-|#|,)*$/;
+    const legal = /^(\w|\.|\/|-|#|@|,)*$/;
 
     if (!this.allowlistedKeys.includes(key) && !key.match(legal)) {
       // keys cannot be stripped so we have to throw - thats ok, we don't want to parse such docs at all


### PR DESCRIPTION
Envoy-related api objects use `@type` a lot:
```yaml
kind: EnvoyFilter
metadata:
  name: metadata-exchange-1.8
  namespace: istio-system
spec:
  configPatches:
    - applyTo: HTTP_FILTER
      match:
        context: SIDECAR_INBOUND
        proxy:
          proxyVersion: '^1\.8.*'
        listener:
          filterChain:
            filter:
              name: "envoy.filters.network.http_connection_manager"
      patch:
        operation: INSERT_BEFORE
        value:
          name: istio.metadata_exchange
          typed_config:
            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
```

Without this patch, one would get an error similar to this:
```
Error: Key '@type' contains non standard characters (Must match regex '/^(\w|\.|\/|-|#|,)*$/'
```

Fixes #