### PR TITLE
chore: run os matrix tests (#1026)

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: {}
 jobs:
   init:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     steps:
@@ -29,6 +29,13 @@ jobs:
           go-version: "1.18"
       - name: Run integration tests
         run: yarn run integ:init
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - macos-latest
+          - ubuntu-latest
   init-typescript-app:
     runs-on: ubuntu-latest
     permissions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,8 +7,10 @@ queue_rules:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)
       - status-success=build
-      - status-success=init
       - status-success=init-typescript-app (18)
+      - status-success=init (windows-latest)
+      - status-success=init (macos-latest)
+      - status-success=init (ubuntu-latest)
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
@@ -24,5 +26,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)
       - status-success=build
-      - status-success=init
       - status-success=init-typescript-app (18)
+      - status-success=init (windows-latest)
+      - status-success=init (macos-latest)
+      - status-success=init (ubuntu-latest)

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -168,7 +168,7 @@
           "exec": "yarn run package"
         },
         {
-          "exec": "jest --testPathIgnorePatterns \"^((?!integ).)*$\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts"
+          "exec": "jest --testMatch \"<rootDir>/test/integ/**/*.test.ts\" --testPathIgnorePatterns \"/node_modules/\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts"
         }
       ]
     },
@@ -182,7 +182,7 @@
           "exec": "yarn run package"
         },
         {
-          "exec": "jest --testPathIgnorePatterns \"^((?!integ).)*$\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts -t go-app-npm"
+          "exec": "jest --testMatch \"<rootDir>/test/integ/**/*.test.ts\" --testPathIgnorePatterns \"/node_modules/\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts -t go-app-npm"
         }
       ]
     },
@@ -196,7 +196,7 @@
           "exec": "yarn run package"
         },
         {
-          "exec": "jest --testPathIgnorePatterns \"^((?!integ).)*$\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts -t go-app-yarn"
+          "exec": "jest --testMatch \"<rootDir>/test/integ/**/*.test.ts\" --testPathIgnorePatterns \"/node_modules/\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts -t go-app-yarn"
         }
       ]
     },
@@ -210,7 +210,7 @@
           "exec": "yarn run package"
         },
         {
-          "exec": "jest --testPathIgnorePatterns \"^((?!integ).)*$\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts -t java-app-npm"
+          "exec": "jest --testMatch \"<rootDir>/test/integ/**/*.test.ts\" --testPathIgnorePatterns \"/node_modules/\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts -t java-app-npm"
         }
       ]
     },
@@ -224,7 +224,7 @@
           "exec": "yarn run package"
         },
         {
-          "exec": "jest --testPathIgnorePatterns \"^((?!integ).)*$\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts -t java-app-yarn"
+          "exec": "jest --testMatch \"<rootDir>/test/integ/**/*.test.ts\" --testPathIgnorePatterns \"/node_modules/\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts -t java-app-yarn"
         }
       ]
     },
@@ -238,7 +238,7 @@
           "exec": "yarn run package"
         },
         {
-          "exec": "jest --testPathIgnorePatterns \"^((?!integ).)*$\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts -t python-app-npm"
+          "exec": "jest --testMatch \"<rootDir>/test/integ/**/*.test.ts\" --testPathIgnorePatterns \"/node_modules/\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts -t python-app-npm"
         }
       ]
     },
@@ -252,7 +252,7 @@
           "exec": "yarn run package"
         },
         {
-          "exec": "jest --testPathIgnorePatterns \"^((?!integ).)*$\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts -t python-app-yarn"
+          "exec": "jest --testMatch \"<rootDir>/test/integ/**/*.test.ts\" --testPathIgnorePatterns \"/node_modules/\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts -t python-app-yarn"
         }
       ]
     },
