### PR TITLE
fix(import): incorrect and unnecessary properties recorder to `cdk8s.yaml` on `cdk8s import`

### DIFF
--- a/src/cli/cmds/import.ts
+++ b/src/cli/cmds/import.ts
@@ -22,7 +22,7 @@ class Command implements yargs.CommandModule {
     .example('cdk8s import mattermost:=mattermost_crd.yaml', 'Imports constructs for the mattermost cluster custom resource definition using a custom module name')
     .example('cdk8s import github:crossplane/crossplane@0.14.0', 'Imports constructs for a GitHub repo using doc.crds.dev')
 
-    .option('save', { type: 'boolean', required: false, default: true, desc: "Save the import URL in the 'imports' section of the cdk8s.yaml configuration file. Note that any comments made in the file will be lost.", alias: 's' })
+    .option('save', { type: 'boolean', required: false, default: true, desc: "Dont save the import URL in the 'imports' section of the cdk8s.yaml configuration file.", alias: 's' })
     .option('output', { default: DEFAULT_OUTDIR, type: 'string', desc: 'Output directory', alias: 'o' })
     .option('exclude', { type: 'array', desc: 'Do not import types that match these regular expressions. They will be represented as the "any" type (only for "k8s")' })
     .option('class-prefix', { type: 'string', desc: 'A prefix to add to all generated class names. By default, this is "Kube" for "k8s" imports and disabled for CRD imports. Use --no-class-prefix to disable. Must be PascalCase' })

--- a/src/cli/cmds/import.ts
+++ b/src/cli/cmds/import.ts
@@ -22,7 +22,7 @@ class Command implements yargs.CommandModule {
     .example('cdk8s import mattermost:=mattermost_crd.yaml', 'Imports constructs for the mattermost cluster custom resource definition using a custom module name')
     .example('cdk8s import github:crossplane/crossplane@0.14.0', 'Imports constructs for a GitHub repo using doc.crds.dev')
 
-    .option('save', { type: 'boolean', required: false, desc: "Save the import URL in the 'imports' section of the cdk8s.yaml configuration file. Note that any comments made in the file will be lost.", alias: 's' })
+    .option('save', { type: 'boolean', required: false, default: true, desc: "Save the import URL in the 'imports' section of the cdk8s.yaml configuration file. Note that any comments made in the file will be lost.", alias: 's' })
     .option('output', { default: DEFAULT_OUTDIR, type: 'string', desc: 'Output directory', alias: 'o' })
     .option('exclude', { type: 'array', desc: 'Do not import types that match these regular expressions. They will be represented as the "any" type (only for "k8s")' })
     .option('class-prefix', { type: 'string', desc: 'A prefix to add to all generated class names. By default, this is "Kube" for "k8s" imports and disabled for CRD imports. Use --no-class-prefix to disable. Must be PascalCase' })

--- a/src/cli/cmds/import.ts
+++ b/src/cli/cmds/import.ts
@@ -1,6 +1,6 @@
 import * as yargs from 'yargs';
 import { readConfigSync, ImportSpec } from '../../config';
-import { importDispatch } from '../../import/dispatch';
+import { PREFIX_DELIM, importDispatch } from '../../import/dispatch';
 import { DEFAULT_API_VERSION } from '../../import/k8s';
 
 const config = readConfigSync();
@@ -22,6 +22,7 @@ class Command implements yargs.CommandModule {
     .example('cdk8s import mattermost:=mattermost_crd.yaml', 'Imports constructs for the mattermost cluster custom resource definition using a custom module name')
     .example('cdk8s import github:crossplane/crossplane@0.14.0', 'Imports constructs for a GitHub repo using doc.crds.dev')
 
+    .option('save', { type: 'boolean', required: false, desc: "Save the import URL in the 'imports' section of the cdk8s.yaml configuration file. Note that any comments made in the file will be lost.", alias: 's' })
     .option('output', { default: DEFAULT_OUTDIR, type: 'string', desc: 'Output directory', alias: 'o' })
     .option('exclude', { type: 'array', desc: 'Do not import types that match these regular expressions. They will be represented as the "any" type (only for "k8s")' })
     .option('class-prefix', { type: 'string', desc: 'A prefix to add to all generated class names. By default, this is "Kube" for "k8s" imports and disabled for CRD imports. Use --no-class-prefix to disable. Must be PascalCase' })
@@ -36,12 +37,13 @@ class Command implements yargs.CommandModule {
       outdir: argv.output,
       targetLanguage: argv.language,
       classNamePrefix,
+      save: argv.save,
     });
   }
 }
 
 function parseImports(spec: string): ImportSpec {
-  const splitImport = spec.split(':=');
+  const splitImport = spec.split(PREFIX_DELIM);
 
   // k8s@x.y.z
   // crd.yaml

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,7 @@ export function readConfigSync(): Config {
 }
 
 export async function addImportToConfig(source: string) {
-  let curConfig = readConfigSync();
+  let curConfig = yaml.parse(fs.readFileSync(CONFIG_FILE, 'utf-8'));
 
   const curImports = curConfig.imports ?? [];
   if (!curImports.includes(source)) {

--- a/src/import/base.ts
+++ b/src/import/base.ts
@@ -16,6 +16,7 @@ export interface ImportOptions {
   readonly moduleNamePrefix?: string;
   readonly targetLanguage: Language;
   readonly outdir: string;
+  readonly save?: boolean;
 
   /**
    * Path to copy the output .jsii file.

--- a/src/import/dispatch.ts
+++ b/src/import/dispatch.ts
@@ -21,7 +21,7 @@ export async function importDispatch(imports: ImportSpec[], argv: any, options: 
       ...options,
     });
 
-    if (options.save ?? false) {
+    if (options.save ?? true) {
       const spec = importSpec.moduleNamePrefix ? `${importSpec.moduleNamePrefix}${PREFIX_DELIM}${importSpec.source}` : importSpec.source;
       await addImportToConfig(spec);
     }

--- a/src/import/dispatch.ts
+++ b/src/import/dispatch.ts
@@ -4,6 +4,8 @@ import { matchCrdsDevUrl } from './crds-dev';
 import { ImportKubernetesApi } from './k8s';
 import { ImportSpec, addImportToConfig } from '../config';
 
+export const PREFIX_DELIM = ':=';
+
 export async function importDispatch(imports: ImportSpec[], argv: any, options: ImportOptions) {
   for (const importSpec of imports) {
     const importer = await matchImporter(importSpec, argv);
@@ -18,7 +20,11 @@ export async function importDispatch(imports: ImportSpec[], argv: any, options: 
       moduleNamePrefix: importSpec.moduleNamePrefix,
       ...options,
     });
-    await addImportToConfig(importSpec.source);
+
+    if (options.save ?? false) {
+      const spec = importSpec.moduleNamePrefix ? `${importSpec.moduleNamePrefix}${PREFIX_DELIM}${importSpec.source}` : importSpec.source;
+      await addImportToConfig(spec);
+    }
   }
 }
 

--- a/test/import/import-crd.test.ts
+++ b/test/import/import-crd.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as yaml from 'yaml';
 import { testImportMatchSnapshot } from './util';
-import { readConfigSync, ImportSpec } from '../../src/config';
+import { ImportSpec } from '../../src/config';
 import { Language, ImportOptions } from '../../src/import/base';
 import { ManifestObjectDefinition, ImportCustomResourceDefinition } from '../../src/import/crd';
 import { importDispatch } from '../../src/import/dispatch';
@@ -581,6 +581,7 @@ describe('cdk8s.yaml file', () => {
     importOptions = {
       targetLanguage: Language.TYPESCRIPT,
       outdir: tempDir,
+      save: true,
     };
 
     process.chdir(tempDir);
@@ -597,16 +598,25 @@ describe('cdk8s.yaml file', () => {
   test('is updated with new imports', async () => {
     await importDispatch([jenkinsCRD], {}, importOptions);
 
-    const config = readConfigSync();
-    expect(config.imports?.length == 2).toBeTruthy();
-    expect(config.imports?.includes(jenkinsCRD.source)).toBeTruthy();
+    const config = yaml.parse(fs.readFileSync('cdk8s.yaml', 'utf-8'));
+    expect(config).toMatchSnapshot();
   });
 
   test('does not update with CRD that is imported twice', async () => {
     await importDispatch([jenkinsCRD], {}, importOptions);
     await importDispatch([jenkinsCRD], {}, importOptions);
 
-    const config = readConfigSync();
-    expect(config.imports?.length == 2).toBeTruthy();
+    const config = yaml.parse(fs.readFileSync('cdk8s.yaml', 'utf-8'));
+    expect(config).toMatchSnapshot();
+  });
+
+  test('is updated with aliased import when used', async () => {
+
+    const spec: ImportSpec = { ...jenkinsCRD, moduleNamePrefix: 'jenk' };
+    await importDispatch([spec], {}, importOptions);
+
+    const config = yaml.parse(fs.readFileSync('cdk8s.yaml', 'utf-8'));
+    expect(config).toMatchSnapshot();
+
   });
 });

--- a/test/import/import-crd.test.ts
+++ b/test/import/import-crd.test.ts
@@ -581,7 +581,6 @@ describe('cdk8s.yaml file', () => {
     importOptions = {
       targetLanguage: Language.TYPESCRIPT,
       outdir: tempDir,
-      save: true,
     };
 
     process.chdir(tempDir);
@@ -619,4 +618,15 @@ describe('cdk8s.yaml file', () => {
     expect(config).toMatchSnapshot();
 
   });
+
+  test('is not updated with import when used save is false', async () => {
+
+    const spec: ImportSpec = { ...jenkinsCRD, moduleNamePrefix: 'jenk' };
+    await importDispatch([spec], {}, { ...importOptions, save: false });
+
+    const config = yaml.parse(fs.readFileSync('cdk8s.yaml', 'utf-8'));
+    expect(config).toMatchSnapshot();
+
+  });
+
 });


### PR DESCRIPTION
When an import is specified with an alias, i.e `cdk8s import 1.24:=k8s@1.24`, the alias is being ignored when saving it to the configuration file. This creates duplicate import entries, one with the alias and one without. 

In addition, default configuration values that were only meant for in-process operation are written to the config file on import - this should not happen.

Also added a `--no-save` flag that skips writing the import to the file. This can be helpful if users have comments in `cdk8s.yaml`, which cannot be preserved upon rewrite. 

Fixes https://github.com/cdk8s-team/cdk8s/issues/1442