### PR TITLE
chore(synth): fix test failing on node 16

### DIFF
--- a/test/synth/synth-stdout.test.ts
+++ b/test/synth/synth-stdout.test.ts
@@ -297,9 +297,11 @@ describe('validations', () => {
       },
     }];
 
-    // to cover both node18 and below, which have different error messages
-    // in this case.
-    const re = new RegExp('Must be a full url|ERR_INVALID_URL');
+    const messageNode14 = 'invalid config registry';
+    const messageNode16 = messageNode14;
+    const messageNode18 = 'ERR_INVALID_URL';
+
+    const re = new RegExp(`${messageNode14}|${messageNode18}|${messageNode16}`);
     await expect(() => synth({ validations })).rejects.toThrow(re);
 
   });


### PR DESCRIPTION
Apparently, Node 16 has yet another error message in this case.

Here are the observed error messages on each node version:

```console
    Node 18

    Received message: "Command failed: npm install some-plugin@0.0.0 --no-save --prefix /var/folders/mb/5zx1h88x2891nhk4qpr6_zc8jcqzm6/T/cdk8s-qLzQ3N/.cdk8s/plugins/some-plugin/0.0.0
    npm ERR! code ERR_INVALID_URL
    npm ERR! Invalid URL·
    npm ERR! A complete log of this run can be found in:

    Node 16

    Received message: "Command failed: npm install some-plugin@0.0.0 --no-save --prefix /var/folders/mb/5zx1h88x2891nhk4qpr6_zc8jcqzm6/T/cdk8s-C3PkC6/.cdk8s/plugins/some-plugin/0.0.0
    npm WARN invalid config registry=\"npm_config_registry\" set in environment
    npm WARN invalid config Must be full url with \"http://\"
    npm ERR! code ETARGET
    npm ERR! notarget No matching version found for some-plugin@0.0.0.
    npm ERR! notarget In most cases you or one of your dependencies are requesting
    npm ERR! notarget a package version that doesn't exist.·
    npm ERR! A complete log of this run can be found in:

    Node 14

    Received message: "Command failed: npm install some-plugin@0.0.0 --no-save --prefix /var/folders/mb/5zx1h88x2891nhk4qpr6_zc8jcqzm6/T/cdk8s-cXTAFO/.cdk8s/plugins/some-plugin/0.0.0
    npm WARN invalid config registry=\"npm_config_registry\"
    npm WARN invalid config Must be a full url with 'http://'
    npm ERR! code ETARGET
    npm ERR! notarget No matching version found for some-plugin@0.0.0.
    npm ERR! notarget In most cases you or one of your dependencies are requesting
    npm ERR! notarget a package version that doesn't exist.·
    npm ERR! A complete log of this run can be found in:    
```

Notice how it changed `Must be a full url -> Must be full url -> code ERR_INVALID_URL`