### PR TITLE
fix: unable to require `package.json`

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -91,6 +91,7 @@ const project = new typescript.TypeScriptProject({
 project.addFields({
   exports: {
     './plugins': './lib/plugins/index.js',
+    './package.json': './package.json',
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -139,7 +139,8 @@
     }
   },
   "exports": {
-    "./plugins": "./lib/plugins/index.js"
+    "./plugins": "./lib/plugins/index.js",
+    "./package.json": "./package.json"
   },
   "resolutions": {
     "@types/responselike": "1.0.0",


### PR DESCRIPTION
## Summary

This PR adds the "package.json" file as a resolvable file. This is so that the `cdk8s/website/build.sh` is able to read the package.json's `version` for use when building the website.