@@ -266,7 +266,7 @@
           "exec": "yarn run package"
         },
         {
-          "exec": "jest --testPathIgnorePatterns \"^((?!integ).)*$\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts -t typescript-app-npm"
+          "exec": "jest --testMatch \"<rootDir>/test/integ/**/*.test.ts\" --testPathIgnorePatterns \"/node_modules/\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts -t typescript-app-npm"
         }
       ]
     },
@@ -280,7 +280,7 @@
           "exec": "yarn run package"
         },
         {
-          "exec": "jest --testPathIgnorePatterns \"^((?!integ).)*$\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts -t typescript-app-yarn"
+          "exec": "jest --testMatch \"<rootDir>/test/integ/**/*.test.ts\" --testPathIgnorePatterns \"/node_modules/\" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 integ/init.test.ts -t typescript-app-yarn"
         }
       ]
     },
@@ -292,7 +292,7 @@
           "exec": "mkdir -p dist/js"
         },
         {
-          "exec": "mv $(npm pack) dist/js/"
+          "exec": "npm pack --pack-destination dist/js"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -91,6 +91,13 @@ schemas.exec('ts-node scripts/crd.schema.ts');
 
 project.compileTask.spawn(schemas);
 
+// so that it works on windows as well
+// default projen uses $(npm pack) which fails
+project.packageTask.reset();
+project.packageTask.exec('mkdir -p dist/js');
+project.packageTask.exec('npm pack --pack-destination dist/js');
+
+
 addIntegTests(project);
 
 project.synth();

--- a/projenrc/integ.ts
+++ b/projenrc/integ.ts
@@ -4,6 +4,8 @@ import { typescript, github } from 'projen';
 
 export function addIntegTests(project: typescript.TypeScriptProject) {
 
+  const oses = ['windows-latest', 'macos-latest', 'ubuntu-latest'];
+
   const integWorkflow = project.github!.addWorkflow('integ');
   integWorkflow.on({ pullRequest: {}, workflowDispatch: {} });
 
@@ -29,7 +31,15 @@ export function addIntegTests(project: typescript.TypeScriptProject) {
 
   // run all init tests on node 16
   integWorkflow.addJob('init', {
-    runsOn: ['ubuntu-latest'],
+    runsOn: ['${{ matrix.os }}'],
+    strategy: {
+      failFast: false,
+      matrix: {
+        domain: {
+          os: oses,
+        },
+      },
+    },
     permissions: { contents: github.workflows.JobPermission.READ },
     steps: runSteps([initTask.name], '16', true, true),
   });
@@ -48,17 +58,20 @@ export function addIntegTests(project: typescript.TypeScriptProject) {
     steps: runSteps(['integ:init:typescript-app-npm', 'integ:init:typescript-app-yarn'], '${{ matrix.nodeVersion }}', false, false),
   });
 
-  project.autoMerge!.addConditions('status-success=init');
-
   for (const nodeVersion of nodeVersions) {
     project.autoMerge!.addConditions(`status-success=init-typescript-app (${nodeVersion})`);
+  }
+
+  for (const os of oses) {
+    project.autoMerge!.addConditions(`status-success=init (${os})`);
   }
 
 }
 
 function jest(args: string) {
-  // we override 'testPathIgnorePatterns' so that it matches only integration tests
-  return `jest --testPathIgnorePatterns "^((?!integ).)*$" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 ${args}`;
+  // we override 'testPathIgnorePatterns' and 'testMatch' so that it matches only integration tests
+  // see https://github.com/jestjs/jest/issues/7914
+  return `jest --testMatch "<rootDir>/test/integ/**/*.test.ts" --testPathIgnorePatterns "/node_modules/" --passWithNoTests --all --updateSnapshot --coverageProvider=v8 ${args}`;
 };
 
 function runSteps(tasks: string[], nodeVersion: string, python: boolean, go: boolean): github.workflows.JobStep[] {


### PR DESCRIPTION
# Backport

This will backport the following commits from `2.x` to `1.x`:
 - [chore: run os matrix tests (#1026)](https://github.com/cdk8s-team/cdk8s-cli/pull/1026)

<!--- Backport version: 8.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)