### PR TITLE
fix(init-typescript): `cdk8s synth` fails if `ts-node` is not globally installed

### DIFF
--- a/templates/typescript-app/cdk8s.yaml
+++ b/templates/typescript-app/cdk8s.yaml
@@ -1,4 +1,4 @@
 language: typescript
-app: ts-node main.ts
+app: npx ts-node main.ts
 imports:
   - k8s


### PR DESCRIPTION
Fixes cdk8s-team/cdk8s#1273