### PR TITLE
fix(import): fails if executed without a `cdk8s.yaml` config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,12 @@ export function readConfigSync(): Config {
 }
 
 export async function addImportToConfig(source: string) {
+
+  if (!fs.existsSync(CONFIG_FILE)) {
+    // cdk8s import might be executed outside of an application (i.e without a config file)
+    return;
+  }
+
   let curConfig = yaml.parse(fs.readFileSync(CONFIG_FILE, 'utf-8'));
 
   const curImports = curConfig.imports ?? [];

--- a/test/import/import-crd.test.ts
+++ b/test/import/import-crd.test.ts
@@ -629,4 +629,14 @@ describe('cdk8s.yaml file', () => {
 
   });
 
+  test('doesnt have to exist when importing', async () => {
+
+    const spec: ImportSpec = { ...jenkinsCRD, moduleNamePrefix: 'jenk' };
+
+    fs.removeSync('cdk8s.yaml');
+
+    await importDispatch([spec], {}, { ...importOptions });
+
+  });
+
 });


### PR DESCRIPTION
Fixes https://github.com/cdk8s-team/cdk8s-cli/issues/1323