### PR TITLE
chore: upgrade node and workflows dependencies (#960)

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -10,21 +10,21 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Install pipenv
         run: pip install pipenv
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: "1.18"
       - name: Run integration tests
@@ -34,9 +34,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.nodeVersion }}
       - name: Install dependencies
@@ -47,5 +47,4 @@ jobs:
       fail-fast: false
       matrix:
         nodeVersion:
-          - 16
           - 18

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,6 @@ queue_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=init
-      - status-success=init-typescript-app (16)
       - status-success=init-typescript-app (18)
 pull_request_rules:
   - name: Automatic merge on approval and successful build
@@ -26,5 +25,4 @@ pull_request_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=init
-      - status-success=init-typescript-app (16)
       - status-success=init-typescript-app (18)

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -97,7 +97,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^14",
+      "version": "^16",
       "type": "runtime"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -84,7 +84,7 @@ project.gitignore.exclude('.vscode/');
 // add @types/node as a regular dependency since it's needed to during "import"
 // to compile the generated jsii code.
 project.deps.removeDependency('@types/node', DependencyType.BUILD);
-project.deps.addDependency('@types/node@^14', DependencyType.RUNTIME);
+project.deps.addDependency('@types/node@^16', DependencyType.RUNTIME);
 
 const schemas = project.addTask('schemas');
 schemas.exec('ts-node scripts/crd.schema.ts');

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript-json-schema": "^0.56.0"
   },
   "dependencies": {
-    "@types/node": "^14",
+    "@types/node": "^16",
     "ajv": "^8.12.0",
     "cdk8s": "^1.10.54",
     "codemaker": "^1.80.0",

--- a/projenrc/integ.ts
+++ b/projenrc/integ.ts
@@ -22,15 +22,15 @@ export function addIntegTests(project: typescript.TypeScriptProject) {
     }
   }
 
-  // run all init tests on node 14
+  // run all init tests on node 16
   integWorkflow.addJob('init', {
     runsOn: ['ubuntu-latest'],
     permissions: { contents: github.workflows.JobPermission.READ },
-    steps: runSteps(initTask.name, '14', true, true),
+    steps: runSteps(initTask.name, '16', true, true),
   });
 
-  // run typescript app on node 16 and 18 as well
-  const nodeVersions = [16, 18];
+  // run typescript app on node 18 as well
+  const nodeVersions = [18];
   integWorkflow.addJob('init-typescript-app', {
     runsOn: ['ubuntu-latest'],
     strategy: {
@@ -58,10 +58,10 @@ function jest(args: string) {
 
 function runSteps(task: string, nodeVersion: string, python: boolean, go: boolean): github.workflows.JobStep[] {
   const steps: github.workflows.JobStep[] = [
-    { uses: 'actions/checkout@v2' },
+    { uses: 'actions/checkout@v3' },
     {
       name: 'Set up Node.js',
-      uses: 'actions/setup-node@v2',
+      uses: 'actions/setup-node@v3',
       with: { 'node-version': nodeVersion },
     },
     {
@@ -73,7 +73,7 @@ function runSteps(task: string, nodeVersion: string, python: boolean, go: boolea
   if (python) {
     steps.push({
       name: 'Set up Python 3.x',
-      uses: 'actions/setup-python@v2',
+      uses: 'actions/setup-python@v4',
       with: {
         'python-version': '3.x',
       },
@@ -87,7 +87,7 @@ function runSteps(task: string, nodeVersion: string, python: boolean, go: boolea
   if (go) {
     steps.push({
       name: 'Set up Go',
-      uses: 'actions/setup-go@v2',
+      uses: 'actions/setup-go@v4',
       with: {
         'go-version': '1.18',
       },

--- a/src/util.ts
+++ b/src/util.ts
@@ -13,7 +13,7 @@ import { ValidationPlugin, ValidationContext, ValidationReport, Validation } fro
 import { SafeReviver } from './reviver';
 
 export async function shell(program: string, args: string[] = [], options: SpawnOptions = { }): Promise<string> {
-  const command = `"${program} ${args.join(' ')}" at ${path.resolve(options.cwd ?? '.')}`;
+  const command = `"${program} ${args.join(' ')}" at ${path.resolve(options.cwd?.toString() ?? '.')}`;
   return new Promise((ok, ko) => {
     const child = spawn(program, args, { stdio: ['inherit', 'pipe', 'inherit'], ...options });
     const data = new Array<Buffer>();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,10 +1079,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.1.1.tgz#afc492e8dbe7f672dd3a13674823522b467a45ad"
   integrity sha512-uKBEevTNb+l6/aCQaKVnUModfEMjAl98lw2Si9P5y4hLu9tm6AlX2ZIoXZX6Wh9lJueYPrGPKk5WMCNHg/u6/A==
 
-"@types/node@^14":
-  version "14.18.46"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.46.tgz#ffc5a96cbe4fb5af9d16ac08e50229de30969487"
-  integrity sha512-n4yVT5FuY5NCcGHCosQSGvvCT74HhowymPN2OEcsHPw6U1NuxV9dvxWbrM2dnBukWjdMYzig1WfIkWdTTQJqng==
+"@types/node@^16":
+  version "16.18.30"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.30.tgz#4a2c426370712a10c630a55ba086c55c17ca54e0"
+  integrity sha512-Kmp/wBZk19Dn7uRiol8kF8agnf8m0+TU9qIwyfPmXglVxMlmiIz0VQSMw5oFgwhmD2aKTlfBIO5FtsVj3y7hKQ==
 
 "@types/node@^16.9.2":
   version "16.18.27"


### PR DESCRIPTION
# Backport

This will backport the following commits from `2.x` to `1.x`:
 - [chore: upgrade node and workflows dependencies (#960)](https://github.com/cdk8s-team/cdk8s-cli/pull/960)

<!--- Backport version: 8.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)