### PR TITLE
chore: validation test failing on node 18

### DIFF
--- a/templates/typescript-app/.hooks.sscaff.js
+++ b/templates/typescript-app/.hooks.sscaff.js
@@ -18,7 +18,7 @@ exports.post = ctx => {
       '@types/jest@26',
       'jest@26',
       'ts-jest@26',
-      'typescript'
+      'typescript@4'
   ], true);
 
   const env = { ...process.env };

--- a/templates/typescript-app/.hooks.sscaff.js
+++ b/templates/typescript-app/.hooks.sscaff.js
@@ -18,7 +18,7 @@ exports.post = ctx => {
       '@types/jest@26',
       'jest@26',
       'ts-jest@26',
-      'typescript@4'
+      'typescript@4.9.5'
   ], true);
 
   const env = { ...process.env };

--- a/test/synth/synth-stdout.test.ts
+++ b/test/synth/synth-stdout.test.ts
@@ -256,7 +256,7 @@ describe('validations', () => {
       },
     }];
 
-    await expect(() => synth({ validations })).rejects.toThrow(/Must be a full url with/);
+    await expect(() => synth({ validations })).rejects.toThrow(/ERR_INVALID_URL/);
 
   });
 

--- a/test/synth/synth-stdout.test.ts
+++ b/test/synth/synth-stdout.test.ts
@@ -256,7 +256,10 @@ describe('validations', () => {
       },
     }];
 
-    await expect(() => synth({ validations })).rejects.toThrow(/ERR_INVALID_URL/);
+    // to cover both node18 and below, which have different error messages
+    // in this case.
+    const re = new RegExp('Must be a full url|ERR_INVALID_URL');
+    await expect(() => synth({ validations })).rejects.toThrow(re);
 
   });
 


### PR DESCRIPTION
The test currently fails when running on node 18:

```console
● validations › can pass environment to installation command

    expect(received).rejects.toThrow(expected)

    Expected pattern: /Must be a full url with/
    Received message: "Command failed: npm install some-plugin@0.0.0 --no-save --prefix /var/folders/mb/5zx1h88x2891nhk4qpr6_zc8jcqzm6/T/cdk8s-yrdEsA/.cdk8s/plugins/some-plugin/0.0.0
    npm ERR! code ERR_INVALID_URL
    npm ERR! Invalid URL·
    npm ERR! A complete log of this run can be found in:
    npm ERR!     /Users/epolon/.npm/_logs/2023-03-20T06_39_07_174Z-debug-0.log
    "
```

Amazingly, its because node 18 changed the string of the error message we are asserting against.
I changed the code to assert against the error code string, which should be more stable. 