### PR TITLE
fix: `colors` breaks cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "cdk8s": "^1.3.28",
     "cdk8s-plus-22": "^1.0.0-beta.81",
     "codemaker": "^1.52.0",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "constructs": "^3.3.182",
     "fs-extra": "^8",
     "jsii-pacmak": "^1.52.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1640,7 +1640,7 @@ colors@1.0.3:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-colors@^1.4.0:
+colors@1.4.0, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==


### PR DESCRIPTION
Fixes https://github.com/cdk8s-team/cdk8s-cli/issues/171

Pin to version `1.4.0`. See https://github.com/Marak/colors.js/issues/285

Signed-off-by: iliapolo <epolon@amazon.com>