### PR TITLE
chore: add manually generated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,995 @@
+## [0.0.0](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.100...v0.0.0) (2022-08-31)
+
+### [2.0.100](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.99...v2.0.100) (2022-08-30)
+
+### [2.0.99](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.98...v2.0.99) (2022-08-29)
+
+### [2.0.98](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.97...v2.0.98) (2022-08-28)
+
+
+### Bug Fixes
+
+* typescript app template does not compile on Windows ([#421](https://github.com/cdk8s-team/cdk8s-cli/issues/421)) ([43d9db1](https://github.com/cdk8s-team/cdk8s-cli/commit/43d9db1fffe554215b1ff8fce38e6cfe669bef60)), closes [cdk8s-team/cdk8s-cli#362](https://github.com/cdk8s-team/cdk8s-cli/issues/362)
+
+### [2.0.97](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.96...v2.0.97) (2022-08-28)
+
+### [2.0.96](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.95...v2.0.96) (2022-08-27)
+
+### [2.0.95](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.94...v2.0.95) (2022-08-26)
+
+### [2.0.94](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.93...v2.0.94) (2022-08-25)
+
+### [2.0.93](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.92...v2.0.93) (2022-08-24)
+
+### [2.0.92](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.91...v2.0.92) (2022-08-23)
+
+### [2.0.91](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.90...v2.0.91) (2022-08-22)
+
+### [2.0.90](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.89...v2.0.90) (2022-08-21)
+
+### [2.0.89](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.88...v2.0.89) (2022-08-20)
+
+### [2.0.88](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.87...v2.0.88) (2022-08-19)
+
+### [2.0.87](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.86...v2.0.87) (2022-08-18)
+
+### [2.0.86](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.85...v2.0.86) (2022-08-17)
+
+### [2.0.85](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.84...v2.0.85) (2022-08-16)
+
+### [2.0.84](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.83...v2.0.84) (2022-08-15)
+
+### [2.0.83](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.82...v2.0.83) (2022-08-14)
+
+### [2.0.82](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.81...v2.0.82) (2022-08-13)
+
+### [2.0.81](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.80...v2.0.81) (2022-08-12)
+
+### [2.0.80](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.79...v2.0.80) (2022-08-11)
+
+### [2.0.79](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.78...v2.0.79) (2022-08-10)
+
+### [2.0.78](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.77...v2.0.78) (2022-08-09)
+
+### [2.0.77](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.76...v2.0.77) (2022-08-08)
+
+### [2.0.76](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.75...v2.0.76) (2022-08-07)
+
+### [2.0.75](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.74...v2.0.75) (2022-08-06)
+
+### [2.0.74](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.73...v2.0.74) (2022-08-05)
+
+### [2.0.73](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.72...v2.0.73) (2022-08-04)
+
+### [2.0.72](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.71...v2.0.72) (2022-08-03)
+
+### [2.0.71](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.70...v2.0.71) (2022-08-02)
+
+### [2.0.70](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.69...v2.0.70) (2022-08-01)
+
+### [2.0.69](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.68...v2.0.69) (2022-07-31)
+
+### [2.0.68](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.67...v2.0.68) (2022-07-30)
+
+### [2.0.67](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.66...v2.0.67) (2022-07-29)
+
+### [2.0.66](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.65...v2.0.66) (2022-07-28)
+
+### [2.0.65](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.64...v2.0.65) (2022-07-27)
+
+
+### Bug Fixes
+
+* **import:** fail to import CRD without a schema ([#417](https://github.com/cdk8s-team/cdk8s-cli/issues/417)) ([3a3fce7](https://github.com/cdk8s-team/cdk8s-cli/commit/3a3fce7f4fd15a20f9e2289e320ba3092eba9688))
+
+### [2.0.64](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.63...v2.0.64) (2022-07-27)
+
+### [2.0.63](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.62...v2.0.63) (2022-07-26)
+
+### [2.0.62](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.61...v2.0.62) (2022-07-25)
+
+### [2.0.61](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.60...v2.0.61) (2022-07-24)
+
+### [2.0.60](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.59...v2.0.60) (2022-07-23)
+
+### [2.0.59](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.58...v2.0.59) (2022-07-22)
+
+### [2.0.58](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.57...v2.0.58) (2022-07-21)
+
+### [2.0.57](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.56...v2.0.57) (2022-07-21)
+
+
+### Bug Fixes
+
+* **import:** missing versions when importing multi-version crd ([#387](https://github.com/cdk8s-team/cdk8s-cli/issues/387)) ([74cb37e](https://github.com/cdk8s-team/cdk8s-cli/commit/74cb37e8d7b8a9260c9e3afe217dbb0040efad28))
+
+### [2.0.56](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.55...v2.0.56) (2022-07-20)
+
+### [2.0.55](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.54...v2.0.55) (2022-07-19)
+
+### [2.0.54](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.53...v2.0.54) (2022-07-18)
+
+### [2.0.53](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.52...v2.0.53) (2022-07-17)
+
+### [2.0.52](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.51...v2.0.52) (2022-07-16)
+
+### [2.0.51](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.50...v2.0.51) (2022-07-15)
+
+### [2.0.50](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.49...v2.0.50) (2022-07-14)
+
+### [2.0.49](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.48...v2.0.49) (2022-07-13)
+
+### [2.0.48](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.47...v2.0.48) (2022-07-12)
+
+### [2.0.47](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.46...v2.0.47) (2022-07-11)
+
+### [2.0.46](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.45...v2.0.46) (2022-07-10)
+
+### [2.0.45](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.44...v2.0.45) (2022-07-09)
+
+### [2.0.44](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.43...v2.0.44) (2022-07-08)
+
+### [2.0.43](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.42...v2.0.43) (2022-07-07)
+
+### [2.0.42](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.41...v2.0.42) (2022-07-06)
+
+### [2.0.41](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.40...v2.0.41) (2022-07-05)
+
+### [2.0.40](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.39...v2.0.40) (2022-07-04)
+
+### [2.0.39](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.38...v2.0.39) (2022-07-03)
+
+### [2.0.38](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.37...v2.0.38) (2022-07-02)
+
+### [2.0.37](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.36...v2.0.37) (2022-07-01)
+
+### [2.0.36](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.35...v2.0.36) (2022-06-30)
+
+### [2.0.35](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.34...v2.0.35) (2022-06-29)
+
+
+### Bug Fixes
+
+* typescript-app template broken for npm > 7 ([#362](https://github.com/cdk8s-team/cdk8s-cli/issues/362)) ([77bc7b3](https://github.com/cdk8s-team/cdk8s-cli/commit/77bc7b36ec4f91d76d12eee935eb682ef3a79fa8))
+
+### [2.0.34](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.33...v2.0.34) (2022-06-29)
+
+### [2.0.33](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.32...v2.0.33) (2022-06-28)
+
+### [2.0.32](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.31...v2.0.32) (2022-06-26)
+
+### [2.0.31](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.30...v2.0.31) (2022-06-25)
+
+### [2.0.30](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.29...v2.0.30) (2022-06-24)
+
+### [2.0.29](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.28...v2.0.29) (2022-06-23)
+
+### [2.0.28](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.27...v2.0.28) (2022-06-22)
+
+### [2.0.27](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.26...v2.0.27) (2022-06-21)
+
+### [2.0.26](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.25...v2.0.26) (2022-06-20)
+
+### [2.0.25](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.24...v2.0.25) (2022-06-19)
+
+### [2.0.24](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.23...v2.0.24) (2022-06-18)
+
+### [2.0.23](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.22...v2.0.23) (2022-06-17)
+
+### [2.0.22](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.21...v2.0.22) (2022-06-16)
+
+### [2.0.21](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.20...v2.0.21) (2022-06-15)
+
+### [2.0.20](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.19...v2.0.20) (2022-06-14)
+
+### [2.0.19](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.18...v2.0.19) (2022-06-13)
+
+### [2.0.18](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.17...v2.0.18) (2022-06-12)
+
+### [2.0.17](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.16...v2.0.17) (2022-06-11)
+
+### [2.0.16](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.15...v2.0.16) (2022-06-10)
+
+### [2.0.15](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.14...v2.0.15) (2022-06-09)
+
+### [2.0.14](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.13...v2.0.14) (2022-06-08)
+
+### [2.0.13](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.12...v2.0.13) (2022-06-07)
+
+### [2.0.12](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.11...v2.0.12) (2022-06-06)
+
+### [2.0.11](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.10...v2.0.11) (2022-06-05)
+
+### [2.0.10](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.9...v2.0.10) (2022-06-04)
+
+### [2.0.9](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.8...v2.0.9) (2022-06-03)
+
+### [2.0.8](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.7...v2.0.8) (2022-06-02)
+
+### [2.0.7](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.6...v2.0.7) (2022-06-01)
+
+### [2.0.6](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.5...v2.0.6) (2022-05-31)
+
+### [2.0.5](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.4...v2.0.5) (2022-05-30)
+
+### [2.0.4](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.3...v2.0.4) (2022-05-29)
+
+### [2.0.3](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.2...v2.0.3) (2022-05-28)
+
+### [2.0.2](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.1...v2.0.2) (2022-05-26)
+
+### [2.0.1](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.0...v2.0.1) (2022-05-25)
+
+## [2.0.0](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.0-rc.7...v2.0.0) (2022-05-24)
+
+## [2.0.0-rc.7](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.0-rc.6...v2.0.0-rc.7) (2022-05-24)
+
+## [2.0.0-rc.6](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.0-rc.5...v2.0.0-rc.6) (2022-05-23)
+
+## [2.0.0-rc.5](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.0-rc.4...v2.0.0-rc.5) (2022-05-22)
+
+## [2.0.0-rc.4](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.0-rc.3...v2.0.0-rc.4) (2022-05-21)
+
+## [2.0.0-rc.3](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.0-rc.2...v2.0.0-rc.3) (2022-05-20)
+
+## [2.0.0-rc.2](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.0-rc.1...v2.0.0-rc.2) (2022-05-20)
+
+## [2.0.0-rc.1](https://github.com/cdk8s-team/cdk8s-cli/compare/v2.0.0-rc.0...v2.0.0-rc.1) (2022-05-19)
+
+## [2.0.0-rc.0](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.164...v2.0.0-rc.0) (2022-05-18)
+
+
+### Features
+
+* introduce v2.x ([#278](https://github.com/cdk8s-team/cdk8s-cli/issues/278)) ([7a06925](https://github.com/cdk8s-team/cdk8s-cli/commit/7a06925f97215c74035b6d30d9d6cf3f8a8f080b))
+
+### [1.0.164](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.163...v1.0.164) (2022-05-02)
+
+### [1.0.163](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.162...v1.0.163) (2022-05-01)
+
+### [1.0.162](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.161...v1.0.162) (2022-04-30)
+
+### [1.0.161](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.160...v1.0.161) (2022-04-27)
+
+### [1.0.160](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.159...v1.0.160) (2022-04-27)
+
+### [1.0.159](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.158...v1.0.159) (2022-04-26)
+
+### [1.0.158](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.157...v1.0.158) (2022-04-25)
+
+### [1.0.157](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.156...v1.0.157) (2022-04-24)
+
+### [1.0.156](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.155...v1.0.156) (2022-04-23)
+
+### [1.0.155](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.154...v1.0.155) (2022-04-22)
+
+### [1.0.154](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.153...v1.0.154) (2022-04-21)
+
+### [1.0.153](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.152...v1.0.153) (2022-04-20)
+
+### [1.0.152](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.151...v1.0.152) (2022-04-19)
+
+### [1.0.151](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.150...v1.0.151) (2022-04-18)
+
+### [1.0.150](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.149...v1.0.150) (2022-04-17)
+
+### [1.0.149](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.148...v1.0.149) (2022-04-16)
+
+### [1.0.148](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.147...v1.0.148) (2022-04-15)
+
+### [1.0.147](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.146...v1.0.147) (2022-04-14)
+
+### [1.0.146](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.145...v1.0.146) (2022-04-11)
+
+### [1.0.145](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.144...v1.0.145) (2022-04-10)
+
+### [1.0.144](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.143...v1.0.144) (2022-04-09)
+
+### [1.0.143](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.142...v1.0.143) (2022-04-05)
+
+### [1.0.142](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.141...v1.0.142) (2022-04-04)
+
+### [1.0.141](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.140...v1.0.141) (2022-04-03)
+
+### [1.0.140](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.139...v1.0.140) (2022-04-02)
+
+### [1.0.139](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.138...v1.0.139) (2022-04-01)
+
+### [1.0.138](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.137...v1.0.138) (2022-03-31)
+
+### [1.0.137](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.136...v1.0.137) (2022-03-30)
+
+### [1.0.136](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.135...v1.0.136) (2022-03-29)
+
+### [1.0.135](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.134...v1.0.135) (2022-03-28)
+
+### [1.0.134](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.133...v1.0.134) (2022-03-27)
+
+### [1.0.133](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.132...v1.0.133) (2022-03-26)
+
+### [1.0.132](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.131...v1.0.132) (2022-03-25)
+
+### [1.0.131](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.130...v1.0.131) (2022-03-24)
+
+### [1.0.130](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.129...v1.0.130) (2022-03-23)
+
+### [1.0.129](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.128...v1.0.129) (2022-03-22)
+
+### [1.0.128](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.127...v1.0.128) (2022-03-18)
+
+### [1.0.127](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.126...v1.0.127) (2022-03-17)
+
+### [1.0.126](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.125...v1.0.126) (2022-03-16)
+
+### [1.0.125](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.124...v1.0.125) (2022-03-15)
+
+
+### Bug Fixes
+
+* import strips out enums with spaces ([#196](https://github.com/cdk8s-team/cdk8s-cli/issues/196)) ([379116f](https://github.com/cdk8s-team/cdk8s-cli/commit/379116f73217de232802a2b83f468faa4d1008de)), closes [#108](https://github.com/cdk8s-team/cdk8s-cli/issues/108) [#109](https://github.com/cdk8s-team/cdk8s-cli/issues/109)
+
+### [1.0.124](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.123...v1.0.124) (2022-03-15)
+
+### [1.0.123](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.122...v1.0.123) (2022-03-14)
+
+### [1.0.122](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.121...v1.0.122) (2022-03-13)
+
+### [1.0.121](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.120...v1.0.121) (2022-03-12)
+
+### [1.0.120](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.119...v1.0.120) (2022-03-11)
+
+### [1.0.119](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.118...v1.0.119) (2022-03-10)
+
+### [1.0.118](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.117...v1.0.118) (2022-03-09)
+
+### [1.0.117](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.116...v1.0.117) (2022-03-08)
+
+### [1.0.116](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.115...v1.0.116) (2022-03-07)
+
+### [1.0.115](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.114...v1.0.115) (2022-03-06)
+
+### [1.0.114](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.113...v1.0.114) (2022-03-05)
+
+### [1.0.113](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.112...v1.0.113) (2022-03-04)
+
+### [1.0.112](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.111...v1.0.112) (2022-03-03)
+
+### [1.0.111](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.110...v1.0.111) (2022-03-01)
+
+### [1.0.110](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.109...v1.0.110) (2022-02-27)
+
+### [1.0.109](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.108...v1.0.109) (2022-02-26)
+
+### [1.0.108](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.107...v1.0.108) (2022-02-25)
+
+### [1.0.107](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.106...v1.0.107) (2022-02-24)
+
+### [1.0.106](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.105...v1.0.106) (2022-02-23)
+
+### [1.0.105](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.104...v1.0.105) (2022-02-22)
+
+### [1.0.104](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.103...v1.0.104) (2022-02-21)
+
+### [1.0.103](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.102...v1.0.103) (2022-02-20)
+
+### [1.0.102](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.101...v1.0.102) (2022-02-19)
+
+### [1.0.101](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.100...v1.0.101) (2022-02-18)
+
+### [1.0.100](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.99...v1.0.100) (2022-02-17)
+
+
+### Bug Fixes
+
+* **import-crd:** non typescript languages fail for crds with a common group id ([#202](https://github.com/cdk8s-team/cdk8s-cli/issues/202)) ([5f5b802](https://github.com/cdk8s-team/cdk8s-cli/commit/5f5b80283bb1387efb6f8b79aaada8d62f78f034))
+
+### [1.0.99](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.98...v1.0.99) (2022-02-17)
+
+### [1.0.98](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.97...v1.0.98) (2022-02-16)
+
+
+### Bug Fixes
+
+* improve error messages around imports ([#200](https://github.com/cdk8s-team/cdk8s-cli/issues/200)) ([b8f89f2](https://github.com/cdk8s-team/cdk8s-cli/commit/b8f89f2d5318535c317293501cb91cf4a7cb8fea)), closes [#192](https://github.com/cdk8s-team/cdk8s-cli/issues/192)
+
+### [1.0.97](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.96...v1.0.97) (2022-02-16)
+
+### [1.0.96](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.95...v1.0.96) (2022-02-15)
+
+### [1.0.95](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.94...v1.0.95) (2022-02-11)
+
+### [1.0.94](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.93...v1.0.94) (2022-02-09)
+
+### [1.0.93](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.92...v1.0.93) (2022-02-08)
+
+### [1.0.92](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.91...v1.0.92) (2022-02-07)
+
+### [1.0.91](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.90...v1.0.91) (2022-02-05)
+
+### [1.0.90](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.89...v1.0.90) (2022-02-04)
+
+### [1.0.89](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.88...v1.0.89) (2022-02-02)
+
+### [1.0.88](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.87...v1.0.88) (2022-01-30)
+
+### [1.0.87](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.86...v1.0.87) (2022-01-29)
+
+### [1.0.86](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.85...v1.0.86) (2022-01-28)
+
+### [1.0.85](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.84...v1.0.85) (2022-01-26)
+
+### [1.0.84](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.83...v1.0.84) (2022-01-25)
+
+
+### Bug Fixes
+
+* error displays after manifests are successfully generated ([#176](https://github.com/cdk8s-team/cdk8s-cli/issues/176)) ([b3af38c](https://github.com/cdk8s-team/cdk8s-cli/commit/b3af38c36dd5a098a4034b02f96f0046367ae041))
+
+### [1.0.83](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.82...v1.0.83) (2022-01-24)
+
+### [1.0.82](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.81...v1.0.82) (2022-01-23)
+
+### [1.0.81](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.80...v1.0.81) (2022-01-22)
+
+### [1.0.80](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.79...v1.0.80) (2022-01-20)
+
+### [1.0.79](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.78...v1.0.79) (2022-01-19)
+
+### [1.0.78](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.77...v1.0.78) (2022-01-16)
+
+### [1.0.77](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.76...v1.0.77) (2022-01-14)
+
+### [1.0.76](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.75...v1.0.76) (2022-01-13)
+
+### [1.0.74](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.73...v1.0.74) (2022-01-09)
+
+
+### Bug Fixes
+
+* `colors` breaks cli ([#172](https://github.com/cdk8s-team/cdk8s-cli/issues/172)) ([3360654](https://github.com/cdk8s-team/cdk8s-cli/commit/33606545c0365ce19409aa7795083ab82b3ba5e3))
+
+### [1.0.73](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.72...v1.0.73) (2022-01-08)
+
+### [1.0.72](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.71...v1.0.72) (2022-01-07)
+
+### [1.0.71](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.70...v1.0.71) (2022-01-06)
+
+### [1.0.70](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.69...v1.0.70) (2022-01-05)
+
+### [1.0.69](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.68...v1.0.69) (2022-01-03)
+
+### [1.0.68](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.67...v1.0.68) (2022-01-02)
+
+### [1.0.67](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.66...v1.0.67) (2022-01-01)
+
+### [1.0.66](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.65...v1.0.66) (2021-12-31)
+
+### [1.0.65](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.64...v1.0.65) (2021-12-29)
+
+### [1.0.64](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.63...v1.0.64) (2021-12-28)
+
+### [1.0.63](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.62...v1.0.63) (2021-12-27)
+
+### [1.0.62](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.61...v1.0.62) (2021-12-26)
+
+### [1.0.61](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.60...v1.0.61) (2021-12-25)
+
+### [1.0.60](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.59...v1.0.60) (2021-12-24)
+
+### [1.0.59](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.58...v1.0.59) (2021-12-23)
+
+### [1.0.58](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.57...v1.0.58) (2021-12-22)
+
+### [1.0.57](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.56...v1.0.57) (2021-12-21)
+
+### [1.0.56](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.55...v1.0.56) (2021-12-20)
+
+### [1.0.55](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.54...v1.0.55) (2021-12-19)
+
+### [1.0.54](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.53...v1.0.54) (2021-12-19)
+
+### [1.0.53](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.52...v1.0.53) (2021-12-18)
+
+### [1.0.52](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.51...v1.0.52) (2021-12-13)
+
+### [1.0.51](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.50...v1.0.51) (2021-12-12)
+
+### [1.0.50](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.49...v1.0.50) (2021-12-11)
+
+### [1.0.49](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.48...v1.0.49) (2021-12-09)
+
+### [1.0.48](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.47...v1.0.48) (2021-12-08)
+
+### [1.0.47](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.46...v1.0.47) (2021-12-07)
+
+### [1.0.46](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.45...v1.0.46) (2021-12-06)
+
+### [1.0.45](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.44...v1.0.45) (2021-12-06)
+
+### [1.0.44](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.43...v1.0.44) (2021-12-01)
+
+### [1.0.43](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.42...v1.0.43) (2021-12-01)
+
+### [1.0.42](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.41...v1.0.42) (2021-12-01)
+
+
+### Bug Fixes
+
+* cdk8s init is failing ([#140](https://github.com/cdk8s-team/cdk8s-cli/issues/140)) ([e813723](https://github.com/cdk8s-team/cdk8s-cli/commit/e813723ee5afa4bd816b2441c0470edd469c25a8)), closes [#139](https://github.com/cdk8s-team/cdk8s-cli/issues/139)
+
+### [1.0.41](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.40...v1.0.41) (2021-11-29)
+
+### [1.0.40](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.39...v1.0.40) (2021-11-28)
+
+### [1.0.39](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.38...v1.0.39) (2021-11-26)
+
+### [1.0.38](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.37...v1.0.38) (2021-11-24)
+
+### [1.0.37](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.36...v1.0.37) (2021-11-23)
+
+### [1.0.36](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.35...v1.0.36) (2021-11-22)
+
+### [1.0.35](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.34...v1.0.35) (2021-11-20)
+
+### [1.0.34](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.33...v1.0.34) (2021-11-19)
+
+### [1.0.33](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.32...v1.0.33) (2021-11-18)
+
+### [1.0.32](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.31...v1.0.32) (2021-11-17)
+
+### [1.0.31](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.30...v1.0.31) (2021-11-16)
+
+### [1.0.30](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.29...v1.0.30) (2021-11-15)
+
+### [1.0.29](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.28...v1.0.29) (2021-11-13)
+
+### [1.0.28](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.27...v1.0.28) (2021-11-12)
+
+### [1.0.27](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.26...v1.0.27) (2021-11-10)
+
+### [1.0.26](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.25...v1.0.26) (2021-11-09)
+
+### [1.0.25](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.24...v1.0.25) (2021-11-08)
+
+### [1.0.24](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.23...v1.0.24) (2021-11-07)
+
+### [1.0.23](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.22...v1.0.23) (2021-11-05)
+
+### [1.0.22](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.21...v1.0.22) (2021-11-04)
+
+### [1.0.21](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.20...v1.0.21) (2021-11-02)
+
+### [1.0.20](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.19...v1.0.20) (2021-11-01)
+
+### [1.0.19](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.18...v1.0.19) (2021-10-31)
+
+### [1.0.18](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.17...v1.0.18) (2021-10-30)
+
+### [1.0.17](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.16...v1.0.17) (2021-10-29)
+
+### [1.0.16](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.15...v1.0.16) (2021-10-28)
+
+### [1.0.15](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.14...v1.0.15) (2021-10-27)
+
+### [1.0.14](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.13...v1.0.14) (2021-10-26)
+
+### [1.0.13](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.12...v1.0.13) (2021-10-25)
+
+### [1.0.12](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.11...v1.0.12) (2021-10-24)
+
+### [1.0.11](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.10...v1.0.11) (2021-10-23)
+
+### [1.0.10](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.9...v1.0.10) (2021-10-22)
+
+### [1.0.9](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.8...v1.0.9) (2021-10-21)
+
+### [1.0.8](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.7...v1.0.8) (2021-10-20)
+
+### [1.0.7](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.6...v1.0.7) (2021-10-19)
+
+### [1.0.6](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.5...v1.0.6) (2021-10-18)
+
+### [1.0.5](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.4...v1.0.5) (2021-10-17)
+
+### [1.0.4](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.3...v1.0.4) (2021-10-16)
+
+### [1.0.3](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.2...v1.0.3) (2021-10-15)
+
+### [1.0.2](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.1...v1.0.2) (2021-10-14)
+
+### [1.0.1](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0...v1.0.1) (2021-10-13)
+
+## [1.0.0](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.70...v1.0.0) (2021-10-12)
+
+
+### Features
+
+* 1.0 🚀 ([#91](https://github.com/cdk8s-team/cdk8s-cli/issues/91)) ([ebdaba1](https://github.com/cdk8s-team/cdk8s-cli/commit/ebdaba104a542f38bd52b0cd2aa64195c677db9f))
+
+## [1.0.0-beta.70](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.69...v1.0.0-beta.70) (2021-10-11)
+
+## [1.0.0-beta.69](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.68...v1.0.0-beta.69) (2021-10-10)
+
+## [1.0.0-beta.68](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.67...v1.0.0-beta.68) (2021-10-09)
+
+## [1.0.0-beta.67](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.66...v1.0.0-beta.67) (2021-10-07)
+
+## [1.0.0-beta.66](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.65...v1.0.0-beta.66) (2021-10-05)
+
+## [1.0.0-beta.65](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.64...v1.0.0-beta.65) (2021-10-04)
+
+## [1.0.0-beta.64](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.63...v1.0.0-beta.64) (2021-10-04)
+
+## [1.0.0-beta.63](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.62...v1.0.0-beta.63) (2021-10-03)
+
+
+### Features
+
+* default k8s import version to 1.22.0 ([#78](https://github.com/cdk8s-team/cdk8s-cli/issues/78)) ([f70f478](https://github.com/cdk8s-team/cdk8s-cli/commit/f70f47892ecc24c8b79e47e96db7cbfd211ea1a3))
+
+## [1.0.0-beta.62](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.61...v1.0.0-beta.62) (2021-10-03)
+
+## [1.0.0-beta.61](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.60...v1.0.0-beta.61) (2021-10-02)
+
+## [1.0.0-beta.60](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.59...v1.0.0-beta.60) (2021-10-01)
+
+## [1.0.0-beta.59](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.58...v1.0.0-beta.59) (2021-09-30)
+
+## [1.0.0-beta.58](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.57...v1.0.0-beta.58) (2021-09-29)
+
+## [1.0.0-beta.57](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.56...v1.0.0-beta.57) (2021-09-28)
+
+## [1.0.0-beta.56](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.55...v1.0.0-beta.56) (2021-09-27)
+
+## [1.0.0-beta.55](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.54...v1.0.0-beta.55) (2021-09-26)
+
+## [1.0.0-beta.54](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.53...v1.0.0-beta.54) (2021-09-24)
+
+## [1.0.0-beta.53](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.52...v1.0.0-beta.53) (2021-09-22)
+
+
+### Features
+
+* use cdk8s-plus-22 for all new projects ([#69](https://github.com/cdk8s-team/cdk8s-cli/issues/69)) ([5eef812](https://github.com/cdk8s-team/cdk8s-cli/commit/5eef81266ecd1d9038e3c605887a29a39439121a))
+
+## [1.0.0-beta.52](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.51...v1.0.0-beta.52) (2021-09-20)
+
+## [1.0.0-beta.51](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.50...v1.0.0-beta.51) (2021-09-19)
+
+
+### Features
+
+* input validation ([#67](https://github.com/cdk8s-team/cdk8s-cli/issues/67)) ([de6ae79](https://github.com/cdk8s-team/cdk8s-cli/commit/de6ae79d6643b8522ac5692c2a3cad43d5778200))
+
+## [1.0.0-beta.50](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.49...v1.0.0-beta.50) (2021-09-09)
+
+## [1.0.0-beta.49](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.48...v1.0.0-beta.49) (2021-09-07)
+
+
+### Bug Fixes
+
+* init python-app errors on Windows ([#64](https://github.com/cdk8s-team/cdk8s-cli/issues/64)) ([aff9e4e](https://github.com/cdk8s-team/cdk8s-cli/commit/aff9e4e0e8affbe2aa652053a742ccf570fba341))
+
+## [1.0.0-beta.48](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.47...v1.0.0-beta.48) (2021-09-02)
+
+
+### Bug Fixes
+
+* unquoted paths cannot be executed on windows ([#63](https://github.com/cdk8s-team/cdk8s-cli/issues/63)) ([a413901](https://github.com/cdk8s-team/cdk8s-cli/commit/a413901e9c2b012caa7b19f7721076cf6a372efc))
+
+## [1.0.0-beta.45](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.44...v1.0.0-beta.45) (2021-08-24)
+
+## [1.0.0-beta.44](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.43...v1.0.0-beta.44) (2021-08-23)
+
+## [1.0.0-beta.43](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.42...v1.0.0-beta.43) (2021-08-22)
+
+## [1.0.0-beta.42](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.41...v1.0.0-beta.42) (2021-08-21)
+
+## [1.0.0-beta.41](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.40...v1.0.0-beta.41) (2021-08-20)
+
+## [1.0.0-beta.40](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.39...v1.0.0-beta.40) (2021-08-19)
+
+
+### Features
+
+* fix imports not supporting Lazy values ([#55](https://github.com/cdk8s-team/cdk8s-cli/issues/55)) ([cb3fe0d](https://github.com/cdk8s-team/cdk8s-cli/commit/cb3fe0dcb4e028065e67794f99399026a69edab6))
+
+## [1.0.0-beta.39](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.38...v1.0.0-beta.39) (2021-08-19)
+
+## [1.0.0-beta.38](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.37...v1.0.0-beta.38) (2021-08-19)
+
+## [1.0.0-beta.37](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.36...v1.0.0-beta.37) (2021-08-12)
+
+
+### Features
+
+* go project template and imports ([#48](https://github.com/cdk8s-team/cdk8s-cli/issues/48)) ([ecb4639](https://github.com/cdk8s-team/cdk8s-cli/commit/ecb4639db7f21c2123dbacf63fb4e24636c290c1)), closes [#26](https://github.com/cdk8s-team/cdk8s-cli/issues/26) [#27](https://github.com/cdk8s-team/cdk8s-cli/issues/27)
+
+## [1.0.0-beta.36](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.35...v1.0.0-beta.36) (2021-08-11)
+
+
+### Features
+
+* include CLI information for long import times ([#53](https://github.com/cdk8s-team/cdk8s-cli/issues/53)) ([19560fb](https://github.com/cdk8s-team/cdk8s-cli/commit/19560fb4defdb74ccd6cb100feec8c68044c283f))
+
+## [1.0.0-beta.35](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.34...v1.0.0-beta.35) (2021-08-02)
+
+
+### Features
+
+* add flag to control upgrade check ([#12](https://github.com/cdk8s-team/cdk8s-cli/issues/12)) ([586fe28](https://github.com/cdk8s-team/cdk8s-cli/commit/586fe28869ba0a7b2036bc03ec541c7ddbeeb5e2))
+
+## [1.0.0-beta.34](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.33...v1.0.0-beta.34) (2021-08-02)
+
+## [1.0.0-beta.33](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.32...v1.0.0-beta.33) (2021-08-01)
+
+## [1.0.0-beta.32](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.31...v1.0.0-beta.32) (2021-07-31)
+
+## [1.0.0-beta.31](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.30...v1.0.0-beta.31) (2021-07-29)
+
+## [1.0.0-beta.30](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.29...v1.0.0-beta.30) (2021-07-28)
+
+
+### Bug Fixes
+
+* **import:** cannot import props that have non-standard capitalization ([#43](https://github.com/cdk8s-team/cdk8s-cli/issues/43)) ([5e2b300](https://github.com/cdk8s-team/cdk8s-cli/commit/5e2b300c4540957b8ca2cb0e6112aa39f45362e9))
+
+## [1.0.0-beta.29](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.28...v1.0.0-beta.29) (2021-07-28)
+
+## [1.0.0-beta.28](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.27...v1.0.0-beta.28) (2021-07-27)
+
+## [1.0.0-beta.27](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.26...v1.0.0-beta.27) (2021-07-27)
+
+
+### Bug Fixes
+
+* **import:** CRDs not including metadata field ([#44](https://github.com/cdk8s-team/cdk8s-cli/issues/44)) ([1bb6c62](https://github.com/cdk8s-team/cdk8s-cli/commit/1bb6c622864603df1fca6366b37131920ae18da4))
+
+## [1.0.0-beta.26](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.25...v1.0.0-beta.26) (2021-06-18)
+
+## [1.0.0-beta.25](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.24...v1.0.0-beta.25) (2021-06-17)
+
+## [1.0.0-beta.24](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.23...v1.0.0-beta.24) (2021-06-13)
+
+## [1.0.0-beta.23](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.22...v1.0.0-beta.23) (2021-06-13)
+
+## [1.0.0-beta.22](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.21...v1.0.0-beta.22) (2021-06-07)
+
+## [1.0.0-beta.21](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.20...v1.0.0-beta.21) (2021-06-07)
+
+## [1.0.0-beta.20](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.19...v1.0.0-beta.20) (2021-06-06)
+
+## [1.0.0-beta.19](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.18...v1.0.0-beta.19) (2021-06-01)
+
+
+### Bug Fixes
+
+* **init:** python and java init is broken due to invalid versions ([#8](https://github.com/cdk8s-team/cdk8s-cli/issues/8)) ([a13f6e9](https://github.com/cdk8s-team/cdk8s-cli/commit/a13f6e966517b2a8394f5c21213fe7eded6da0d6))
+
+## [1.0.0-beta.18](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.17...v1.0.0-beta.18) (2021-06-01)
+
+## [1.0.0-beta.17](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.16...v1.0.0-beta.17) (2021-06-01)
+
+## [1.0.0-beta.16](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.15...v1.0.0-beta.16) (2021-06-01)
+
+## [1.0.0-beta.15](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.14...v1.0.0-beta.15) (2021-05-31)
+
+## [1.0.0-beta.14](https://github.com/cdk8s-team/cdk8s-cli/compare/v1.0.0-beta.11...v1.0.0-beta.14) (2021-05-31)
+
+## [1.0.0-beta.11](https://github.com/cdk8s-team/cdk8s-cli/compare/2616372a202c552e0fdd1be73eff2dbe5175704b...v1.0.0-beta.11) (2021-05-26)
+
+
+### ⚠ BREAKING CHANGES
+
+* **lib:** the deprecated API `Duration.toISOString()` has been removed. Use `Duration.toIsoString()` instead.
+* **lib:** CAUTION! Auto-generated resource names will change with this release. Resource names in manifests synthesized by a previous version of the CDK8s will be invalidated. Deploying new manifests will cause **resources to be replaced**. Temporarily, you can opt to use the legacy hashing mechanism by setting the environment variable `CDK8S_LEGACY_HASH=1`.
+* **lib:** `Names.toDnsLabel()` now accepts a construct scope instead of a string path, and a set of options instead of `maxLen`.
+* **lib:** `Names.toLabelValue()` now accepts a construct scope instead of a string path, and a set of options instead of `maxLen`.
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* **plus-17:** All L2 resource names will undergo a name change (e.g `test-chart-config-configmap-233db8e7` -> `test-chart-config-c3f7d3c0`)
+
+Resolves https://github.com/awslabs/cdk8s/issues/373
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* Construct input types generated by `cdk8s import` are now called `XxxProps` instead of `XxxOptions` to conform with the CDK ecosystem.
+* **core:** `ApiObjectOptions` is now called `ApiObjectProps`
+* **core:** `AppOptions` is now called `AppProps`
+* **core:** `ChartOptions` is now called `ChartProps`
+* **core:** `HelmOptions` is now called `HelmProps`
+* **core:** `IncludeOptions` is now called `IncludeProps`
+* **cli:** when importing k8s api objects using `cdk8s import`, non-stable APIs will be have an API level postfix. For example, k8s@1.18 will have an `IngressV1Beta1` API object.
+* **cli:** The `--include` CLI option has been removed since all API objects are always imported.
+* **cli:** When using the CLI to import the core Kubernetes API objects, the imported classes will now have a `Kube` prefix in order to make it easier to differentiate them from the classes offered by the high-level APIs in CDK8s+ (e.g. `k8s.Deployment` is now `k8s.KubeDeployment`). You can disable through the `--no-class-prefix` option: `cdk8s import --no-class-prefix k8s`.
+* **plus:** Containers now need to be inputed as interfaces rather than classes. Instead of passing `new kplus.Container(props)`, simply pass in `props`.
+
+Resolves https://github.com/awslabs/cdk8s/issues/365
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* **lib:** `EnvValue.fromSecret(secret, key)` has been removed in favor of `EnvValue.fromSecretValue({ secret, key })`.
+* **plus:** `spec` was removed from all cdk8s+ constructs and that now have a flat structure. See [Example](https://github.com/awslabs/cdk8s/tree/master/packages/cdk8s-plus#at-a-glance) for new usage.
+
+* **plus**: Construct id's for deployment will change due to a latent bug that appended the word `pod` to them.
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* **plus:** `deployment.expose()` now takes `port` as a positional argument (before: `deployment.expose({ port })`, now: `deployment.expose(port)`).
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* **lib:** auto-generated resource names that included duplicate hyphens will change will be replaced when applied.
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* **lib:** cdk8s-plus's value of a label `cdk8s.deployment` of Pods are changed
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* **lib:** resource names will now be rendered differently, omitting adjacent duplicate components.
+
+Signed-off-by: campionfellin <campionfellin@gmail.com>
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* **lib:** `cdk8s` discontinues support for the `onPrepare` and `onSynthesis` construct hooks. These methods will eventually be removed from the `constructs` programming model.
+* **cli:** enum string values are now proper enums instead of just `string`s.
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+* **cli:** the generated module names of imported CRDs now include the resource's group and not just its kind in order to ensure uniqueness. For example, when importing the Jenkins CRD, instead of 'imports/jenkins.ts`, we now have `imports/jenkins.io/jenkins.ts`.
+- **cli**: class names are now normalized to `PascalCase`.
+* please upgrade your dependency requirement for "constructs" to ^2.0.0
+* **cli:** `cdk8s gen` is now `cdk8s import k8s` and output goes to `imports/k8s.ts` instead of `.gen/index.ts`.
+* **cli:** `cdk8s import` now generates a single file with all types, which means you will have to modify TypeScript code to `import { Deployment, Pod, ... } from './imports/k8s'` instead of importing multiple files.
+
+### Features
+
+* add contributor instructions about using jsii docker image ([#397](https://github.com/cdk8s-team/cdk8s-cli/issues/397)) ([bb0a5cc](https://github.com/cdk8s-team/cdk8s-cli/commit/bb0a5cc0762e753f1f18093b3cd15cbb83bd7c5e))
+* allow arbitrary construct names ([#64](https://github.com/cdk8s-team/cdk8s-cli/issues/64)) ([1309960](https://github.com/cdk8s-team/cdk8s-cli/commit/1309960e62d13b00dc964f6c88e15d74390e09a2)), closes [#48](https://github.com/cdk8s-team/cdk8s-cli/issues/48)
+* cdk8s website ([#89](https://github.com/cdk8s-team/cdk8s-cli/issues/89)) ([430d9b7](https://github.com/cdk8s-team/cdk8s-cli/commit/430d9b7e6b99dd54e6fe611fb22e1dcafb18cc13))
+* **cdk8s:** k8s-compatible object names from construct path ([2f3df34](https://github.com/cdk8s-team/cdk8s-cli/commit/2f3df34bc3343ddd85472f77945f093b69ad4076))
+* **cdk8s:** the App root construct ([#15](https://github.com/cdk8s-team/cdk8s-cli/issues/15)) ([c595240](https://github.com/cdk8s-team/cdk8s-cli/commit/c595240ed934c300ad5f9db209692d2113b3d113))
+* chart-level labels ([#355](https://github.com/cdk8s-team/cdk8s-cli/issues/355)) ([c545c1e](https://github.com/cdk8s-team/cdk8s-cli/commit/c545c1efec86d3af5852101d01f4fbad2e000ac6))
+* chart.generateObjectName ([03a1d26](https://github.com/cdk8s-team/cdk8s-cli/commit/03a1d2668a7c4fef9dac5db81b6496eff2208eab))
+* Chart.of(node) ([d6a9dc0](https://github.com/cdk8s-team/cdk8s-cli/commit/d6a9dc0cb87d11fd603f330059cc1ab326c44a71))
+* chart.toJson() and apiObject.toJson() ([#63](https://github.com/cdk8s-team/cdk8s-cli/issues/63)) ([80e8402](https://github.com/cdk8s-team/cdk8s-cli/commit/80e8402790c4112e64bda2dd9a42fa897ee4ab8b)), closes [#48](https://github.com/cdk8s-team/cdk8s-cli/issues/48)
+* **cli:** "cdk8s gen" is now "cdk8s import k8s" ([#43](https://github.com/cdk8s-team/cdk8s-cli/issues/43)) ([fb9e0b5](https://github.com/cdk8s-team/cdk8s-cli/commit/fb9e0b5396a019bd979cc6ad0f646d76c5b85bc6)), closes [#31](https://github.com/cdk8s-team/cdk8s-cli/issues/31) [#40](https://github.com/cdk8s-team/cdk8s-cli/issues/40)
+* **cli:** cdk8s import crd.yaml ([#70](https://github.com/cdk8s-team/cdk8s-cli/issues/70)) ([5d1c278](https://github.com/cdk8s-team/cdk8s-cli/commit/5d1c278f391f2561c8999efcd2015f2de9e26b72)), closes [#27](https://github.com/cdk8s-team/cdk8s-cli/issues/27)
+* **cli:** cdk8s init template for java ([#245](https://github.com/cdk8s-team/cdk8s-cli/issues/245)) ([2bec62a](https://github.com/cdk8s-team/cdk8s-cli/commit/2bec62afac55fc8fe0c34ed6cfbb508977c43815))
+* **cli:** cdk8s synth ([#44](https://github.com/cdk8s-team/cdk8s-cli/issues/44)) ([d457ea9](https://github.com/cdk8s-team/cdk8s-cli/commit/d457ea9184e45c5d94b93ac17e3deecdd0b8c657)), closes [#41](https://github.com/cdk8s-team/cdk8s-cli/issues/41)
+* **cli:** cdk8s.yaml ([#52](https://github.com/cdk8s-team/cdk8s-cli/issues/52)) ([e6834d3](https://github.com/cdk8s-team/cdk8s-cli/commit/e6834d3ae03810d1402c34a123adb8a1376808b7)), closes [#42](https://github.com/cdk8s-team/cdk8s-cli/issues/42)
+* **cli:** class prefix for imported constructs ([#370](https://github.com/cdk8s-team/cdk8s-cli/issues/370)) ([0b18df3](https://github.com/cdk8s-team/cdk8s-cli/commit/0b18df37a42d1c2f29719089cf7996efdbab8cb3)), closes [#140](https://github.com/cdk8s-team/cdk8s-cli/issues/140)
+* **cli:** enable using imported resources as raw manifests ([#447](https://github.com/cdk8s-team/cdk8s-cli/issues/447)) ([aa2422e](https://github.com/cdk8s-team/cdk8s-cli/commit/aa2422e1844d4684b0c61f871c9cbc9f34c08183))
+* **cli:** ignore hidden files in "cdk8s init" ([#99](https://github.com/cdk8s-team/cdk8s-cli/issues/99)) ([5681e14](https://github.com/cdk8s-team/cdk8s-cli/commit/5681e148ce7621562d27ca32843183337554943c))
+* **cli:** import - support enum string fields ([#210](https://github.com/cdk8s-team/cdk8s-cli/issues/210)) ([8b8ad44](https://github.com/cdk8s-team/cdk8s-cli/commit/8b8ad44bba1f0ebced6d41af52d079b1a2ec54b2)), closes [#196](https://github.com/cdk8s-team/cdk8s-cli/issues/196)
+* **cli:** import a single module per api group ([#402](https://github.com/cdk8s-team/cdk8s-cli/issues/402)) ([ac295fe](https://github.com/cdk8s-team/cdk8s-cli/commit/ac295fe78544c4b06f732fe945dfa6423eea5c83)), closes [#378](https://github.com/cdk8s-team/cdk8s-cli/issues/378) [#401](https://github.com/cdk8s-team/cdk8s-cli/issues/401)
+* **cli:** import constructs for all API levels ([#379](https://github.com/cdk8s-team/cdk8s-cli/issues/379)) ([b0d7621](https://github.com/cdk8s-team/cdk8s-cli/commit/b0d76210fe944b03f8197b821da134120015e139)), closes [#380](https://github.com/cdk8s-team/cdk8s-cli/issues/380)
+* **cli:** import CRDs from a running cluster ([#207](https://github.com/cdk8s-team/cdk8s-cli/issues/207)) ([5153422](https://github.com/cdk8s-team/cdk8s-cli/commit/5153422432d78aa97b928f507be27048e1868c7a)), closes [#197](https://github.com/cdk8s-team/cdk8s-cli/issues/197)
+* **cli:** import from crds.dev ([#378](https://github.com/cdk8s-team/cdk8s-cli/issues/378)) ([c62d0a4](https://github.com/cdk8s-team/cdk8s-cli/commit/c62d0a4c86c6256d93cc8b717b081fd4a16de0be)), closes [#377](https://github.com/cdk8s-team/cdk8s-cli/issues/377)
+* **cli:** import only one class for every api object ([#39](https://github.com/cdk8s-team/cdk8s-cli/issues/39)) ([2db4cfb](https://github.com/cdk8s-team/cdk8s-cli/commit/2db4cfbb20e7b6d8b09e8b8c9e6d096f0ea9fefe))
+* **cli:** java import support  ([#226](https://github.com/cdk8s-team/cdk8s-cli/issues/226)) ([9619a73](https://github.com/cdk8s-team/cdk8s-cli/commit/9619a730766a109e429007c459f77541ebb97399))
+* **cli:** jest tests in typescript-app template ([b6aed5a](https://github.com/cdk8s-team/cdk8s-cli/commit/b6aed5ad9252c18f6f86d94caa472895c1c6a529))
+* **cli:** new version notifications ([#454](https://github.com/cdk8s-team/cdk8s-cli/issues/454)) ([065756e](https://github.com/cdk8s-team/cdk8s-cli/commit/065756ef89afa938cc120f3af83b23851e06098d)), closes [#452](https://github.com/cdk8s-team/cdk8s-cli/issues/452)
+* **cli:** project templates with "cdk8s init" ([#10](https://github.com/cdk8s-team/cdk8s-cli/issues/10)) ([4aa59d9](https://github.com/cdk8s-team/cdk8s-cli/commit/4aa59d9486d475b008244a90b6a1ee23772b5700))
+* **cli:** python project template ([9be957f](https://github.com/cdk8s-team/cdk8s-cli/commit/9be957f4a34f8ad94afd77541a29dfdf423cb608))
+* **cli:** python project template ([#36](https://github.com/cdk8s-team/cdk8s-cli/issues/36)) ([30f3bb7](https://github.com/cdk8s-team/cdk8s-cli/commit/30f3bb7d787f0d1b16b90c8ddafc4dcc451c4e4b))
+* **cli:** python support for "import" ([#47](https://github.com/cdk8s-team/cdk8s-cli/issues/47)) ([3b93d64](https://github.com/cdk8s-team/cdk8s-cli/commit/3b93d6465c2748693ce220c307c1b94b1cdaa11f))
+* **cli:** remove the cookiecutter prerequisite ([#13](https://github.com/cdk8s-team/cdk8s-cli/issues/13)) ([10ab259](https://github.com/cdk8s-team/cdk8s-cli/commit/10ab2591828b790a6bbcdb306d302d5f8a30d30e))
+* **cli:** stdout option for cdk8s synth ([#361](https://github.com/cdk8s-team/cdk8s-cli/issues/361)) ([bbf116b](https://github.com/cdk8s-team/cdk8s-cli/commit/bbf116b93d9a14c24094aa51ec3a383489341190))
+* **cli:** support CRDs with apiVersion "apiextensions.k8s.io/v1" ([#142](https://github.com/cdk8s-team/cdk8s-cli/issues/142)) ([f5111b0](https://github.com/cdk8s-team/cdk8s-cli/commit/f5111b07eefbc58a4ae23b498e6b41f48a0b82ac))
+* **cli:** support import module name overriding in python ([#107](https://github.com/cdk8s-team/cdk8s-cli/issues/107)) ([327ba47](https://github.com/cdk8s-team/cdk8s-cli/commit/327ba47524b7dfdb05096bb9a78c9d504db4a02c))
+* **cli:** typescript - yarn run upgrade & upgrade:next ([735e840](https://github.com/cdk8s-team/cdk8s-cli/commit/735e840f0ef440e715d34923aed184e58a9f243c))
+* **cli:** typescript project - "yarn build" now includes "synth" ([7b15e3a](https://github.com/cdk8s-team/cdk8s-cli/commit/7b15e3a4f47e4d17b417012a82b335690be8cc52))
+* cookiecutter template for typescript app projects ([#9](https://github.com/cdk8s-team/cdk8s-cli/issues/9)) ([55087e2](https://github.com/cdk8s-team/cdk8s-cli/commit/55087e2be37de680b8dea25a806f013e17f6351a))
+* default chart namespaces ([#68](https://github.com/cdk8s-team/cdk8s-cli/issues/68)) ([36b9ff1](https://github.com/cdk8s-team/cdk8s-cli/commit/36b9ff1b32699da894eae085c809c2399ac9b837))
+* **docs:** add python and pipenv prerequisites ([db23fa1](https://github.com/cdk8s-team/cdk8s-cli/commit/db23fa168ed6262d199383a651769fc2fae14a11)), closes [#166](https://github.com/cdk8s-team/cdk8s-cli/issues/166)
+* **docs:** getting started in python ([#60](https://github.com/cdk8s-team/cdk8s-cli/issues/60)) ([27d3bac](https://github.com/cdk8s-team/cdk8s-cli/commit/27d3bac4579ea8cdf0b6c692e05ab0ac47e17590))
+* documentation website ([#367](https://github.com/cdk8s-team/cdk8s-cli/issues/367)) ([505f946](https://github.com/cdk8s-team/cdk8s-cli/commit/505f9460e53a0cf3a0249b762431addda999ec4a)), closes [#366](https://github.com/cdk8s-team/cdk8s-cli/issues/366)
+* escape hatches ([#372](https://github.com/cdk8s-team/cdk8s-cli/issues/372)) ([12b0f01](https://github.com/cdk8s-team/cdk8s-cli/commit/12b0f01c5c1ef4c621f5b501d39911a207251ca1)), closes [#144](https://github.com/cdk8s-team/cdk8s-cli/issues/144)
+* **example:** python hello example ([#101](https://github.com/cdk8s-team/cdk8s-cli/issues/101)) ([e792d2b](https://github.com/cdk8s-team/cdk8s-cli/commit/e792d2bebb5101daecc53c4aaed9500c3ef27617))
+* **examples:** central readme for all examples ([#176](https://github.com/cdk8s-team/cdk8s-cli/issues/176)) ([9cab302](https://github.com/cdk8s-team/cdk8s-cli/commit/9cab302939c3d8ce3104e30d2bd1ad22b87bcbf8)), closes [#174](https://github.com/cdk8s-team/cdk8s-cli/issues/174)
+* **examples:** Elasticsearch query using CDK8s+ and CRD ([#281](https://github.com/cdk8s-team/cdk8s-cli/issues/281)) ([3be1a96](https://github.com/cdk8s-team/cdk8s-cli/commit/3be1a96b1801f2e23673b454e0a0b59cf7f1b6e5))
+* **examples:** reorganize examples by language ([#138](https://github.com/cdk8s-team/cdk8s-cli/issues/138)) ([85cf631](https://github.com/cdk8s-team/cdk8s-cli/commit/85cf6313c20771b718c19ee6085afc23cd787311))
+* **examples:** updates to hello-world example and directory reorganization ([#33](https://github.com/cdk8s-team/cdk8s-cli/issues/33)) ([1c8f694](https://github.com/cdk8s-team/cdk8s-cli/commit/1c8f694b51fac662477175c2e8f12b38b810d2bf))
+* experimental golang bindings ([#523](https://github.com/cdk8s-team/cdk8s-cli/issues/523)) ([6737351](https://github.com/cdk8s-team/cdk8s-cli/commit/6737351ee3c3d119e0a2969e90f911b9e45c1a11))
+* getting started documentation ([2616372](https://github.com/cdk8s-team/cdk8s-cli/commit/2616372a202c552e0fdd1be73eff2dbe5175704b))
+* ImagePullPolicy support for cdk8s-plus Container ([#313](https://github.com/cdk8s-team/cdk8s-cli/issues/313)) ([8307757](https://github.com/cdk8s-team/cdk8s-cli/commit/8307757deb9b70db4fda716d4a4afb7cef522dc9))
+* Introducing "cdk8s+": high-level APIs for Kubernetes ([#239](https://github.com/cdk8s-team/cdk8s-cli/issues/239)) ([1b991f6](https://github.com/cdk8s-team/cdk8s-cli/commit/1b991f691bd214e9aaac66e90e3b065d0c31b9aa))
+* **lib:** allow hash to be optionally included in Names functions. ([#396](https://github.com/cdk8s-team/cdk8s-cli/issues/396)) ([2c86526](https://github.com/cdk8s-team/cdk8s-cli/commit/2c86526e6434b7317c338b3446613b8ff7650e5a))
+* **lib:** dependencies and ordering of charts and objects ([#223](https://github.com/cdk8s-team/cdk8s-cli/issues/223)) ([701579e](https://github.com/cdk8s-team/cdk8s-cli/commit/701579e46a1f5891a1233c2e44e06a528f5a183e)), closes [#111](https://github.com/cdk8s-team/cdk8s-cli/issues/111)
+* **lib:** Expose DependecyGraph for upstream use ([#329](https://github.com/cdk8s-team/cdk8s-cli/issues/329)) ([ee88402](https://github.com/cdk8s-team/cdk8s-cli/commit/ee884023a313fae44e69124da9e37a9e52611845)), closes [#328](https://github.com/cdk8s-team/cdk8s-cli/issues/328)
+* **lib:** flag to disable dictionary sort ([#534](https://github.com/cdk8s-team/cdk8s-cli/issues/534)) ([a4eca40](https://github.com/cdk8s-team/cdk8s-cli/commit/a4eca40f72d654ea0355ec513073b05c7dbffe9e)), closes [#525](https://github.com/cdk8s-team/cdk8s-cli/issues/525)
+* **lib:** helm construct ([#346](https://github.com/cdk8s-team/cdk8s-cli/issues/346)) ([6ee449f](https://github.com/cdk8s-team/cdk8s-cli/commit/6ee449fc1b82e2c59ec24d327044f828665df8b5)), closes [#65](https://github.com/cdk8s-team/cdk8s-cli/issues/65)
+* **lib:** introduce "include" ([#202](https://github.com/cdk8s-team/cdk8s-cli/issues/202)) ([75d13e8](https://github.com/cdk8s-team/cdk8s-cli/commit/75d13e8b06351b66bd5d495f6ac6a3575fac6421)), closes [#199](https://github.com/cdk8s-team/cdk8s-cli/issues/199)
+* **lib:** omit duplicate components in generated names ([#258](https://github.com/cdk8s-team/cdk8s-cli/issues/258)) ([473b5ef](https://github.com/cdk8s-team/cdk8s-cli/commit/473b5ef7f442b932e9c4c4356945b91e8e1bc4e4))
+* **lib:** SecretValue ([#351](https://github.com/cdk8s-team/cdk8s-cli/issues/351)) ([dd7cf58](https://github.com/cdk8s-team/cdk8s-cli/commit/dd7cf5857b82da75b88f6786933070c570e5df23))
+* **lib:** yaml utility functions ([#198](https://github.com/cdk8s-team/cdk8s-cli/issues/198)) ([9e0f030](https://github.com/cdk8s-team/cdk8s-cli/commit/9e0f030ecdb249d9095d0d774b33919a17cc48f7))
+* migrate to cdk.dev slack workspace ([#336](https://github.com/cdk8s-team/cdk8s-cli/issues/336)) ([b203e5a](https://github.com/cdk8s-team/cdk8s-cli/commit/b203e5a897e297227c33442031ce3b0dcfefa486))
+* new website ([#143](https://github.com/cdk8s-team/cdk8s-cli/issues/143)) ([fcc59b0](https://github.com/cdk8s-team/cdk8s-cli/commit/fcc59b062824aad31dea209fa9df1088425c240b))
+* only publish doc site on release commits ([#507](https://github.com/cdk8s-team/cdk8s-cli/issues/507)) ([5acc54b](https://github.com/cdk8s-team/cdk8s-cli/commit/5acc54b004951e60334abc369ec85a537cc2a973))
+* peer-depend on "constructs" instead of "@aws-cdk/core" ([#66](https://github.com/cdk8s-team/cdk8s-cli/issues/66)) ([c336c95](https://github.com/cdk8s-team/cdk8s-cli/commit/c336c95f4e4355f94abe66d2839ccbb26d4f15b8))
+* **plus-17:** add StatefulSet construct ([#400](https://github.com/cdk8s-team/cdk8s-cli/issues/400)) ([98aad99](https://github.com/cdk8s-team/cdk8s-cli/commit/98aad99a0a325b706c8f1c4e5f2ac1af77795400))
+* **plus-17:** Add type option for secrets in kplus. ([#425](https://github.com/cdk8s-team/cdk8s-cli/issues/425)) ([28d660f](https://github.com/cdk8s-team/cdk8s-cli/commit/28d660f6d252de26268d3eb72060580894de3e21))
+* **plus-17:** additional options for the Job construct. ([#398](https://github.com/cdk8s-team/cdk8s-cli/issues/398)) ([17e8801](https://github.com/cdk8s-team/cdk8s-cli/commit/17e8801bc748e3ff0e999b994645058cc17637ce))
+* **plus-17:** restrict CIDR IP addresses for a LoadBalancer ([#446](https://github.com/cdk8s-team/cdk8s-cli/issues/446)) ([cf96ae2](https://github.com/cdk8s-team/cdk8s-cli/commit/cf96ae2319e821307e23d6343883b531294e6359)), closes [#435](https://github.com/cdk8s-team/cdk8s-cli/issues/435)
+* **plus:** add liveness and startup probes to Container ([#358](https://github.com/cdk8s-team/cdk8s-cli/issues/358)) ([f3f9a6a](https://github.com/cdk8s-team/cdk8s-cli/commit/f3f9a6a7474e60ff90376a4d74be55d08014b2d3))
+* **plus:** Container is now inputed as an interface instead of class ([#376](https://github.com/cdk8s-team/cdk8s-cli/issues/376)) ([33bf97a](https://github.com/cdk8s-team/cdk8s-cli/commit/33bf97a9a6f4bca5c259964d833955639835f12c))
+* **plus:** expose service options in `expose()` ([#357](https://github.com/cdk8s-team/cdk8s-cli/issues/357)) ([7137698](https://github.com/cdk8s-team/cdk8s-cli/commit/713769883c9b4fe0ec443d0e776155d720b65cb6))
+* **plus:** Ingress ([#340](https://github.com/cdk8s-team/cdk8s-cli/issues/340)) ([14ac668](https://github.com/cdk8s-team/cdk8s-cli/commit/14ac668f5f88445f14864ac3d271f8a9afbd40c7)), closes [#125](https://github.com/cdk8s-team/cdk8s-cli/issues/125)
+* **plus:** readiness probes ([#353](https://github.com/cdk8s-team/cdk8s-cli/issues/353)) ([a57e466](https://github.com/cdk8s-team/cdk8s-cli/commit/a57e466d67b561bec95c7be26eb7a36625ebb744))
+* **plus:** service.addDeployment() ([#342](https://github.com/cdk8s-team/cdk8s-cli/issues/342)) ([5413b3b](https://github.com/cdk8s-team/cdk8s-cli/commit/5413b3bf6ca13f9839407d561b622e64a4de62e4))
+* **podinfo:** allow containers to bind to deployment ([45237c0](https://github.com/cdk8s-team/cdk8s-cli/commit/45237c0aa630a7c0992abee9303dc86b73aba4f5))
+* **readme:** add link to "awesome cdk8s" ([0889a6e](https://github.com/cdk8s-team/cdk8s-cli/commit/0889a6e5d738d928219b24c523b8bfdcec73bc43))
+* sort keys of ApiObject manifests ([#67](https://github.com/cdk8s-team/cdk8s-cli/issues/67)) ([1fe89bd](https://github.com/cdk8s-team/cdk8s-cli/commit/1fe89bd7355d48c99c35be7d4429b1095529dc7f)), closes [#17](https://github.com/cdk8s-team/cdk8s-cli/issues/17)
+* surface cdk8s in awscdk.io ([45e188e](https://github.com/cdk8s-team/cdk8s-cli/commit/45e188e08a607a0fbc8b5003ce9ab84789f1322e))
+* switch to 1.0.0-beta version line ([#384](https://github.com/cdk8s-team/cdk8s-cli/issues/384)) ([ffce8c6](https://github.com/cdk8s-team/cdk8s-cli/commit/ffce8c696ce502ec4a14f65b715474faa7f74c7b))
+* **website:** add reference docs links ([2034ec0](https://github.com/cdk8s-team/cdk8s-cli/commit/2034ec06f0c9fb419a194cbb23a18e2678076d29))
+
+
+### Bug Fixes
+
+* `yaml` not found in jsii languages ([39ef409](https://github.com/cdk8s-team/cdk8s-cli/commit/39ef40935459e3cb910c11b07bec8fd474f45813))
+* allow tests to run without write access to os.tmpdir parent ([#338](https://github.com/cdk8s-team/cdk8s-cli/issues/338)) ([dc17022](https://github.com/cdk8s-team/cdk8s-cli/commit/dc1702207deb4367a1d05717a009851a7d3dac68))
+* **cdk8s:** autogenerated names fail validation for some resource types ([#18](https://github.com/cdk8s-team/cdk8s-cli/issues/18)) ([b70e4fe](https://github.com/cdk8s-team/cdk8s-cli/commit/b70e4fe5e8fdfc47e953d90d64337ff9f108fa39)), closes [#16](https://github.com/cdk8s-team/cdk8s-cli/issues/16)
+* cli does not work when used from a symlink ([#11](https://github.com/cdk8s-team/cdk8s-cli/issues/11)) ([4bd3a37](https://github.com/cdk8s-team/cdk8s-cli/commit/4bd3a37625c4e13c68eb1561ed5fe7ebcb8c5a33))
+* **cli-init:** install "constructs" instead of "@aws-cdk/core" ([6ccc03f](https://github.com/cdk8s-team/cdk8s-cli/commit/6ccc03fc9ee82ad292d4f8efd1d66447c67b1122))
+* **cli:** allow any python 3 to be used ([#518](https://github.com/cdk8s-team/cdk8s-cli/issues/518)) ([2a49196](https://github.com/cdk8s-team/cdk8s-cli/commit/2a491963547eab0b3348acae03fc5bf1db215794))
+* **cli:** Conform python and java package names to language standards (no hyphens) ([#283](https://github.com/cdk8s-team/cdk8s-cli/issues/283)) ([f0b33c0](https://github.com/cdk8s-team/cdk8s-cli/commit/f0b33c09e3f75cfc7e230605a9bb11d506ea4018))
+* **cli:** importing local files is broken on windows ([#427](https://github.com/cdk8s-team/cdk8s-cli/issues/427)) ([2c4a185](https://github.com/cdk8s-team/cdk8s-cli/commit/2c4a1858b5c88cf4e5eb6ac5e8f0bcb1495adbf4))
+* **cli:** impossible to import two crds with same kind ([#203](https://github.com/cdk8s-team/cdk8s-cli/issues/203)) ([f6248ce](https://github.com/cdk8s-team/cdk8s-cli/commit/f6248ce5b7f3004108f0449a319015c8d6e99df4))
+* **cli:** init could not find a version that matches cdk8s0-13-0 ([e1267f6](https://github.com/cdk8s-team/cdk8s-cli/commit/e1267f608d8981578971564b1228be80e0e117e0))
+* **cli:** new typescript apps cannot be created with [@next](https://github.com/next) versions ([#55](https://github.com/cdk8s-team/cdk8s-cli/issues/55)) ([119d95c](https://github.com/cdk8s-team/cdk8s-cli/commit/119d95c78c3620be9adcd1cb5402e6f0ee901293))
+* **cli:** options type not generated for certain CRDs ([#229](https://github.com/cdk8s-team/cdk8s-cli/issues/229)) ([0cbaf19](https://github.com/cdk8s-team/cdk8s-cli/commit/0cbaf19c0d9f1cff6832c44c0699e20c83903a64)), closes [#219](https://github.com/cdk8s-team/cdk8s-cli/issues/219)
+* **cli:** python init template doesn't install cdk8s-plus in the correct env ([#399](https://github.com/cdk8s-team/cdk8s-cli/issues/399)) ([0d3017b](https://github.com/cdk8s-team/cdk8s-cli/commit/0d3017b4285bb015d129cdf24c9e2da2d00f9025))
+* **cli:** python init templates are broken ([#393](https://github.com/cdk8s-team/cdk8s-cli/issues/393)) ([d786001](https://github.com/cdk8s-team/cdk8s-cli/commit/d786001edd0b91653d14aa687865f3e1eb68a88f))
+* **cli:** typescript-app does not include main.ts ([43b435a](https://github.com/cdk8s-team/cdk8s-cli/commit/43b435a535f6d99f0ac0a3e570ebe95386c584ae))
+* **cli:** unable to import a crd that has no schema ([#132](https://github.com/cdk8s-team/cdk8s-cli/issues/132)) ([b8115cb](https://github.com/cdk8s-team/cdk8s-cli/commit/b8115cb809b2b33be73a98f99b1cefa4de152654))
+* **cli:** unable to import CRDs with non-trivial "xxxOf" constraints ([#212](https://github.com/cdk8s-team/cdk8s-cli/issues/212)) ([18136ed](https://github.com/cdk8s-team/cdk8s-cli/commit/18136ed26d833a27036b7cbf04fac4b8f7d9b542)), closes [#171](https://github.com/cdk8s-team/cdk8s-cli/issues/171)
+* **cli:** unable to import types with all-caps TLAs ([#211](https://github.com/cdk8s-team/cdk8s-cli/issues/211)) ([a11d0e8](https://github.com/cdk8s-team/cdk8s-cli/commit/a11d0e8f8f8e5bbc745d9315086b97cbc49d2890)), closes [#209](https://github.com/cdk8s-team/cdk8s-cli/issues/209)
+* **crd:** Ensure yaml doc is defined before casting to CustomResourceApiObject ([#130](https://github.com/cdk8s-team/cdk8s-cli/issues/130)) ([03e6d84](https://github.com/cdk8s-team/cdk8s-cli/commit/03e6d84ee5182d7e547d9b09d2d121daedb7f7c3))
+* **crd:** fix multi-resource importing of CRDs ([#78](https://github.com/cdk8s-team/cdk8s-cli/issues/78)) ([fd8f753](https://github.com/cdk8s-team/cdk8s-cli/commit/fd8f75359b37a6f76368d498f00d8dc615650423))
+* **crd:** import a CRD from an insecure server ([#102](https://github.com/cdk8s-team/cdk8s-cli/issues/102)) ([4dde096](https://github.com/cdk8s-team/cdk8s-cli/commit/4dde096419aadc1173835388d52f927e502f469a)), closes [#94](https://github.com/cdk8s-team/cdk8s-cli/issues/94)
+* **docs:** align getting started with new code ([#410](https://github.com/cdk8s-team/cdk8s-cli/issues/410)) ([c61e109](https://github.com/cdk8s-team/cdk8s-cli/commit/c61e109e5cdddeb6c5c3b4ff86d2f7f79e11b9ff))
+* **docs:** correct logo paths ([#503](https://github.com/cdk8s-team/cdk8s-cli/issues/503)) ([9426047](https://github.com/cdk8s-team/cdk8s-cli/commit/94260473ef7c7e29799b4368981c8415dbd0fd8f))
+* **docs:** do not mark arguments as optional in python getting-started ([#191](https://github.com/cdk8s-team/cdk8s-cli/issues/191)) ([be090d0](https://github.com/cdk8s-team/cdk8s-cli/commit/be090d09b6bdc2105e21c2f6de0cdcc9da657b50))
+* **docs:** top-level "getting started" page not found ([#120](https://github.com/cdk8s-team/cdk8s-cli/issues/120)) ([eb9d2ad](https://github.com/cdk8s-team/cdk8s-cli/commit/eb9d2ad0e09f7bc8ba1ee2346aad2f3119d1f3e9)), closes [#106](https://github.com/cdk8s-team/cdk8s-cli/issues/106)
+* **docs:** typo of helm doc ([#566](https://github.com/cdk8s-team/cdk8s-cli/issues/566)) ([7d5c97e](https://github.com/cdk8s-team/cdk8s-cli/commit/7d5c97e6f152f332cbb02f554d27ed542d319699))
+* **docs:** WebService typescript example formatting ([#408](https://github.com/cdk8s-team/cdk8s-cli/issues/408)) ([e2470f9](https://github.com/cdk8s-team/cdk8s-cli/commit/e2470f96e737af784f11168474ca24e52619c238))
+* **examples:** "replicas" option is not respected in the web-service example ([#87](https://github.com/cdk8s-team/cdk8s-cli/issues/87)) ([97ca582](https://github.com/cdk8s-team/cdk8s-cli/commit/97ca582b8a2fb0f1925518b0040acec9f32dd969))
+* **examples:** Add missing dependencies on python examples. ([#290](https://github.com/cdk8s-team/cdk8s-cli/issues/290)) ([36e6fab](https://github.com/cdk8s-team/cdk8s-cli/commit/36e6fab9c4c0f30f6f49c93c1f284d8054955fcd)), closes [#289](https://github.com/cdk8s-team/cdk8s-cli/issues/289)
+* Fix yaml quote serialization 325 ([#327](https://github.com/cdk8s-team/cdk8s-cli/issues/327)) ([6b1f662](https://github.com/cdk8s-team/cdk8s-cli/commit/6b1f66278446efd01cb3d0b61a5fca712725fefa)), closes [#325](https://github.com/cdk8s-team/cdk8s-cli/issues/325)
+* **gha:** Fix conditional homebrew release script ([5ecb143](https://github.com/cdk8s-team/cdk8s-cli/commit/5ecb1434a8e4b2622cf3e001929a72c511ab89fa))
+* **gha:** prevent gha from running on forks ([26eb407](https://github.com/cdk8s-team/cdk8s-cli/commit/26eb4076f1a786894f4d0efa7fa5883b6a444603))
+* **go:** invalid go module name ([87af61b](https://github.com/cdk8s-team/cdk8s-cli/commit/87af61ba4e4942b4e1d01d3ee4f05bcea8d57e3a))
+* **imports:** Specify moduleName overrides for imports ([#84](https://github.com/cdk8s-team/cdk8s-cli/issues/84)) ([63daf78](https://github.com/cdk8s-team/cdk8s-cli/commit/63daf781d80690476b875785f7bb7beea2d5e029))
+* input type names are "XxxOptions" instead of "XxxProps" ([#381](https://github.com/cdk8s-team/cdk8s-cli/issues/381)) ([b2bd34e](https://github.com/cdk8s-team/cdk8s-cli/commit/b2bd34e43dc487673b7dce3061195465a5806f38)), closes [#371](https://github.com/cdk8s-team/cdk8s-cli/issues/371)
+* java importing crd fails ([#257](https://github.com/cdk8s-team/cdk8s-cli/issues/257)) ([f0ef3b4](https://github.com/cdk8s-team/cdk8s-cli/commit/f0ef3b467969a90efcbfc663353565c8639bb5bd))
+* Lazy is not resolved in metadata ([#443](https://github.com/cdk8s-team/cdk8s-cli/issues/443)) ([914d4a8](https://github.com/cdk8s-team/cdk8s-cli/commit/914d4a89ace15a6081267cbf5d359459f8514ee9))
+* **lib:** `uniqueId` is not compatible with the k8s labels ([#326](https://github.com/cdk8s-team/cdk8s-cli/issues/326)) ([161f368](https://github.com/cdk8s-team/cdk8s-cli/commit/161f3682e9229cace25d3c283c98028f1e1ca0a6)), closes [#323](https://github.com/cdk8s-team/cdk8s-cli/issues/323)
+* **lib:** corrupted manifests when including large files ([#350](https://github.com/cdk8s-team/cdk8s-cli/issues/350)) ([649f41b](https://github.com/cdk8s-team/cdk8s-cli/commit/649f41ba65a9bb7f8c7d0c4a260ae9ddd773afb8))
+* **lib:** deprecated toISOString() conflicts with toIsoString() ([#524](https://github.com/cdk8s-team/cdk8s-cli/issues/524)) ([d4e0c3d](https://github.com/cdk8s-team/cdk8s-cli/commit/d4e0c3d75c65ec91908327fbb7ce24d7d6981b9e))
+* **lib:** duplicate hyphens in generated resource names ([#341](https://github.com/cdk8s-team/cdk8s-cli/issues/341)) ([6f6366a](https://github.com/cdk8s-team/cdk8s-cli/commit/6f6366a55c31f6ec9af09f33effcfa52a1b23fe8))
+* **lib:** ENOBUFS for large helm charts ([#529](https://github.com/cdk8s-team/cdk8s-cli/issues/529)) ([4164f38](https://github.com/cdk8s-team/cdk8s-cli/commit/4164f38706b5a2bb65aff0224df6e133e217f070)), closes [#454](https://github.com/cdk8s-team/cdk8s-cli/issues/454)
+* **lib:** fail to import octal numbers via include (and helm) ([#349](https://github.com/cdk8s-team/cdk8s-cli/issues/349)) ([bed9eed](https://github.com/cdk8s-team/cdk8s-cli/commit/bed9eedd31e07bd00461d6e54c798bf43fc65ede)), closes [#348](https://github.com/cdk8s-team/cdk8s-cli/issues/348)
+* **lib:** names generated using non-FIPS compliant algorithm ([#392](https://github.com/cdk8s-team/cdk8s-cli/issues/392)) ([a1acae7](https://github.com/cdk8s-team/cdk8s-cli/commit/a1acae7a1b935fc06a15c820bf28619d1e4c0f37)), closes [#334](https://github.com/cdk8s-team/cdk8s-cli/issues/334)
+* **lib:** unable to express empty objects and array ([#200](https://github.com/cdk8s-team/cdk8s-cli/issues/200)) ([9ae5efb](https://github.com/cdk8s-team/cdk8s-cli/commit/9ae5efb9834e1608ae196db88680a34005ac7203))
+* move output of java imports into /src/main/java ([#240](https://github.com/cdk8s-team/cdk8s-cli/issues/240)) ([9445358](https://github.com/cdk8s-team/cdk8s-cli/commit/94453588a504fe35dd4da7b7c6d9b92a1d93c4f3))
+* multiline string with line greater than 80 characters lose newlines ([#589](https://github.com/cdk8s-team/cdk8s-cli/issues/589)) ([e95b8a1](https://github.com/cdk8s-team/cdk8s-cli/commit/e95b8a1783ce020e7913cbf58ad8efd39db1a6c4)), closes [#588](https://github.com/cdk8s-team/cdk8s-cli/issues/588)
+* not folding strings ([#495](https://github.com/cdk8s-team/cdk8s-cli/issues/495)) ([8dda8bd](https://github.com/cdk8s-team/cdk8s-cli/commit/8dda8bdac90f9254fa95a736a1b29c87609934df)), closes [#494](https://github.com/cdk8s-team/cdk8s-cli/issues/494)
+* **plus-17:** adds externalName to service props ([#424](https://github.com/cdk8s-team/cdk8s-cli/issues/424)) ([b4b7c55](https://github.com/cdk8s-team/cdk8s-cli/commit/b4b7c55134ffc14203a58eb72227251225c79cc3))
+* **plus-17:** don't allow containers to be contructed from containers ([#404](https://github.com/cdk8s-team/cdk8s-cli/issues/404)) ([5d11533](https://github.com/cdk8s-team/cdk8s-cli/commit/5d11533f9aea672793459b9f2c6caaddb6430e3e))
+* **plus-17:** L2 default child ([#389](https://github.com/cdk8s-team/cdk8s-cli/issues/389)) ([a8337e8](https://github.com/cdk8s-team/cdk8s-cli/commit/a8337e805dce81e0d0883bb296c1017b5ac2311f))
+* **plus-17:** multiple mounts per volume result in duplicate volumes for pod spec ([#489](https://github.com/cdk8s-team/cdk8s-cli/issues/489)) ([47c913e](https://github.com/cdk8s-team/cdk8s-cli/commit/47c913e1abc026611332fcf03b209adda7aba419))
+* **plus:** support node ports for cdk8s-plus service ([#315](https://github.com/cdk8s-team/cdk8s-cli/issues/315)) ([85ec225](https://github.com/cdk8s-team/cdk8s-cli/commit/85ec225bcdbab3631ffebbf6c93c3ac70937b4b9)), closes [#296](https://github.com/cdk8s-team/cdk8s-cli/issues/296)
+* **readme:** hello example link is broken [#74](https://github.com/cdk8s-team/cdk8s-cli/issues/74) ([0b858cf](https://github.com/cdk8s-team/cdk8s-cli/commit/0b858cfd8d1306be67394cb733984b8b49dfcc06))
+* **readme:** missing information about imports in cdk8s-cli readme ([#108](https://github.com/cdk8s-team/cdk8s-cli/issues/108)) ([e9f291e](https://github.com/cdk8s-team/cdk8s-cli/commit/e9f291e8da8beebc1bb26b20078ed0d3675ce580))
+* **redirect:** Handle 302 redirect case when importing from remote url ([#131](https://github.com/cdk8s-team/cdk8s-cli/issues/131)) ([1ed88ca](https://github.com/cdk8s-team/cdk8s-cli/commit/1ed88ca32c998b590093fd0090ecbf9a6662043e))
+* set yaml default schema to 1.1 ([#505](https://github.com/cdk8s-team/cdk8s-cli/issues/505)) ([266c094](https://github.com/cdk8s-team/cdk8s-cli/commit/266c094b19231e3beea836a6d77842954077d4f1))
+* union types could not be synthesized ([5a47262](https://github.com/cdk8s-team/cdk8s-cli/commit/5a47262e4f55ac9b1f13bcbfbc9cdf1efd3a1b7b))
+* **website:** doc links are broken due to wrong version number ([#312](https://github.com/cdk8s-team/cdk8s-cli/issues/312)) ([f2f9402](https://github.com/cdk8s-team/cdk8s-cli/commit/f2f9402d975aa9a2b8bab6db68fc8bccb74a6772)), closes [#307](https://github.com/cdk8s-team/cdk8s-cli/issues/307)
+* which command missing for windows ([#417](https://github.com/cdk8s-team/cdk8s-cli/issues/417)) ([38a7034](https://github.com/cdk8s-team/cdk8s-cli/commit/38a703411c7162bfa4d1904ef6b94e2a017ea4da))
+
+
+### Miscellaneous Chores
+
+* upgrade jsii & constructs ([#80](https://github.com/cdk8s-team/cdk8s-cli/issues/80)) ([f917e0a](https://github.com/cdk8s-team/cdk8s-cli/commit/f917e0a29490eb0369d4583a7303f1fded7f6693))
+
+
+### Code Refactoring
+
+* **plus:** Remove the `spec` nesting level on both input and output ([#347](https://github.com/cdk8s-team/cdk8s-cli/issues/347)) ([5e34850](https://github.com/cdk8s-team/cdk8s-cli/commit/5e34850f4b3cc9c80fda4f0df245afcaa29b1daf))
+


### PR DESCRIPTION
This repository was created utilizing Projen and I believe there is not way of auto generating a Changelog utilizing projen. 

Using the same [library's](https://github.com/conventional-changelog/conventional-changelog) CLI as AWS CDK for generating changelog for this repository.

## DCO
Signed-off-by: Vinayak Kukreja <vinakuk@amazon.com>