### PR TITLE
fix: cdk8s init is failing

### DIFF
--- a/templates/typescript-app/.hooks.sscaff.js
+++ b/templates/typescript-app/.hooks.sscaff.js
@@ -14,10 +14,10 @@ exports.post = ctx => {
 
   installDeps([ npm_cdk8s, npm_cdk8s_plus, `constructs@^${constructs_version}` ]);
   installDeps([
-      '@types/node',
-      '@types/jest',
-      'jest',
-      'ts-jest',
+      '@types/node@14',
+      '@types/jest@26',
+      'jest@26',
+      'ts-jest@26',
       'typescript'
   ], true);
 


### PR DESCRIPTION
Fixes #139

I looked into some other solutions that would install versions of dependencies based on the versions within `cdk8s-cli`'s package.json, but decided against it since it would add more complexity to our scaffolding logic that doesn't provide much benefit.