### PR TITLE
fix(init): pipenv installation instructions leads to broken ssl website

### DIFF
--- a/templates/python-app/.hooks.sscaff.js
+++ b/templates/python-app/.hooks.sscaff.js
@@ -9,7 +9,7 @@ exports.pre = () => {
   try {
     execSync(`${platform() === 'win32' ? 'where' : 'which'} pipenv`);
   } catch {
-    console.error(`Unable to find "pipenv". Install from https://pipenv.kennethreitz.org`);
+    console.error(`Unable to find "pipenv". Install from https://pipenv.pypa.io/en/latest/installation/`);
     process.exit(1);
   }
 };


### PR DESCRIPTION
The website we link to for `pipenv` installation([pipenv.kennethreitz.org](https://pipenv.kennethreitz.org/)) is not working anymore. Switching it to https://pipenv.pypa.io/en/latest/installation/ which I gathered from official github repository of pipenv https://github.com/kennethreitz/pipenv.

Fixes https://github.com/cdk8s-team/cdk8s/issues/1145