### PR TITLE
fix: packages installed in the wrong folder

### DIFF
--- a/src/plugins/_manager.ts
+++ b/src/plugins/_manager.ts
@@ -116,7 +116,7 @@ export class PluginManager {
 
   private installPackage(pkg: string, version: string, env: { [key: string]: any }) {
 
-    const pluginDir = this.pluginDir(pkg, version);
+    const pluginDir = path.join(this.dir, pkg, version);
     fs.mkdirpSync(pluginDir);
 
     const command = [


### PR DESCRIPTION
npm creates the `node_modules` folder on any package install, if you use the same folder structure to create and get a package it's resulting in a `Package Not Found` error