### PR TITLE
fix(init-typescript): `cdk8s synth` fails if `ts-node` is not globally installed (#896)

### DIFF
--- a/templates/typescript-app/cdk8s.yaml
+++ b/templates/typescript-app/cdk8s.yaml
@@ -1,4 +1,4 @@
 language: typescript
-app: ts-node main.ts
+app: npx ts-node main.ts
 imports:
   - k8s


### PR DESCRIPTION
# Backport

This will backport the following commits from `2.x` to `1.x`:
 - [fix(init-typescript): `cdk8s synth` fails if `ts-node` is not globally installed (#896)](https://github.com/cdk8s-team/cdk8s-cli/pull/896)

<!--- Backport version: 8.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)