### PR TITLE
chore: remove jsii-superchain for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,6 @@ jobs:
           echo "::error::Files were changed during build (see build log). If this was triggered from a fork, you will need to update your branch."
           cat .repo.patch
           exit 1
-    container:
-      image: jsii/superchain
   self-mutation:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,6 @@ jobs:
         with:
           name: build-artifact
           path: dist
-    container:
-      image: jsii/superchain
   release_github:
     name: Publish to GitHub Releases
     needs: release

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -38,8 +38,6 @@ jobs:
         with:
           name: .repo.patch
           path: .repo.patch
-    container:
-      image: jsii/superchain
   pr:
     name: Create Pull Request
     needs: upgrade

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -22,8 +22,6 @@ const project = new typescript.TypeScriptProject({
     'containers',
   ],
 
-  // needed for "cdk init" tests to work in all languages
-  workflowContainerImage: 'jsii/superchain',
   workflowBootstrapSteps: [{ run: 'pip3 install pipenv' }],
 
   releaseToNpm: true,

--- a/test/import/import-crd.test.ts
+++ b/test/import/import-crd.test.ts
@@ -9,7 +9,7 @@ import { testImportMatchSnapshot } from './util';
 const fixtures = path.join(__dirname, 'fixtures');
 
 async function withTempFixture(data: any, test: (fixture: string, cwd: string) => Promise<void>) {
-  const tempDir = fs.mkdtempSync(os.tmpdir());
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk8s-import-test'));
   const fixture = path.join(tempDir, 'fixture.yaml');
   try {
     if (Array.isArray(data)) {


### PR DESCRIPTION
Fix some currently failing builds caused by jsii-superchain "latest" tag no longer being available. Instead of switching to another version, let's just drop it as a requirement.

Signed-off-by: Christopher Rybicki <rybickic@amazon.com>