### PR TITLE
fix(init): typescript project initialization may fail on windows (#1165)

### DIFF
--- a/src/cli/cmds/init.ts
+++ b/src/cli/cmds/init.ts
@@ -45,22 +45,21 @@ async function determineDeps(): Promise<Deps> {
   const cdk8sCli = new ModuleVersion('cdk8s-cli');
   const jsii = new ModuleVersion('jsii-pacmak');
 
+  const cdk8sTarball = process.env.CDK8S_TARBALL;
+  const cdk8sTarballEscaped = cdk8sTarball ? (cdk8sTarball.replace(/\\/g, '\\\\')) : undefined;
+
   return {
-    npm_cdk8s: cdk8s.npmDependency,
     pypi_cdk8s: cdk8s.pypiDependency,
     mvn_cdk8s: cdk8s.mavenDependency,
     cdk8s_core_version: cdk8s.version,
     constructs_version: constructsVersion,
     jsii_version: jsii.version,
-
-    // when running tests, install the tarball created from our source
-    npm_cdk8s_cli: process.env.CDK8S_TARBALL ?? cdk8sCli.npmDependency,
+    cdk8s_cli_spec: cdk8sTarballEscaped ?? `^${cdk8sCli.version}`,
   };
 }
 
 interface Deps {
-  npm_cdk8s: string;
-  npm_cdk8s_cli?: string;
+  cdk8s_cli_spec: string;
   pypi_cdk8s: string;
   mvn_cdk8s: string;
   cdk8s_core_version: string;

--- a/templates/typescript-app/.hooks.sscaff.js
+++ b/templates/typescript-app/.hooks.sscaff.js
@@ -1,34 +1,11 @@
 const { execSync } = require('child_process');
 const { readFileSync } = require('fs');
-const { dirname } = require('path');
-
-const clibin = dirname(require.resolve('../../bin/cdk8s'));
 
 exports.post = ctx => {
-  const npm_cdk8s = ctx.npm_cdk8s;
-  const npm_cdk8s_cli = ctx.npm_cdk8s_cli;
-  const constructs_version = ctx.constructs_version;
-
-  if (!npm_cdk8s) { throw new Error(`missing context "npm_cdk8s"`); }
-
-  installDeps([ npm_cdk8s, `constructs@^${constructs_version}` ]);
-  installDeps([
-      '@types/node@14',
-      '@types/jest@26',
-      'jest@26',
-      'ts-jest@26',
-      'typescript@4.9.5',
-      'ts-node@10',
-  ], true);
 
   const env = { ...process.env };
 
-  // install cdk8s cli if defined
-  if (npm_cdk8s_cli) {
-    installDeps([npm_cdk8s_cli], true);
-  } else {
-    env.PATH = `${clibin}:${process.env.PATH}`;
-  }
+  execSync('npm install', { stdio: 'inherit', env });
 
   // import k8s objects
   execSync('npm run import', { stdio: 'inherit', env });
@@ -38,9 +15,3 @@ exports.post = ctx => {
 
   console.log(readFileSync('./help', 'utf-8'));
 };
-
-function installDeps(deps, isDev) {
-  const devDep = isDev ? '-D' : '';
-  execSync(`npm install ${devDep} ${deps.join(' ')}`, { stdio: 'inherit' });
-}
-

--- a/templates/typescript-app/package.json
+++ b/templates/typescript-app/package.json
@@ -14,5 +14,19 @@
     "build": "npm run compile && npm run test && npm run synth",
     "upgrade": "npm i cdk8s@latest cdk8s-cli@latest",
     "upgrade:next": "npm i cdk8s@next cdk8s-cli@next"
+  },
+  "dependencies": {
+    "cdk8s": "^{{ cdk8s_core_version }}",
+    "cdk8s-plus-25": "^{{ cdk8s_plus_version }}",
+    "constructs": "^{{ constructs_version }}"
+  },
+  "devDependencies": {
+    "cdk8s-cli": "{{ cdk8s_cli_spec }}",
+    "@types/node": "^14",
+    "@types/jest": "^26",
+    "jest": "^26",
+    "ts-jest": "^26",
+    "typescript": "^4.9.5",
+    "ts-node": "^10"
   }
 }

--- a/templates/typescript-app/package.json
+++ b/templates/typescript-app/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "cdk8s": "^{{ cdk8s_core_version }}",
-    "cdk8s-plus-25": "^{{ cdk8s_plus_version }}",
     "constructs": "^{{ constructs_version }}"
   },
   "devDependencies": {


### PR DESCRIPTION
# Backport

This will backport the following commits from `2.x` to `1.x`:
 - [fix(init): typescript project initialization may fail on windows (#1165)](https://github.com/cdk8s-team/cdk8s-cli/pull/1165)

<!--- Backport version: 8.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)