### PR TITLE
chore: reschedule upgrades to make build failures less likely

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -4,7 +4,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 1 * * *
 jobs:
   upgrade:
     name: Upgrade

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -18,11 +18,6 @@
       "type": "build"
     },
     {
-      "name": "@types/node",
-      "version": "^12",
-      "type": "build"
-    },
-    {
       "name": "@typescript-eslint/eslint-plugin",
       "version": "^5",
       "type": "build"
@@ -94,7 +89,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^12.13.0",
+      "version": "^12",
       "type": "runtime"
     },
     {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@types/glob": "^7.2.0",
     "@types/jest": "^26.0.24",
     "@types/json-schema": "^7.0.9",
-    "@types/node": "^12",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
     "eslint": "^8",
@@ -55,7 +54,7 @@
     "typescript-json-schema": "^0.53.0"
   },
   "dependencies": {
-    "@types/node": "^12.13.0",
+    "@types/node": "^12",
     "ajv": "^8.10.0",
     "cdk8s": "^1.5.17",
     "cdk8s-plus-22": "^1.0.0-beta.117",

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,7 +843,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.18.tgz#3b4fed5cfb58010e3a2be4b6e74615e4847f1074"
   integrity sha512-eKj4f/BsN/qcculZiRSujogjvp5O/k4lOW5m35NopjZM/QwLOR075a8pJW5hD+Rtdm2DaCVPENS6KtSQnUD6BA==
 
-"@types/node@^12.13.0":
+"@types/node@^12":
   version "12.20.46"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.46.tgz#7e49dee4c54fd19584e6a9e0da5f3dc2e9136bc7"
   integrity sha512-cPjLXj8d6anFPzFvOPxS3fvly3Shm5nTfl6g8X5smexixbuGUf7hfr21J5tX9JW+UPStp/5P5R8qrKL5IyVJ+A==


### PR DESCRIPTION
New versions of cdk8s and cdk8s-plus are published/released to different languages at slightly different times because the publishing happens on different package registries.

However, this causes our integration tests to sporadically fail because:

1. upgrade-dependencies workflows are triggered at roughly the same time every day for all repositories
2. our integration tests expect if cdk8s@x.y.z is available on NPM, then cdk8s@x.y.z is also available on PyPI, Maven, etc.

Currently, whenever this issue happens, it can be easily fixed by re-running the workflow again at any time that isn't when a new version of cdk8s or cdk8s-plus is being released. (so any time that's not close to 00:00 UTC). But this shouldn't have to be a manual effort.

This PR mitigates (1) and decreases the chance of upgrade workflows failing by running the workflow at an offset time compared to the other repos.

Signed-off-by: Christopher Rybicki <rybickic@amazon.com>