### PR TITLE
feat(import): sanitize enums for helm chart schemas

### DIFF
--- a/src/import/helm.ts
+++ b/src/import/helm.ts
@@ -64,6 +64,7 @@ export class ImportHelm extends ImportBase {
     const types = new TypeGenerator({
       definitions: this.schema?.definitions,
       toJson: false,
+      sanitizeEnums: true,
     });
 
     generateHelmConstruct(types, {

--- a/test/import/__snapshots__/import-helm.test.ts.snap
+++ b/test/import/__snapshots__/import-helm.test.ts.snap
@@ -5009,7 +5009,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 914,
+        "line": 952,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinity",
       "properties": Array [
@@ -5025,7 +5025,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 920,
+            "line": 958,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -5050,7 +5050,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 927,
+            "line": 965,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -5074,7 +5074,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1035,
+        "line": 1073,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -5090,7 +5090,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1041,
+            "line": 1079,
           },
           "name": "preference",
           "optional": true,
@@ -5109,7 +5109,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1048,
+            "line": 1086,
           },
           "name": "weight",
           "optional": true,
@@ -5134,7 +5134,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1188,
+        "line": 1226,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
       "properties": Array [
@@ -5149,7 +5149,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1194,
+            "line": 1232,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -5173,7 +5173,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1201,
+            "line": 1239,
           },
           "name": "matchFields",
           "optional": true,
@@ -5202,7 +5202,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1392,
+        "line": 1430,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
       "properties": Array [
@@ -5217,7 +5217,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1398,
+            "line": 1436,
           },
           "name": "key",
           "optional": true,
@@ -5243,7 +5243,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1413,
+            "line": 1451,
           },
           "name": "operator",
           "optional": true,
@@ -5263,7 +5263,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1420,
+            "line": 1458,
           },
           "name": "values",
           "optional": true,
@@ -5298,7 +5298,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1752,
+        "line": 1790,
       },
       "members": Array [
         Object {
@@ -5354,7 +5354,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1429,
+        "line": 1467,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
       "properties": Array [
@@ -5369,7 +5369,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1435,
+            "line": 1473,
           },
           "name": "key",
           "optional": true,
@@ -5395,7 +5395,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1450,
+            "line": 1488,
           },
           "name": "operator",
           "optional": true,
@@ -5415,7 +5415,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1457,
+            "line": 1495,
           },
           "name": "values",
           "optional": true,
@@ -5450,7 +5450,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1780,
+        "line": 1818,
       },
       "members": Array [
         Object {
@@ -5507,7 +5507,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1057,
+        "line": 1095,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -5523,7 +5523,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1063,
+            "line": 1101,
           },
           "name": "nodeSelectorTerms",
           "optional": true,
@@ -5553,7 +5553,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1210,
+        "line": 1248,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
       "properties": Array [
@@ -5568,7 +5568,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1216,
+            "line": 1254,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -5592,7 +5592,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1223,
+            "line": 1261,
           },
           "name": "matchFields",
           "optional": true,
@@ -5621,7 +5621,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1466,
+        "line": 1504,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
       "properties": Array [
@@ -5636,7 +5636,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1472,
+            "line": 1510,
           },
           "name": "key",
           "optional": true,
@@ -5662,7 +5662,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1487,
+            "line": 1525,
           },
           "name": "operator",
           "optional": true,
@@ -5682,7 +5682,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1494,
+            "line": 1532,
           },
           "name": "values",
           "optional": true,
@@ -5717,7 +5717,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1808,
+        "line": 1846,
       },
       "members": Array [
         Object {
@@ -5773,7 +5773,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1503,
+        "line": 1541,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
       "properties": Array [
@@ -5788,7 +5788,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1509,
+            "line": 1547,
           },
           "name": "key",
           "optional": true,
@@ -5814,7 +5814,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1524,
+            "line": 1562,
           },
           "name": "operator",
           "optional": true,
@@ -5834,7 +5834,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1531,
+            "line": 1569,
           },
           "name": "values",
           "optional": true,
@@ -5869,7 +5869,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1836,
+        "line": 1874,
       },
       "members": Array [
         Object {
@@ -5925,7 +5925,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 936,
+        "line": 974,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinity",
       "properties": Array [
@@ -5941,7 +5941,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 942,
+            "line": 980,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -5966,7 +5966,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 949,
+            "line": 987,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -5995,7 +5995,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1072,
+        "line": 1110,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -6010,7 +6010,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1078,
+            "line": 1116,
           },
           "name": "podAffinityTerm",
           "optional": true,
@@ -6029,7 +6029,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1085,
+            "line": 1123,
           },
           "name": "weight",
           "optional": true,
@@ -6053,7 +6053,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1232,
+        "line": 1270,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "properties": Array [
@@ -6069,7 +6069,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1259,
+            "line": 1297,
           },
           "name": "topologyKey",
           "type": Object {
@@ -6088,7 +6088,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1238,
+            "line": 1276,
           },
           "name": "labelSelector",
           "optional": true,
@@ -6108,7 +6108,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1252,
+            "line": 1290,
           },
           "name": "namespaces",
           "optional": true,
@@ -6133,7 +6133,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1245,
+            "line": 1283,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -6158,7 +6158,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1540,
+        "line": 1578,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "properties": Array [
@@ -6174,7 +6174,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1546,
+            "line": 1584,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -6199,7 +6199,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1553,
+            "line": 1591,
           },
           "name": "matchLabels",
           "optional": true,
@@ -6228,7 +6228,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1856,
+        "line": 1894,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "properties": Array [
@@ -6243,7 +6243,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1862,
+            "line": 1900,
           },
           "name": "key",
           "optional": true,
@@ -6263,7 +6263,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1869,
+            "line": 1907,
           },
           "name": "operator",
           "optional": true,
@@ -6283,7 +6283,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1876,
+            "line": 1914,
           },
           "name": "values",
           "optional": true,
@@ -6313,7 +6313,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1562,
+        "line": 1600,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
       "properties": Array [
@@ -6329,7 +6329,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1568,
+            "line": 1606,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -6354,7 +6354,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1575,
+            "line": 1613,
           },
           "name": "matchLabels",
           "optional": true,
@@ -6383,7 +6383,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1885,
+        "line": 1923,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -6398,7 +6398,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1891,
+            "line": 1929,
           },
           "name": "key",
           "optional": true,
@@ -6418,7 +6418,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1898,
+            "line": 1936,
           },
           "name": "operator",
           "optional": true,
@@ -6438,7 +6438,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1905,
+            "line": 1943,
           },
           "name": "values",
           "optional": true,
@@ -6467,7 +6467,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1094,
+        "line": 1132,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -6483,7 +6483,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1100,
+            "line": 1138,
           },
           "name": "labelSelector",
           "optional": true,
@@ -6503,7 +6503,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1114,
+            "line": 1152,
           },
           "name": "namespaces",
           "optional": true,
@@ -6528,7 +6528,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1107,
+            "line": 1145,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -6548,7 +6548,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1121,
+            "line": 1159,
           },
           "name": "topologyKey",
           "optional": true,
@@ -6573,7 +6573,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1268,
+        "line": 1306,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "properties": Array [
@@ -6589,7 +6589,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1274,
+            "line": 1312,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -6614,7 +6614,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1281,
+            "line": 1319,
           },
           "name": "matchLabels",
           "optional": true,
@@ -6643,7 +6643,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1584,
+        "line": 1622,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "properties": Array [
@@ -6658,7 +6658,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1590,
+            "line": 1628,
           },
           "name": "key",
           "optional": true,
@@ -6678,7 +6678,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1597,
+            "line": 1635,
           },
           "name": "operator",
           "optional": true,
@@ -6698,7 +6698,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1604,
+            "line": 1642,
           },
           "name": "values",
           "optional": true,
@@ -6728,7 +6728,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1290,
+        "line": 1328,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
       "properties": Array [
@@ -6744,7 +6744,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1296,
+            "line": 1334,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -6769,7 +6769,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1303,
+            "line": 1341,
           },
           "name": "matchLabels",
           "optional": true,
@@ -6798,7 +6798,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1613,
+        "line": 1651,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -6813,7 +6813,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1619,
+            "line": 1657,
           },
           "name": "key",
           "optional": true,
@@ -6833,7 +6833,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1626,
+            "line": 1664,
           },
           "name": "operator",
           "optional": true,
@@ -6853,7 +6853,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1633,
+            "line": 1671,
           },
           "name": "values",
           "optional": true,
@@ -6882,7 +6882,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 958,
+        "line": 996,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinity",
       "properties": Array [
@@ -6898,7 +6898,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 964,
+            "line": 1002,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -6923,7 +6923,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 971,
+            "line": 1009,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -6952,7 +6952,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1130,
+        "line": 1168,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -6967,7 +6967,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1136,
+            "line": 1174,
           },
           "name": "podAffinityTerm",
           "optional": true,
@@ -6986,7 +6986,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1143,
+            "line": 1181,
           },
           "name": "weight",
           "optional": true,
@@ -7010,7 +7010,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1312,
+        "line": 1350,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "properties": Array [
@@ -7026,7 +7026,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1339,
+            "line": 1377,
           },
           "name": "topologyKey",
           "type": Object {
@@ -7045,7 +7045,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1318,
+            "line": 1356,
           },
           "name": "labelSelector",
           "optional": true,
@@ -7065,7 +7065,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1332,
+            "line": 1370,
           },
           "name": "namespaces",
           "optional": true,
@@ -7090,7 +7090,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1325,
+            "line": 1363,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -7115,7 +7115,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1642,
+        "line": 1680,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "properties": Array [
@@ -7131,7 +7131,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1648,
+            "line": 1686,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -7156,7 +7156,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1655,
+            "line": 1693,
           },
           "name": "matchLabels",
           "optional": true,
@@ -7185,7 +7185,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1914,
+        "line": 1952,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "properties": Array [
@@ -7200,7 +7200,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1920,
+            "line": 1958,
           },
           "name": "key",
           "optional": true,
@@ -7220,7 +7220,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1927,
+            "line": 1965,
           },
           "name": "operator",
           "optional": true,
@@ -7240,7 +7240,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1934,
+            "line": 1972,
           },
           "name": "values",
           "optional": true,
@@ -7270,7 +7270,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1664,
+        "line": 1702,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
       "properties": Array [
@@ -7286,7 +7286,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1670,
+            "line": 1708,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -7311,7 +7311,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1677,
+            "line": 1715,
           },
           "name": "matchLabels",
           "optional": true,
@@ -7340,7 +7340,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1943,
+        "line": 1981,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -7355,7 +7355,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1949,
+            "line": 1987,
           },
           "name": "key",
           "optional": true,
@@ -7375,7 +7375,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1956,
+            "line": 1994,
           },
           "name": "operator",
           "optional": true,
@@ -7395,7 +7395,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1963,
+            "line": 2001,
           },
           "name": "values",
           "optional": true,
@@ -7424,7 +7424,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1152,
+        "line": 1190,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -7440,7 +7440,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1158,
+            "line": 1196,
           },
           "name": "labelSelector",
           "optional": true,
@@ -7460,7 +7460,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1172,
+            "line": 1210,
           },
           "name": "namespaces",
           "optional": true,
@@ -7485,7 +7485,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1165,
+            "line": 1203,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -7505,7 +7505,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1179,
+            "line": 1217,
           },
           "name": "topologyKey",
           "optional": true,
@@ -7530,7 +7530,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1348,
+        "line": 1386,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "properties": Array [
@@ -7546,7 +7546,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1354,
+            "line": 1392,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -7571,7 +7571,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1361,
+            "line": 1399,
           },
           "name": "matchLabels",
           "optional": true,
@@ -7600,7 +7600,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1686,
+        "line": 1724,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "properties": Array [
@@ -7615,7 +7615,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1692,
+            "line": 1730,
           },
           "name": "key",
           "optional": true,
@@ -7635,7 +7635,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1699,
+            "line": 1737,
           },
           "name": "operator",
           "optional": true,
@@ -7655,7 +7655,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1706,
+            "line": 1744,
           },
           "name": "values",
           "optional": true,
@@ -7685,7 +7685,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1370,
+        "line": 1408,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
       "properties": Array [
@@ -7701,7 +7701,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1376,
+            "line": 1414,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -7726,7 +7726,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1383,
+            "line": 1421,
           },
           "name": "matchLabels",
           "optional": true,
@@ -7755,7 +7755,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1715,
+        "line": 1753,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -7770,7 +7770,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1721,
+            "line": 1759,
           },
           "name": "key",
           "optional": true,
@@ -7790,7 +7790,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1728,
+            "line": 1766,
           },
           "name": "operator",
           "optional": true,
@@ -7810,7 +7810,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1735,
+            "line": 1773,
           },
           "name": "values",
           "optional": true,
@@ -7901,7 +7901,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 980,
+        "line": 1018,
       },
       "name": "IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
       "properties": Array [
@@ -7915,7 +7915,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 984,
+            "line": 1022,
           },
           "name": "maxSurge",
           "optional": true,
@@ -7933,7 +7933,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 989,
+            "line": 1027,
           },
           "name": "maxUnavailable",
           "optional": true,
@@ -7960,7 +7960,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1003,
+        "line": 1041,
       },
       "members": Array [
         Object {
@@ -8237,7 +8237,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 883,
+        "line": 921,
       },
       "members": Array [
         Object {
@@ -8280,7 +8280,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 902,
+        "line": 940,
       },
       "members": Array [
         Object {
@@ -8483,7 +8483,7 @@ Possible enum values:
           "name": "clusterType",
           "optional": true,
           "type": Object {
-            "primitive": "string",
+            "fqn": "lacework-agent.LaceworkAgentClusterAgentClusterType",
           },
         },
         Object {
@@ -8526,6 +8526,43 @@ Possible enum values:
         },
       ],
       "symbolId": "lacework-agent:LaceworkAgentClusterAgent",
+    },
+    "lacework-agent.LaceworkAgentClusterAgentClusterType": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentClusterAgentClusterType",
+        },
+        "summary": "Kubernetes cluster type.",
+      },
+      "fqn": "lacework-agent.LaceworkAgentClusterAgentClusterType",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 733,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "eks.",
+          },
+          "name": "EKS",
+        },
+        Object {
+          "docs": Object {
+            "summary": "gke.",
+          },
+          "name": "GKE",
+        },
+        Object {
+          "docs": Object {
+            "summary": "unknown.",
+          },
+          "name": "UNKNOWN",
+        },
+      ],
+      "name": "LaceworkAgentClusterAgentClusterType",
+      "symbolId": "lacework-agent:LaceworkAgentClusterAgentClusterType",
     },
     "lacework-agent.LaceworkAgentClusterAgentImage": Object {
       "assembly": "lacework-agent",
@@ -8690,7 +8727,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1021,
+        "line": 1059,
       },
       "members": Array [
         Object {
@@ -9401,7 +9438,7 @@ Possible enum values:
           "name": "containerRuntime",
           "optional": true,
           "type": Object {
-            "primitive": "string",
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigContainerRuntime",
           },
         },
         Object {
@@ -9571,7 +9608,7 @@ Possible enum values:
           "name": "perfmode",
           "optional": true,
           "type": Object {
-            "primitive": "string",
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigPerfmode",
           },
         },
         Object {
@@ -9702,7 +9739,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 731,
+        "line": 745,
       },
       "name": "LaceworkAgentLaceworkConfigAnonymizeIncoming",
       "properties": Array [
@@ -9717,7 +9754,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 742,
+            "line": 756,
           },
           "name": "additionalValues",
           "optional": true,
@@ -9740,7 +9777,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 735,
+            "line": 749,
           },
           "name": "netmask",
           "optional": true,
@@ -9762,7 +9799,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 749,
+        "line": 763,
       },
       "members": Array [
         Object {
@@ -9793,7 +9830,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 759,
+        "line": 773,
       },
       "name": "LaceworkAgentLaceworkConfigCmdlinefilter",
       "properties": Array [
@@ -9807,7 +9844,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 763,
+            "line": 777,
           },
           "name": "allow",
           "optional": true,
@@ -9825,7 +9862,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 768,
+            "line": 782,
           },
           "name": "disallow",
           "optional": true,
@@ -9848,7 +9885,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 775,
+        "line": 789,
       },
       "name": "LaceworkAgentLaceworkConfigCodeaware",
       "properties": Array [
@@ -9862,7 +9899,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 779,
+            "line": 793,
           },
           "name": "enable",
           "optional": true,
@@ -9872,6 +9909,42 @@ Possible enum values:
         },
       ],
       "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigCodeaware",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigContainerRuntime": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigContainerRuntime",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigContainerRuntime",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 800,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "containerd.",
+          },
+          "name": "CONTAINERD",
+        },
+        Object {
+          "docs": Object {
+            "summary": "cri-o.",
+          },
+          "name": "CRI_O",
+        },
+        Object {
+          "docs": Object {
+            "summary": "docker.",
+          },
+          "name": "DOCKER",
+        },
+      ],
+      "name": "LaceworkAgentLaceworkConfigContainerRuntime",
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigContainerRuntime",
     },
     "lacework-agent.LaceworkAgentLaceworkConfigDatacollector": Object {
       "assembly": "lacework-agent",
@@ -9884,7 +9957,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 786,
+        "line": 812,
       },
       "members": Array [
         Object {
@@ -9915,7 +9988,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 796,
+        "line": 822,
       },
       "name": "LaceworkAgentLaceworkConfigFim",
       "properties": Array [
@@ -9929,7 +10002,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 810,
+            "line": 836,
           },
           "name": "enable",
           "type": Object {
@@ -9946,7 +10019,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 815,
+            "line": 841,
           },
           "name": "fileIgnore",
           "type": Object {
@@ -9968,7 +10041,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 820,
+            "line": 846,
           },
           "name": "filePath",
           "type": Object {
@@ -9991,7 +10064,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 837,
+            "line": 863,
           },
           "name": "additionalValues",
           "optional": true,
@@ -10014,7 +10087,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 800,
+            "line": 826,
           },
           "name": "coolingPeriod",
           "optional": true,
@@ -10032,7 +10105,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 805,
+            "line": 831,
           },
           "name": "crawlInterval",
           "optional": true,
@@ -10050,7 +10123,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 825,
+            "line": 851,
           },
           "name": "noAtime",
           "optional": true,
@@ -10068,7 +10141,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 830,
+            "line": 856,
           },
           "name": "runAt",
           "optional": true,
@@ -10091,7 +10164,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 844,
+        "line": 870,
       },
       "name": "LaceworkAgentLaceworkConfigPackagescan",
       "properties": Array [
@@ -10105,7 +10178,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 848,
+            "line": 874,
           },
           "name": "enable",
           "optional": true,
@@ -10123,7 +10196,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 853,
+            "line": 879,
           },
           "name": "interval",
           "optional": true,
@@ -10133,6 +10206,42 @@ Possible enum values:
         },
       ],
       "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigPackagescan",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigPerfmode": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigPerfmode",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigPerfmode",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 902,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "lite.",
+          },
+          "name": "LITE",
+        },
+        Object {
+          "docs": Object {
+            "summary": "scan.",
+          },
+          "name": "SCAN",
+        },
+        Object {
+          "docs": Object {
+            "summary": "ebpflite.",
+          },
+          "name": "EBPFLITE",
+        },
+      ],
+      "name": "LaceworkAgentLaceworkConfigPerfmode",
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigPerfmode",
     },
     "lacework-agent.LaceworkAgentLaceworkConfigProcscan": Object {
       "assembly": "lacework-agent",
@@ -10146,7 +10255,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 860,
+        "line": 886,
       },
       "name": "LaceworkAgentLaceworkConfigProcscan",
       "properties": Array [
@@ -10160,7 +10269,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 864,
+            "line": 890,
           },
           "name": "enable",
           "optional": true,
@@ -10178,7 +10287,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 869,
+            "line": 895,
           },
           "name": "interval",
           "optional": true,
@@ -13960,7 +14069,7 @@ class LaceworkAgentClusterAgent:
         image: typing.Union[\\"LaceworkAgentClusterAgentImage\\", typing.Dict[builtins.str, typing.Any]],
         additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
         cluster_region: typing.Optional[builtins.str] = None,
-        cluster_type: typing.Optional[builtins.str] = None,
+        cluster_type: typing.Optional[\\"LaceworkAgentClusterAgentClusterType\\"] = None,
         scrape_initial_delay_mins: typing.Optional[jsii.Number] = None,
         scrape_interval_mins: typing.Optional[jsii.Number] = None,
     ) -> None:
@@ -14041,13 +14150,13 @@ class LaceworkAgentClusterAgent:
         return typing.cast(typing.Optional[builtins.str], result)
 
     @builtins.property
-    def cluster_type(self) -> typing.Optional[builtins.str]:
+    def cluster_type(self) -> typing.Optional[\\"LaceworkAgentClusterAgentClusterType\\"]:
         '''Kubernetes cluster type.
 
         :schema: LaceworkAgentClusterAgent#clusterType
         '''
         result = self._values.get(\\"cluster_type\\")
-        return typing.cast(typing.Optional[builtins.str], result)
+        return typing.cast(typing.Optional[\\"LaceworkAgentClusterAgentClusterType\\"], result)
 
     @builtins.property
     def scrape_initial_delay_mins(self) -> typing.Optional[jsii.Number]:
@@ -14077,6 +14186,21 @@ class LaceworkAgentClusterAgent:
         return \\"LaceworkAgentClusterAgent(%s)\\" % \\", \\".join(
             k + \\"=\\" + repr(v) for k, v in self._values.items()
         )
+
+
+@jsii.enum(jsii_type=\\"lacework-agent.LaceworkAgentClusterAgentClusterType\\")
+class LaceworkAgentClusterAgentClusterType(enum.Enum):
+    '''Kubernetes cluster type.
+
+    :schema: LaceworkAgentClusterAgentClusterType
+    '''
+
+    EKS = \\"EKS\\"
+    '''eks.'''
+    GKE = \\"GKE\\"
+    '''gke.'''
+    UNKNOWN = \\"UNKNOWN\\"
+    '''unknown.'''
 
 
 @jsii.data_type(
@@ -14740,7 +14864,7 @@ class LaceworkAgentLaceworkConfig:
         cmdlinefilter: typing.Optional[typing.Union[\\"LaceworkAgentLaceworkConfigCmdlinefilter\\", typing.Dict[builtins.str, typing.Any]]] = None,
         codeaware: typing.Optional[typing.Union[\\"LaceworkAgentLaceworkConfigCodeaware\\", typing.Dict[builtins.str, typing.Any]]] = None,
         container_engine_endpoint: typing.Optional[builtins.str] = None,
-        container_runtime: typing.Optional[builtins.str] = None,
+        container_runtime: typing.Optional[\\"LaceworkAgentLaceworkConfigContainerRuntime\\"] = None,
         datacollector: typing.Optional[\\"LaceworkAgentLaceworkConfigDatacollector\\"] = None,
         env: typing.Optional[builtins.str] = None,
         fim: typing.Optional[typing.Union[\\"LaceworkAgentLaceworkConfigFim\\", typing.Dict[builtins.str, typing.Any]]] = None,
@@ -14749,7 +14873,7 @@ class LaceworkAgentLaceworkConfig:
         labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
         metadata_request_interval: typing.Optional[builtins.str] = None,
         packagescan: typing.Optional[typing.Union[\\"LaceworkAgentLaceworkConfigPackagescan\\", typing.Dict[builtins.str, typing.Any]]] = None,
-        perfmode: typing.Optional[builtins.str] = None,
+        perfmode: typing.Optional[\\"LaceworkAgentLaceworkConfigPerfmode\\"] = None,
         procscan: typing.Optional[typing.Union[\\"LaceworkAgentLaceworkConfigProcscan\\", typing.Dict[builtins.str, typing.Any]]] = None,
         proxy_url: typing.Optional[builtins.str] = None,
         server_url: typing.Optional[builtins.str] = None,
@@ -14951,12 +15075,14 @@ class LaceworkAgentLaceworkConfig:
         return typing.cast(typing.Optional[builtins.str], result)
 
     @builtins.property
-    def container_runtime(self) -> typing.Optional[builtins.str]:
+    def container_runtime(
+        self,
+    ) -> typing.Optional[\\"LaceworkAgentLaceworkConfigContainerRuntime\\"]:
         '''
         :schema: LaceworkAgentLaceworkConfig#containerRuntime
         '''
         result = self._values.get(\\"container_runtime\\")
-        return typing.cast(typing.Optional[builtins.str], result)
+        return typing.cast(typing.Optional[\\"LaceworkAgentLaceworkConfigContainerRuntime\\"], result)
 
     @builtins.property
     def datacollector(
@@ -15029,12 +15155,12 @@ class LaceworkAgentLaceworkConfig:
         return typing.cast(typing.Optional[\\"LaceworkAgentLaceworkConfigPackagescan\\"], result)
 
     @builtins.property
-    def perfmode(self) -> typing.Optional[builtins.str]:
+    def perfmode(self) -> typing.Optional[\\"LaceworkAgentLaceworkConfigPerfmode\\"]:
         '''
         :schema: LaceworkAgentLaceworkConfig#perfmode
         '''
         result = self._values.get(\\"perfmode\\")
-        return typing.cast(typing.Optional[builtins.str], result)
+        return typing.cast(typing.Optional[\\"LaceworkAgentLaceworkConfigPerfmode\\"], result)
 
     @builtins.property
     def procscan(self) -> typing.Optional[\\"LaceworkAgentLaceworkConfigProcscan\\"]:
@@ -15262,6 +15388,20 @@ class LaceworkAgentLaceworkConfigCodeaware:
         )
 
 
+@jsii.enum(jsii_type=\\"lacework-agent.LaceworkAgentLaceworkConfigContainerRuntime\\")
+class LaceworkAgentLaceworkConfigContainerRuntime(enum.Enum):
+    '''
+    :schema: LaceworkAgentLaceworkConfigContainerRuntime
+    '''
+
+    CONTAINERD = \\"CONTAINERD\\"
+    '''containerd.'''
+    CRI_O = \\"CRI_O\\"
+    '''cri-o.'''
+    DOCKER = \\"DOCKER\\"
+    '''docker.'''
+
+
 @jsii.enum(jsii_type=\\"lacework-agent.LaceworkAgentLaceworkConfigDatacollector\\")
 class LaceworkAgentLaceworkConfigDatacollector(enum.Enum):
     '''
@@ -15475,6 +15615,20 @@ class LaceworkAgentLaceworkConfigPackagescan:
         return \\"LaceworkAgentLaceworkConfigPackagescan(%s)\\" % \\", \\".join(
             k + \\"=\\" + repr(v) for k, v in self._values.items()
         )
+
+
+@jsii.enum(jsii_type=\\"lacework-agent.LaceworkAgentLaceworkConfigPerfmode\\")
+class LaceworkAgentLaceworkConfigPerfmode(enum.Enum):
+    '''
+    :schema: LaceworkAgentLaceworkConfigPerfmode
+    '''
+
+    LITE = \\"LITE\\"
+    '''lite.'''
+    SCAN = \\"SCAN\\"
+    '''scan.'''
+    EBPFLITE = \\"EBPFLITE\\"
+    '''ebpflite.'''
 
 
 @jsii.data_type(
@@ -15981,6 +16135,7 @@ __all__ = [
     \\"LaceworkAgentCloudservice\\",
     \\"LaceworkAgentCloudserviceGke\\",
     \\"LaceworkAgentClusterAgent\\",
+    \\"LaceworkAgentClusterAgentClusterType\\",
     \\"LaceworkAgentClusterAgentImage\\",
     \\"LaceworkAgentClusterAgentImagePullPolicy\\",
     \\"LaceworkAgentDaemonset\\",
@@ -15993,9 +16148,11 @@ __all__ = [
     \\"LaceworkAgentLaceworkConfigAutoUpgrade\\",
     \\"LaceworkAgentLaceworkConfigCmdlinefilter\\",
     \\"LaceworkAgentLaceworkConfigCodeaware\\",
+    \\"LaceworkAgentLaceworkConfigContainerRuntime\\",
     \\"LaceworkAgentLaceworkConfigDatacollector\\",
     \\"LaceworkAgentLaceworkConfigFim\\",
     \\"LaceworkAgentLaceworkConfigPackagescan\\",
+    \\"LaceworkAgentLaceworkConfigPerfmode\\",
     \\"LaceworkAgentLaceworkConfigProcscan\\",
     \\"Laceworkagent\\",
     \\"LaceworkagentProps\\",
@@ -16358,7 +16515,7 @@ def _typecheckingstub__427477360d777d212ced442a6c1a4283eae0d78b2a8c760ed72582ef9
     image: typing.Union[LaceworkAgentClusterAgentImage, typing.Dict[builtins.str, typing.Any]],
     additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
     cluster_region: typing.Optional[builtins.str] = None,
-    cluster_type: typing.Optional[builtins.str] = None,
+    cluster_type: typing.Optional[LaceworkAgentClusterAgentClusterType] = None,
     scrape_initial_delay_mins: typing.Optional[jsii.Number] = None,
     scrape_interval_mins: typing.Optional[jsii.Number] = None,
 ) -> None:
@@ -16430,7 +16587,7 @@ def _typecheckingstub__137ccaec2780b925802b147c3602013773aba0adcc89e414986c5d5a3
     cmdlinefilter: typing.Optional[typing.Union[LaceworkAgentLaceworkConfigCmdlinefilter, typing.Dict[builtins.str, typing.Any]]] = None,
     codeaware: typing.Optional[typing.Union[LaceworkAgentLaceworkConfigCodeaware, typing.Dict[builtins.str, typing.Any]]] = None,
     container_engine_endpoint: typing.Optional[builtins.str] = None,
-    container_runtime: typing.Optional[builtins.str] = None,
+    container_runtime: typing.Optional[LaceworkAgentLaceworkConfigContainerRuntime] = None,
     datacollector: typing.Optional[LaceworkAgentLaceworkConfigDatacollector] = None,
     env: typing.Optional[builtins.str] = None,
     fim: typing.Optional[typing.Union[LaceworkAgentLaceworkConfigFim, typing.Dict[builtins.str, typing.Any]]] = None,
@@ -16439,7 +16596,7 @@ def _typecheckingstub__137ccaec2780b925802b147c3602013773aba0adcc89e414986c5d5a3
     labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
     metadata_request_interval: typing.Optional[builtins.str] = None,
     packagescan: typing.Optional[typing.Union[LaceworkAgentLaceworkConfigPackagescan, typing.Dict[builtins.str, typing.Any]]] = None,
-    perfmode: typing.Optional[builtins.str] = None,
+    perfmode: typing.Optional[LaceworkAgentLaceworkConfigPerfmode] = None,
     procscan: typing.Optional[typing.Union[LaceworkAgentLaceworkConfigProcscan, typing.Dict[builtins.str, typing.Any]]] = None,
     proxy_url: typing.Optional[builtins.str] = None,
     server_url: typing.Optional[builtins.str] = None,
@@ -16753,7 +16910,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 914,
+        "line": 952,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinity",
       "properties": Array [
@@ -16769,7 +16926,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 920,
+            "line": 958,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -16794,7 +16951,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 927,
+            "line": 965,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -16818,7 +16975,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1035,
+        "line": 1073,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -16834,7 +16991,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1041,
+            "line": 1079,
           },
           "name": "preference",
           "optional": true,
@@ -16853,7 +17010,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1048,
+            "line": 1086,
           },
           "name": "weight",
           "optional": true,
@@ -16878,7 +17035,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1188,
+        "line": 1226,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
       "properties": Array [
@@ -16893,7 +17050,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1194,
+            "line": 1232,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -16917,7 +17074,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1201,
+            "line": 1239,
           },
           "name": "matchFields",
           "optional": true,
@@ -16946,7 +17103,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1392,
+        "line": 1430,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
       "properties": Array [
@@ -16961,7 +17118,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1398,
+            "line": 1436,
           },
           "name": "key",
           "optional": true,
@@ -16987,7 +17144,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1413,
+            "line": 1451,
           },
           "name": "operator",
           "optional": true,
@@ -17007,7 +17164,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1420,
+            "line": 1458,
           },
           "name": "values",
           "optional": true,
@@ -17042,7 +17199,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1752,
+        "line": 1790,
       },
       "members": Array [
         Object {
@@ -17098,7 +17255,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1429,
+        "line": 1467,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
       "properties": Array [
@@ -17113,7 +17270,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1435,
+            "line": 1473,
           },
           "name": "key",
           "optional": true,
@@ -17139,7 +17296,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1450,
+            "line": 1488,
           },
           "name": "operator",
           "optional": true,
@@ -17159,7 +17316,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1457,
+            "line": 1495,
           },
           "name": "values",
           "optional": true,
@@ -17194,7 +17351,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1780,
+        "line": 1818,
       },
       "members": Array [
         Object {
@@ -17251,7 +17408,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1057,
+        "line": 1095,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -17267,7 +17424,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1063,
+            "line": 1101,
           },
           "name": "nodeSelectorTerms",
           "optional": true,
@@ -17297,7 +17454,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1210,
+        "line": 1248,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
       "properties": Array [
@@ -17312,7 +17469,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1216,
+            "line": 1254,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -17336,7 +17493,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1223,
+            "line": 1261,
           },
           "name": "matchFields",
           "optional": true,
@@ -17365,7 +17522,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1466,
+        "line": 1504,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
       "properties": Array [
@@ -17380,7 +17537,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1472,
+            "line": 1510,
           },
           "name": "key",
           "optional": true,
@@ -17406,7 +17563,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1487,
+            "line": 1525,
           },
           "name": "operator",
           "optional": true,
@@ -17426,7 +17583,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1494,
+            "line": 1532,
           },
           "name": "values",
           "optional": true,
@@ -17461,7 +17618,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1808,
+        "line": 1846,
       },
       "members": Array [
         Object {
@@ -17517,7 +17674,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1503,
+        "line": 1541,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
       "properties": Array [
@@ -17532,7 +17689,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1509,
+            "line": 1547,
           },
           "name": "key",
           "optional": true,
@@ -17558,7 +17715,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1524,
+            "line": 1562,
           },
           "name": "operator",
           "optional": true,
@@ -17578,7 +17735,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1531,
+            "line": 1569,
           },
           "name": "values",
           "optional": true,
@@ -17613,7 +17770,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1836,
+        "line": 1874,
       },
       "members": Array [
         Object {
@@ -17669,7 +17826,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 936,
+        "line": 974,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinity",
       "properties": Array [
@@ -17685,7 +17842,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 942,
+            "line": 980,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -17710,7 +17867,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 949,
+            "line": 987,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -17739,7 +17896,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1072,
+        "line": 1110,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -17754,7 +17911,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1078,
+            "line": 1116,
           },
           "name": "podAffinityTerm",
           "optional": true,
@@ -17773,7 +17930,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1085,
+            "line": 1123,
           },
           "name": "weight",
           "optional": true,
@@ -17797,7 +17954,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1232,
+        "line": 1270,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "properties": Array [
@@ -17813,7 +17970,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1259,
+            "line": 1297,
           },
           "name": "topologyKey",
           "type": Object {
@@ -17832,7 +17989,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1238,
+            "line": 1276,
           },
           "name": "labelSelector",
           "optional": true,
@@ -17852,7 +18009,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1252,
+            "line": 1290,
           },
           "name": "namespaces",
           "optional": true,
@@ -17877,7 +18034,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1245,
+            "line": 1283,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -17902,7 +18059,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1540,
+        "line": 1578,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "properties": Array [
@@ -17918,7 +18075,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1546,
+            "line": 1584,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -17943,7 +18100,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1553,
+            "line": 1591,
           },
           "name": "matchLabels",
           "optional": true,
@@ -17972,7 +18129,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1856,
+        "line": 1894,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "properties": Array [
@@ -17987,7 +18144,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1862,
+            "line": 1900,
           },
           "name": "key",
           "optional": true,
@@ -18007,7 +18164,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1869,
+            "line": 1907,
           },
           "name": "operator",
           "optional": true,
@@ -18027,7 +18184,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1876,
+            "line": 1914,
           },
           "name": "values",
           "optional": true,
@@ -18057,7 +18214,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1562,
+        "line": 1600,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
       "properties": Array [
@@ -18073,7 +18230,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1568,
+            "line": 1606,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -18098,7 +18255,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1575,
+            "line": 1613,
           },
           "name": "matchLabels",
           "optional": true,
@@ -18127,7 +18284,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1885,
+        "line": 1923,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -18142,7 +18299,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1891,
+            "line": 1929,
           },
           "name": "key",
           "optional": true,
@@ -18162,7 +18319,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1898,
+            "line": 1936,
           },
           "name": "operator",
           "optional": true,
@@ -18182,7 +18339,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1905,
+            "line": 1943,
           },
           "name": "values",
           "optional": true,
@@ -18211,7 +18368,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1094,
+        "line": 1132,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -18227,7 +18384,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1100,
+            "line": 1138,
           },
           "name": "labelSelector",
           "optional": true,
@@ -18247,7 +18404,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1114,
+            "line": 1152,
           },
           "name": "namespaces",
           "optional": true,
@@ -18272,7 +18429,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1107,
+            "line": 1145,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -18292,7 +18449,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1121,
+            "line": 1159,
           },
           "name": "topologyKey",
           "optional": true,
@@ -18317,7 +18474,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1268,
+        "line": 1306,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "properties": Array [
@@ -18333,7 +18490,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1274,
+            "line": 1312,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -18358,7 +18515,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1281,
+            "line": 1319,
           },
           "name": "matchLabels",
           "optional": true,
@@ -18387,7 +18544,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1584,
+        "line": 1622,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "properties": Array [
@@ -18402,7 +18559,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1590,
+            "line": 1628,
           },
           "name": "key",
           "optional": true,
@@ -18422,7 +18579,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1597,
+            "line": 1635,
           },
           "name": "operator",
           "optional": true,
@@ -18442,7 +18599,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1604,
+            "line": 1642,
           },
           "name": "values",
           "optional": true,
@@ -18472,7 +18629,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1290,
+        "line": 1328,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
       "properties": Array [
@@ -18488,7 +18645,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1296,
+            "line": 1334,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -18513,7 +18670,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1303,
+            "line": 1341,
           },
           "name": "matchLabels",
           "optional": true,
@@ -18542,7 +18699,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1613,
+        "line": 1651,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -18557,7 +18714,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1619,
+            "line": 1657,
           },
           "name": "key",
           "optional": true,
@@ -18577,7 +18734,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1626,
+            "line": 1664,
           },
           "name": "operator",
           "optional": true,
@@ -18597,7 +18754,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1633,
+            "line": 1671,
           },
           "name": "values",
           "optional": true,
@@ -18626,7 +18783,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 958,
+        "line": 996,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinity",
       "properties": Array [
@@ -18642,7 +18799,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 964,
+            "line": 1002,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -18667,7 +18824,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 971,
+            "line": 1009,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -18696,7 +18853,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1130,
+        "line": 1168,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -18711,7 +18868,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1136,
+            "line": 1174,
           },
           "name": "podAffinityTerm",
           "optional": true,
@@ -18730,7 +18887,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1143,
+            "line": 1181,
           },
           "name": "weight",
           "optional": true,
@@ -18754,7 +18911,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1312,
+        "line": 1350,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "properties": Array [
@@ -18770,7 +18927,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1339,
+            "line": 1377,
           },
           "name": "topologyKey",
           "type": Object {
@@ -18789,7 +18946,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1318,
+            "line": 1356,
           },
           "name": "labelSelector",
           "optional": true,
@@ -18809,7 +18966,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1332,
+            "line": 1370,
           },
           "name": "namespaces",
           "optional": true,
@@ -18834,7 +18991,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1325,
+            "line": 1363,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -18859,7 +19016,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1642,
+        "line": 1680,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "properties": Array [
@@ -18875,7 +19032,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1648,
+            "line": 1686,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -18900,7 +19057,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1655,
+            "line": 1693,
           },
           "name": "matchLabels",
           "optional": true,
@@ -18929,7 +19086,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1914,
+        "line": 1952,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "properties": Array [
@@ -18944,7 +19101,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1920,
+            "line": 1958,
           },
           "name": "key",
           "optional": true,
@@ -18964,7 +19121,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1927,
+            "line": 1965,
           },
           "name": "operator",
           "optional": true,
@@ -18984,7 +19141,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1934,
+            "line": 1972,
           },
           "name": "values",
           "optional": true,
@@ -19014,7 +19171,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1664,
+        "line": 1702,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
       "properties": Array [
@@ -19030,7 +19187,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1670,
+            "line": 1708,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -19055,7 +19212,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1677,
+            "line": 1715,
           },
           "name": "matchLabels",
           "optional": true,
@@ -19084,7 +19241,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1943,
+        "line": 1981,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -19099,7 +19256,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1949,
+            "line": 1987,
           },
           "name": "key",
           "optional": true,
@@ -19119,7 +19276,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1956,
+            "line": 1994,
           },
           "name": "operator",
           "optional": true,
@@ -19139,7 +19296,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1963,
+            "line": 2001,
           },
           "name": "values",
           "optional": true,
@@ -19168,7 +19325,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1152,
+        "line": 1190,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -19184,7 +19341,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1158,
+            "line": 1196,
           },
           "name": "labelSelector",
           "optional": true,
@@ -19204,7 +19361,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1172,
+            "line": 1210,
           },
           "name": "namespaces",
           "optional": true,
@@ -19229,7 +19386,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1165,
+            "line": 1203,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -19249,7 +19406,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1179,
+            "line": 1217,
           },
           "name": "topologyKey",
           "optional": true,
@@ -19274,7 +19431,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1348,
+        "line": 1386,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "properties": Array [
@@ -19290,7 +19447,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1354,
+            "line": 1392,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -19315,7 +19472,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1361,
+            "line": 1399,
           },
           "name": "matchLabels",
           "optional": true,
@@ -19344,7 +19501,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1686,
+        "line": 1724,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "properties": Array [
@@ -19359,7 +19516,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1692,
+            "line": 1730,
           },
           "name": "key",
           "optional": true,
@@ -19379,7 +19536,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1699,
+            "line": 1737,
           },
           "name": "operator",
           "optional": true,
@@ -19399,7 +19556,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1706,
+            "line": 1744,
           },
           "name": "values",
           "optional": true,
@@ -19429,7 +19586,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1370,
+        "line": 1408,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
       "properties": Array [
@@ -19445,7 +19602,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1376,
+            "line": 1414,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -19470,7 +19627,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1383,
+            "line": 1421,
           },
           "name": "matchLabels",
           "optional": true,
@@ -19499,7 +19656,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1715,
+        "line": 1753,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -19514,7 +19671,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1721,
+            "line": 1759,
           },
           "name": "key",
           "optional": true,
@@ -19534,7 +19691,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1728,
+            "line": 1766,
           },
           "name": "operator",
           "optional": true,
@@ -19554,7 +19711,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1735,
+            "line": 1773,
           },
           "name": "values",
           "optional": true,
@@ -19645,7 +19802,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 980,
+        "line": 1018,
       },
       "name": "IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
       "properties": Array [
@@ -19659,7 +19816,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 984,
+            "line": 1022,
           },
           "name": "maxSurge",
           "optional": true,
@@ -19677,7 +19834,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 989,
+            "line": 1027,
           },
           "name": "maxUnavailable",
           "optional": true,
@@ -19704,7 +19861,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1003,
+        "line": 1041,
       },
       "members": Array [
         Object {
@@ -19981,7 +20138,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 883,
+        "line": 921,
       },
       "members": Array [
         Object {
@@ -20024,7 +20181,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 902,
+        "line": 940,
       },
       "members": Array [
         Object {
@@ -20227,7 +20384,7 @@ Possible enum values:
           "name": "clusterType",
           "optional": true,
           "type": Object {
-            "primitive": "string",
+            "fqn": "lacework-agent.LaceworkAgentClusterAgentClusterType",
           },
         },
         Object {
@@ -20270,6 +20427,43 @@ Possible enum values:
         },
       ],
       "symbolId": "lacework-agent:LaceworkAgentClusterAgent",
+    },
+    "lacework-agent.LaceworkAgentClusterAgentClusterType": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentClusterAgentClusterType",
+        },
+        "summary": "Kubernetes cluster type.",
+      },
+      "fqn": "lacework-agent.LaceworkAgentClusterAgentClusterType",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 733,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "eks.",
+          },
+          "name": "EKS",
+        },
+        Object {
+          "docs": Object {
+            "summary": "gke.",
+          },
+          "name": "GKE",
+        },
+        Object {
+          "docs": Object {
+            "summary": "unknown.",
+          },
+          "name": "UNKNOWN",
+        },
+      ],
+      "name": "LaceworkAgentClusterAgentClusterType",
+      "symbolId": "lacework-agent:LaceworkAgentClusterAgentClusterType",
     },
     "lacework-agent.LaceworkAgentClusterAgentImage": Object {
       "assembly": "lacework-agent",
@@ -20434,7 +20628,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1021,
+        "line": 1059,
       },
       "members": Array [
         Object {
@@ -21145,7 +21339,7 @@ Possible enum values:
           "name": "containerRuntime",
           "optional": true,
           "type": Object {
-            "primitive": "string",
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigContainerRuntime",
           },
         },
         Object {
@@ -21315,7 +21509,7 @@ Possible enum values:
           "name": "perfmode",
           "optional": true,
           "type": Object {
-            "primitive": "string",
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigPerfmode",
           },
         },
         Object {
@@ -21446,7 +21640,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 731,
+        "line": 745,
       },
       "name": "LaceworkAgentLaceworkConfigAnonymizeIncoming",
       "properties": Array [
@@ -21461,7 +21655,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 742,
+            "line": 756,
           },
           "name": "additionalValues",
           "optional": true,
@@ -21484,7 +21678,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 735,
+            "line": 749,
           },
           "name": "netmask",
           "optional": true,
@@ -21506,7 +21700,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 749,
+        "line": 763,
       },
       "members": Array [
         Object {
@@ -21537,7 +21731,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 759,
+        "line": 773,
       },
       "name": "LaceworkAgentLaceworkConfigCmdlinefilter",
       "properties": Array [
@@ -21551,7 +21745,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 763,
+            "line": 777,
           },
           "name": "allow",
           "optional": true,
@@ -21569,7 +21763,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 768,
+            "line": 782,
           },
           "name": "disallow",
           "optional": true,
@@ -21592,7 +21786,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 775,
+        "line": 789,
       },
       "name": "LaceworkAgentLaceworkConfigCodeaware",
       "properties": Array [
@@ -21606,7 +21800,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 779,
+            "line": 793,
           },
           "name": "enable",
           "optional": true,
@@ -21616,6 +21810,42 @@ Possible enum values:
         },
       ],
       "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigCodeaware",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigContainerRuntime": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigContainerRuntime",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigContainerRuntime",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 800,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "containerd.",
+          },
+          "name": "CONTAINERD",
+        },
+        Object {
+          "docs": Object {
+            "summary": "cri-o.",
+          },
+          "name": "CRI_O",
+        },
+        Object {
+          "docs": Object {
+            "summary": "docker.",
+          },
+          "name": "DOCKER",
+        },
+      ],
+      "name": "LaceworkAgentLaceworkConfigContainerRuntime",
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigContainerRuntime",
     },
     "lacework-agent.LaceworkAgentLaceworkConfigDatacollector": Object {
       "assembly": "lacework-agent",
@@ -21628,7 +21858,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 786,
+        "line": 812,
       },
       "members": Array [
         Object {
@@ -21659,7 +21889,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 796,
+        "line": 822,
       },
       "name": "LaceworkAgentLaceworkConfigFim",
       "properties": Array [
@@ -21673,7 +21903,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 810,
+            "line": 836,
           },
           "name": "enable",
           "type": Object {
@@ -21690,7 +21920,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 815,
+            "line": 841,
           },
           "name": "fileIgnore",
           "type": Object {
@@ -21712,7 +21942,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 820,
+            "line": 846,
           },
           "name": "filePath",
           "type": Object {
@@ -21735,7 +21965,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 837,
+            "line": 863,
           },
           "name": "additionalValues",
           "optional": true,
@@ -21758,7 +21988,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 800,
+            "line": 826,
           },
           "name": "coolingPeriod",
           "optional": true,
@@ -21776,7 +22006,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 805,
+            "line": 831,
           },
           "name": "crawlInterval",
           "optional": true,
@@ -21794,7 +22024,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 825,
+            "line": 851,
           },
           "name": "noAtime",
           "optional": true,
@@ -21812,7 +22042,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 830,
+            "line": 856,
           },
           "name": "runAt",
           "optional": true,
@@ -21835,7 +22065,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 844,
+        "line": 870,
       },
       "name": "LaceworkAgentLaceworkConfigPackagescan",
       "properties": Array [
@@ -21849,7 +22079,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 848,
+            "line": 874,
           },
           "name": "enable",
           "optional": true,
@@ -21867,7 +22097,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 853,
+            "line": 879,
           },
           "name": "interval",
           "optional": true,
@@ -21877,6 +22107,42 @@ Possible enum values:
         },
       ],
       "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigPackagescan",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigPerfmode": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigPerfmode",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigPerfmode",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 902,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "lite.",
+          },
+          "name": "LITE",
+        },
+        Object {
+          "docs": Object {
+            "summary": "scan.",
+          },
+          "name": "SCAN",
+        },
+        Object {
+          "docs": Object {
+            "summary": "ebpflite.",
+          },
+          "name": "EBPFLITE",
+        },
+      ],
+      "name": "LaceworkAgentLaceworkConfigPerfmode",
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigPerfmode",
     },
     "lacework-agent.LaceworkAgentLaceworkConfigProcscan": Object {
       "assembly": "lacework-agent",
@@ -21890,7 +22156,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 860,
+        "line": 886,
       },
       "name": "LaceworkAgentLaceworkConfigProcscan",
       "properties": Array [
@@ -21904,7 +22170,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 864,
+            "line": 890,
           },
           "name": "enable",
           "optional": true,
@@ -21922,7 +22188,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 869,
+            "line": 895,
           },
           "name": "interval",
           "optional": true,
@@ -22709,7 +22975,7 @@ export interface LaceworkAgentClusterAgent {
    *
    * @schema LaceworkAgentClusterAgent#clusterType
    */
-  readonly clusterType?: string;
+  readonly clusterType?: LaceworkAgentClusterAgentClusterType;
 
   /**
    * Kubernetes cluster cloud region
@@ -22785,7 +23051,7 @@ export interface LaceworkAgentLaceworkConfig {
   /**
    * @schema LaceworkAgentLaceworkConfig#containerRuntime
    */
-  readonly containerRuntime?: string;
+  readonly containerRuntime?: LaceworkAgentLaceworkConfigContainerRuntime;
 
   /**
    * @schema LaceworkAgentLaceworkConfig#datacollector
@@ -22864,7 +23130,7 @@ export interface LaceworkAgentLaceworkConfig {
   /**
    * @schema LaceworkAgentLaceworkConfig#perfmode
    */
-  readonly perfmode?: string;
+  readonly perfmode?: LaceworkAgentLaceworkConfigPerfmode;
 
   /**
    * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
@@ -23101,6 +23367,20 @@ export interface LaceworkAgentClusterAgentImage {
 }
 
 /**
+ * Kubernetes cluster type
+ *
+ * @schema LaceworkAgentClusterAgentClusterType
+ */
+export enum LaceworkAgentClusterAgentClusterType {
+  /** eks */
+  EKS = \\"eks\\",
+  /** gke */
+  GKE = \\"gke\\",
+  /** unknown */
+  UNKNOWN = \\"unknown\\",
+}
+
+/**
  * @schema LaceworkAgentLaceworkConfigAnonymizeIncoming
  */
 export interface LaceworkAgentLaceworkConfigAnonymizeIncoming {
@@ -23153,6 +23433,18 @@ export interface LaceworkAgentLaceworkConfigCodeaware {
    */
   readonly enable?: boolean;
 
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigContainerRuntime
+ */
+export enum LaceworkAgentLaceworkConfigContainerRuntime {
+  /** containerd */
+  CONTAINERD = \\"containerd\\",
+  /** cri-o */
+  CRI_O = \\"cri-o\\",
+  /** docker */
+  DOCKER = \\"docker\\",
 }
 
 /**
@@ -23243,6 +23535,18 @@ export interface LaceworkAgentLaceworkConfigProcscan {
    */
   readonly interval?: number;
 
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigPerfmode
+ */
+export enum LaceworkAgentLaceworkConfigPerfmode {
+  /** lite */
+  LITE = \\"lite\\",
+  /** scan */
+  SCAN = \\"scan\\",
+  /** ebpflite */
+  EBPFLITE = \\"ebpflite\\",
 }
 
 /**

--- a/test/import/__snapshots__/import-helm.test.ts.snap
+++ b/test/import/__snapshots__/import-helm.test.ts.snap
@@ -4829,3 +4829,19516 @@ export class Ingressnginx extends Construct {
 ",
 }
 `;
+
+exports[`importing helm chart helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0 with python lanugage 1`] = `
+Object {
+  "author": Object {
+    "name": "generated@generated.com",
+    "roles": Array [
+      "author",
+    ],
+  },
+  "dependencies": "__omitted__",
+  "dependencyClosure": Object {
+    "cdk8s": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Org.Cdk8s",
+          "packageId": "Org.Cdk8s",
+        },
+        "go": Object {
+          "moduleName": "github.com/cdk8s-team/cdk8s-core-go",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "cdk8s",
+            "groupId": "org.cdk8s",
+          },
+          "package": "org.cdk8s",
+        },
+        "js": Object {
+          "npm": "cdk8s",
+        },
+        "python": Object {
+          "distName": "cdk8s",
+          "module": "cdk8s",
+        },
+      },
+    },
+    "constructs": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Constructs",
+          "packageId": "Constructs",
+        },
+        "go": Object {
+          "moduleName": "github.com/aws/constructs-go",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "constructs",
+            "groupId": "software.constructs",
+          },
+          "package": "software.constructs",
+        },
+        "js": Object {
+          "npm": "constructs",
+        },
+        "python": Object {
+          "distName": "constructs",
+          "module": "constructs",
+        },
+      },
+    },
+  },
+  "description": "lacework-agent",
+  "fingerprint": "<fingerprint>",
+  "homepage": "http://generated",
+  "jsiiVersion": "__omitted__",
+  "license": "UNLICENSED",
+  "metadata": Object {
+    "jsii": Object {
+      "pacmak": Object {
+        "hasDefaultInterfaces": true,
+      },
+    },
+  },
+  "name": "lacework-agent",
+  "repository": Object {
+    "type": "git",
+    "url": "http://generated",
+  },
+  "schema": "jsii/0.10.0",
+  "targets": Object {
+    "js": Object {
+      "npm": "lacework-agent",
+    },
+    "python": Object {
+      "distName": "generated",
+      "module": "lacework_agent",
+    },
+  },
+  "types": Object {
+    "lacework-agent.IoK8SApiCoreV1Affinity": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "io.k8s.api.core.v1.Affinity",
+        },
+        "summary": "Affinity is a group of affinity scheduling rules.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1Affinity",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 583,
+      },
+      "name": "IoK8SApiCoreV1Affinity",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.Affinity#nodeAffinity",
+            },
+            "summary": "Node affinity is a group of node affinity scheduling rules.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 589,
+          },
+          "name": "nodeAffinity",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinity",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.Affinity#podAffinity",
+            },
+            "summary": "Pod affinity is a group of inter pod affinity scheduling rules.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 596,
+          },
+          "name": "podAffinity",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinity",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.Affinity#podAntiAffinity",
+            },
+            "summary": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 603,
+          },
+          "name": "podAntiAffinity",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinity",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1Affinity",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinity": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinity",
+        },
+        "summary": "Node affinity is a group of node affinity scheduling rules.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinity",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 914,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinity",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinity#preferredDuringSchedulingIgnoredDuringExecution",
+            },
+            "remarks": "The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+            "summary": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 920,
+          },
+          "name": "preferredDuringSchedulingIgnoredDuringExecution",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinity#requiredDuringSchedulingIgnoredDuringExecution",
+            },
+            "remarks": "that is, it represents the OR of the selectors represented by the node selector terms.",
+            "summary": "A node selector represents the union of the results of one or more label queries over a set of nodes;",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 927,
+          },
+          "name": "requiredDuringSchedulingIgnoredDuringExecution",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinity",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+        },
+        "summary": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1035,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution#preference",
+            },
+            "remarks": "The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+            "summary": "A null or empty node selector term matches no objects.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1041,
+          },
+          "name": "preference",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight",
+            },
+            "summary": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1048,
+          },
+          "name": "weight",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
+        },
+        "remarks": "The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+        "summary": "A null or empty node selector term matches no objects.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1188,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference#matchExpressions",
+            },
+            "summary": "A list of node selector requirements by node's labels.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1194,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference#matchFields",
+            },
+            "summary": "A list of node selector requirements by node's fields.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1201,
+          },
+          "name": "matchFields",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
+        },
+        "summary": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1392,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#key",
+            },
+            "summary": "The label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1398,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#operator",
+            },
+            "remarks": "Possible enum values:
+- \`\\"DoesNotExist\\"\`
+- \`\\"Exists\\"\`
+- \`\\"Gt\\"\`
+- \`\\"In\\"\`
+- \`\\"Lt\\"\`
+- \`\\"NotIn\\"\`",
+            "summary": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1413,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+            "summary": "An array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1420,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator",
+        },
+        "remarks": "Possible enum values:
+- \`\\"DoesNotExist\\"\`
+- \`\\"Exists\\"\`
+- \`\\"Gt\\"\`
+- \`\\"In\\"\`
+- \`\\"Lt\\"\`
+- \`\\"NotIn\\"\`",
+        "summary": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1752,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "DoesNotExist.",
+          },
+          "name": "DOES_NOT_EXIST",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Exists.",
+          },
+          "name": "EXISTS",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Gt.",
+          },
+          "name": "GT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "In.",
+          },
+          "name": "IN",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Lt.",
+          },
+          "name": "LT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "NotIn.",
+          },
+          "name": "NOT_IN",
+        },
+      ],
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator",
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
+        },
+        "summary": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1429,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#key",
+            },
+            "summary": "The label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1435,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#operator",
+            },
+            "remarks": "Possible enum values:
+- \`\\"DoesNotExist\\"\`
+- \`\\"Exists\\"\`
+- \`\\"Gt\\"\`
+- \`\\"In\\"\`
+- \`\\"Lt\\"\`
+- \`\\"NotIn\\"\`",
+            "summary": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1450,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+            "summary": "An array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1457,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator",
+        },
+        "remarks": "Possible enum values:
+- \`\\"DoesNotExist\\"\`
+- \`\\"Exists\\"\`
+- \`\\"Gt\\"\`
+- \`\\"In\\"\`
+- \`\\"Lt\\"\`
+- \`\\"NotIn\\"\`",
+        "summary": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1780,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "DoesNotExist.",
+          },
+          "name": "DOES_NOT_EXIST",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Exists.",
+          },
+          "name": "EXISTS",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Gt.",
+          },
+          "name": "GT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "In.",
+          },
+          "name": "IN",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Lt.",
+          },
+          "name": "LT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "NotIn.",
+          },
+          "name": "NOT_IN",
+        },
+      ],
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator",
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+        },
+        "remarks": "that is, it represents the OR of the selectors represented by the node selector terms.",
+        "summary": "A node selector represents the union of the results of one or more label queries over a set of nodes;",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1057,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution#nodeSelectorTerms",
+            },
+            "remarks": "A list of node selector terms. The terms are ORed.",
+            "summary": "Required.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1063,
+          },
+          "name": "nodeSelectorTerms",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
+        },
+        "remarks": "The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+        "summary": "A null or empty node selector term matches no objects.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1210,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms#matchExpressions",
+            },
+            "summary": "A list of node selector requirements by node's labels.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1216,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms#matchFields",
+            },
+            "summary": "A list of node selector requirements by node's fields.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1223,
+          },
+          "name": "matchFields",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
+        },
+        "summary": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1466,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#key",
+            },
+            "summary": "The label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1472,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#operator",
+            },
+            "remarks": "Possible enum values:
+- \`\\"DoesNotExist\\"\`
+- \`\\"Exists\\"\`
+- \`\\"Gt\\"\`
+- \`\\"In\\"\`
+- \`\\"Lt\\"\`
+- \`\\"NotIn\\"\`",
+            "summary": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1487,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+            "summary": "An array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1494,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator",
+        },
+        "remarks": "Possible enum values:
+- \`\\"DoesNotExist\\"\`
+- \`\\"Exists\\"\`
+- \`\\"Gt\\"\`
+- \`\\"In\\"\`
+- \`\\"Lt\\"\`
+- \`\\"NotIn\\"\`",
+        "summary": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1808,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "DoesNotExist.",
+          },
+          "name": "DOES_NOT_EXIST",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Exists.",
+          },
+          "name": "EXISTS",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Gt.",
+          },
+          "name": "GT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "In.",
+          },
+          "name": "IN",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Lt.",
+          },
+          "name": "LT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "NotIn.",
+          },
+          "name": "NOT_IN",
+        },
+      ],
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator",
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
+        },
+        "summary": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1503,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#key",
+            },
+            "summary": "The label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1509,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#operator",
+            },
+            "remarks": "Possible enum values:
+- \`\\"DoesNotExist\\"\`
+- \`\\"Exists\\"\`
+- \`\\"Gt\\"\`
+- \`\\"In\\"\`
+- \`\\"Lt\\"\`
+- \`\\"NotIn\\"\`",
+            "summary": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1524,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+            "summary": "An array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1531,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator",
+        },
+        "remarks": "Possible enum values:
+- \`\\"DoesNotExist\\"\`
+- \`\\"Exists\\"\`
+- \`\\"Gt\\"\`
+- \`\\"In\\"\`
+- \`\\"Lt\\"\`
+- \`\\"NotIn\\"\`",
+        "summary": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1836,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "DoesNotExist.",
+          },
+          "name": "DOES_NOT_EXIST",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Exists.",
+          },
+          "name": "EXISTS",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Gt.",
+          },
+          "name": "GT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "In.",
+          },
+          "name": "IN",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Lt.",
+          },
+          "name": "LT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "NotIn.",
+          },
+          "name": "NOT_IN",
+        },
+      ],
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator",
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinity": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinity",
+        },
+        "summary": "Pod affinity is a group of inter pod affinity scheduling rules.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinity",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 936,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinity",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinity#preferredDuringSchedulingIgnoredDuringExecution",
+            },
+            "remarks": "The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+            "summary": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 942,
+          },
+          "name": "preferredDuringSchedulingIgnoredDuringExecution",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinity#requiredDuringSchedulingIgnoredDuringExecution",
+            },
+            "remarks": "If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+            "summary": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 949,
+          },
+          "name": "requiredDuringSchedulingIgnoredDuringExecution",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinity",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+        },
+        "summary": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s).",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1072,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution#podAffinityTerm",
+            },
+            "summary": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1078,
+          },
+          "name": "podAffinityTerm",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight",
+            },
+            "summary": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1085,
+          },
+          "name": "weight",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+        },
+        "summary": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1232,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#topologyKey",
+            },
+            "remarks": "Empty topologyKey is not allowed.",
+            "summary": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1259,
+          },
+          "name": "topologyKey",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#labelSelector",
+            },
+            "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "summary": "A label selector is a label query over a set of resources.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1238,
+          },
+          "name": "labelSelector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaces",
+            },
+            "remarks": "The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".",
+            "summary": "namespaces specifies a static list of namespace names that the term applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1252,
+          },
+          "name": "namespaces",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaceSelector",
+            },
+            "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "summary": "A label selector is a label query over a set of resources.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1245,
+          },
+          "name": "namespaceSelector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+        },
+        "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "summary": "A label selector is a label query over a set of resources.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1540,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchExpressions",
+            },
+            "remarks": "The requirements are ANDed.",
+            "summary": "matchExpressions is a list of label selector requirements.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1546,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchLabels",
+            },
+            "remarks": "A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.",
+            "summary": "matchLabels is a map of {key,value} pairs.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1553,
+          },
+          "name": "matchLabels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+        },
+        "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1856,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#key",
+            },
+            "summary": "key is the label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1862,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#operator",
+            },
+            "remarks": "Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "summary": "operator represents a key's relationship to a set of values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1869,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "summary": "values is an array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1876,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+        },
+        "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "summary": "A label selector is a label query over a set of resources.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1562,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchExpressions",
+            },
+            "remarks": "The requirements are ANDed.",
+            "summary": "matchExpressions is a list of label selector requirements.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1568,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchLabels",
+            },
+            "remarks": "A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.",
+            "summary": "matchLabels is a map of {key,value} pairs.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1575,
+          },
+          "name": "matchLabels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+        },
+        "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1885,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#key",
+            },
+            "summary": "key is the label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1891,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#operator",
+            },
+            "remarks": "Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "summary": "operator represents a key's relationship to a set of values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1898,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "summary": "values is an array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1905,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+        },
+        "summary": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1094,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#labelSelector",
+            },
+            "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "summary": "A label selector is a label query over a set of resources.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1100,
+          },
+          "name": "labelSelector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaces",
+            },
+            "remarks": "The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".",
+            "summary": "namespaces specifies a static list of namespace names that the term applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1114,
+          },
+          "name": "namespaces",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaceSelector",
+            },
+            "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "summary": "A label selector is a label query over a set of resources.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1107,
+          },
+          "name": "namespaceSelector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#topologyKey",
+            },
+            "remarks": "Empty topologyKey is not allowed.",
+            "summary": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1121,
+          },
+          "name": "topologyKey",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+        },
+        "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "summary": "A label selector is a label query over a set of resources.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1268,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchExpressions",
+            },
+            "remarks": "The requirements are ANDed.",
+            "summary": "matchExpressions is a list of label selector requirements.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1274,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchLabels",
+            },
+            "remarks": "A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.",
+            "summary": "matchLabels is a map of {key,value} pairs.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1281,
+          },
+          "name": "matchLabels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+        },
+        "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1584,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#key",
+            },
+            "summary": "key is the label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1590,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#operator",
+            },
+            "remarks": "Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "summary": "operator represents a key's relationship to a set of values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1597,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "summary": "values is an array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1604,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+        },
+        "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "summary": "A label selector is a label query over a set of resources.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1290,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchExpressions",
+            },
+            "remarks": "The requirements are ANDed.",
+            "summary": "matchExpressions is a list of label selector requirements.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1296,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchLabels",
+            },
+            "remarks": "A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.",
+            "summary": "matchLabels is a map of {key,value} pairs.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1303,
+          },
+          "name": "matchLabels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+        },
+        "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1613,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#key",
+            },
+            "summary": "key is the label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1619,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#operator",
+            },
+            "remarks": "Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "summary": "operator represents a key's relationship to a set of values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1626,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "summary": "values is an array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1633,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinity": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinity",
+        },
+        "summary": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinity",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 958,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinity",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinity#preferredDuringSchedulingIgnoredDuringExecution",
+            },
+            "remarks": "The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+            "summary": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 964,
+          },
+          "name": "preferredDuringSchedulingIgnoredDuringExecution",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinity#requiredDuringSchedulingIgnoredDuringExecution",
+            },
+            "remarks": "If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+            "summary": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 971,
+          },
+          "name": "requiredDuringSchedulingIgnoredDuringExecution",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinity",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+        },
+        "summary": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s).",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1130,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution#podAffinityTerm",
+            },
+            "summary": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1136,
+          },
+          "name": "podAffinityTerm",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight",
+            },
+            "summary": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1143,
+          },
+          "name": "weight",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+        },
+        "summary": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1312,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#topologyKey",
+            },
+            "remarks": "Empty topologyKey is not allowed.",
+            "summary": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1339,
+          },
+          "name": "topologyKey",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#labelSelector",
+            },
+            "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "summary": "A label selector is a label query over a set of resources.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1318,
+          },
+          "name": "labelSelector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaces",
+            },
+            "remarks": "The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".",
+            "summary": "namespaces specifies a static list of namespace names that the term applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1332,
+          },
+          "name": "namespaces",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaceSelector",
+            },
+            "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "summary": "A label selector is a label query over a set of resources.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1325,
+          },
+          "name": "namespaceSelector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+        },
+        "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "summary": "A label selector is a label query over a set of resources.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1642,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchExpressions",
+            },
+            "remarks": "The requirements are ANDed.",
+            "summary": "matchExpressions is a list of label selector requirements.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1648,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchLabels",
+            },
+            "remarks": "A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.",
+            "summary": "matchLabels is a map of {key,value} pairs.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1655,
+          },
+          "name": "matchLabels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+        },
+        "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1914,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#key",
+            },
+            "summary": "key is the label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1920,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#operator",
+            },
+            "remarks": "Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "summary": "operator represents a key's relationship to a set of values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1927,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "summary": "values is an array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1934,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+        },
+        "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "summary": "A label selector is a label query over a set of resources.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1664,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchExpressions",
+            },
+            "remarks": "The requirements are ANDed.",
+            "summary": "matchExpressions is a list of label selector requirements.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1670,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchLabels",
+            },
+            "remarks": "A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.",
+            "summary": "matchLabels is a map of {key,value} pairs.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1677,
+          },
+          "name": "matchLabels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+        },
+        "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1943,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#key",
+            },
+            "summary": "key is the label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1949,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#operator",
+            },
+            "remarks": "Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "summary": "operator represents a key's relationship to a set of values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1956,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "summary": "values is an array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1963,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+        },
+        "summary": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1152,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#labelSelector",
+            },
+            "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "summary": "A label selector is a label query over a set of resources.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1158,
+          },
+          "name": "labelSelector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaces",
+            },
+            "remarks": "The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".",
+            "summary": "namespaces specifies a static list of namespace names that the term applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1172,
+          },
+          "name": "namespaces",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaceSelector",
+            },
+            "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "summary": "A label selector is a label query over a set of resources.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1165,
+          },
+          "name": "namespaceSelector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#topologyKey",
+            },
+            "remarks": "Empty topologyKey is not allowed.",
+            "summary": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1179,
+          },
+          "name": "topologyKey",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+        },
+        "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "summary": "A label selector is a label query over a set of resources.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1348,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchExpressions",
+            },
+            "remarks": "The requirements are ANDed.",
+            "summary": "matchExpressions is a list of label selector requirements.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1354,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchLabels",
+            },
+            "remarks": "A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.",
+            "summary": "matchLabels is a map of {key,value} pairs.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1361,
+          },
+          "name": "matchLabels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+        },
+        "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1686,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#key",
+            },
+            "summary": "key is the label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1692,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#operator",
+            },
+            "remarks": "Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "summary": "operator represents a key's relationship to a set of values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1699,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "summary": "values is an array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1706,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+        },
+        "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "summary": "A label selector is a label query over a set of resources.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1370,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchExpressions",
+            },
+            "remarks": "The requirements are ANDed.",
+            "summary": "matchExpressions is a list of label selector requirements.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1376,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchLabels",
+            },
+            "remarks": "A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.",
+            "summary": "matchLabels is a map of {key,value} pairs.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1383,
+          },
+          "name": "matchLabels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+        },
+        "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1715,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#key",
+            },
+            "summary": "key is the label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1721,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#operator",
+            },
+            "remarks": "Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "summary": "operator represents a key's relationship to a set of values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1728,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "summary": "values is an array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1735,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategy": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "io.k8s.api.core.v1.DaemonSetUpdateStrategy",
+        },
+        "summary": "DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategy",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 612,
+      },
+      "name": "IoK8SApiCoreV1DaemonSetUpdateStrategy",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.DaemonSetUpdateStrategy#rollingUpdate",
+            },
+            "summary": "Spec to control the desired behavior of daemon set rolling update.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 618,
+          },
+          "name": "rollingUpdate",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.DaemonSetUpdateStrategy#type",
+            },
+            "default": "RollingUpdate.",
+            "remarks": "Possible enum values:
+- \`\\"OnDelete\\"\` Replace the old daemons only when it's killed
+- \`\\"RollingUpdate\\"\` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.",
+            "summary": "Type of daemon set update. Can be \\"RollingUpdate\\" or \\"OnDelete\\". Default is RollingUpdate.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 630,
+          },
+          "name": "type",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategyType",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1DaemonSetUpdateStrategy",
+    },
+    "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
+        },
+        "summary": "Spec to control the desired behavior of daemon set rolling update.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 980,
+      },
+      "name": "IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate#maxSurge",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 984,
+          },
+          "name": "maxSurge",
+          "optional": true,
+          "type": Object {
+            "primitive": "any",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate#maxUnavailable",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 989,
+          },
+          "name": "maxUnavailable",
+          "optional": true,
+          "type": Object {
+            "primitive": "any",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
+    },
+    "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategyType": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1DaemonSetUpdateStrategyType",
+        },
+        "default": "RollingUpdate.",
+        "remarks": "Possible enum values:
+- \`\\"OnDelete\\"\` Replace the old daemons only when it's killed
+- \`\\"RollingUpdate\\"\` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.",
+        "summary": "Type of daemon set update. Can be \\"RollingUpdate\\" or \\"OnDelete\\". Default is RollingUpdate.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategyType",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1003,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "OnDelete.",
+          },
+          "name": "ON_DELETE",
+        },
+        Object {
+          "docs": Object {
+            "summary": "RollingUpdate.",
+          },
+          "name": "ROLLING_UPDATE",
+        },
+      ],
+      "name": "IoK8SApiCoreV1DaemonSetUpdateStrategyType",
+      "symbolId": "lacework-agent:IoK8SApiCoreV1DaemonSetUpdateStrategyType",
+    },
+    "lacework-agent.IoK8SApiCoreV1LocalObjectReference": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "io.k8s.api.core.v1.LocalObjectReference",
+        },
+        "summary": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1LocalObjectReference",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 650,
+      },
+      "name": "IoK8SApiCoreV1LocalObjectReference",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.LocalObjectReference#name",
+            },
+            "remarks": "More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+            "summary": "Name of the referent.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 656,
+          },
+          "name": "name",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1LocalObjectReference",
+    },
+    "lacework-agent.IoK8SApiCoreV1ResourceRequirements": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "io.k8s.api.core.v1.ResourceRequirements",
+        },
+        "summary": "ResourceRequirements describes the compute resource requirements.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1ResourceRequirements",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 508,
+      },
+      "name": "IoK8SApiCoreV1ResourceRequirements",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.ResourceRequirements#limits",
+            },
+            "remarks": "More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+            "summary": "Limits describes the maximum amount of compute resources allowed.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 514,
+          },
+          "name": "limits",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.ResourceRequirements#requests",
+            },
+            "remarks": "If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+            "summary": "Requests describes the minimum amount of compute resources required.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 521,
+          },
+          "name": "requests",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1ResourceRequirements",
+    },
+    "lacework-agent.IoK8SApiCoreV1Toleration": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "io.k8s.api.core.v1.Toleration",
+        },
+        "summary": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1Toleration",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 530,
+      },
+      "name": "IoK8SApiCoreV1Toleration",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.Toleration#effect",
+            },
+            "remarks": "Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+Possible enum values:
+- \`\\"NoExecute\\"\` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+- \`\\"NoSchedule\\"\` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+- \`\\"PreferNoSchedule\\"\` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.",
+            "summary": "Effect indicates the taint effect to match.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 541,
+          },
+          "name": "effect",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1TolerationEffect",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.Toleration#key",
+            },
+            "remarks": "Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+            "summary": "Key is the taint key that the toleration applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 548,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.Toleration#operator",
+            },
+            "default": "Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+            "remarks": "Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+Possible enum values:
+- \`\\"Equal\\"\`
+- \`\\"Exists\\"\`",
+            "summary": "Operator represents a key's relationship to the value.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 560,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1TolerationOperator",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.Toleration#tolerationSeconds",
+            },
+            "remarks": "By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+            "summary": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 567,
+          },
+          "name": "tolerationSeconds",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.Toleration#value",
+            },
+            "remarks": "If the operator is Exists, the value should be empty, otherwise just a regular string.",
+            "summary": "Value is the taint value the toleration matches to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 574,
+          },
+          "name": "value",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1Toleration",
+    },
+    "lacework-agent.IoK8SApiCoreV1TolerationEffect": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1TolerationEffect",
+        },
+        "remarks": "Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+Possible enum values:
+- \`\\"NoExecute\\"\` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+- \`\\"NoSchedule\\"\` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+- \`\\"PreferNoSchedule\\"\` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.",
+        "summary": "Effect indicates the taint effect to match.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1TolerationEffect",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 883,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "NoExecute.",
+          },
+          "name": "NO_EXECUTE",
+        },
+        Object {
+          "docs": Object {
+            "summary": "NoSchedule.",
+          },
+          "name": "NO_SCHEDULE",
+        },
+        Object {
+          "docs": Object {
+            "summary": "PreferNoSchedule.",
+          },
+          "name": "PREFER_NO_SCHEDULE",
+        },
+      ],
+      "name": "IoK8SApiCoreV1TolerationEffect",
+      "symbolId": "lacework-agent:IoK8SApiCoreV1TolerationEffect",
+    },
+    "lacework-agent.IoK8SApiCoreV1TolerationOperator": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1TolerationOperator",
+        },
+        "default": "Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+        "remarks": "Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+Possible enum values:
+- \`\\"Equal\\"\`
+- \`\\"Exists\\"\`",
+        "summary": "Operator represents a key's relationship to the value.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1TolerationOperator",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 902,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "Equal.",
+          },
+          "name": "EQUAL",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Exists.",
+          },
+          "name": "EXISTS",
+        },
+      ],
+      "name": "IoK8SApiCoreV1TolerationOperator",
+      "symbolId": "lacework-agent:IoK8SApiCoreV1TolerationOperator",
+    },
+    "lacework-agent.LaceworkAgentCloudservice": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentCloudservice",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentCloudservice",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 235,
+      },
+      "name": "LaceworkAgentCloudservice",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentCloudservice#gke",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 239,
+          },
+          "name": "gke",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentCloudserviceGke",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentCloudservice",
+    },
+    "lacework-agent.LaceworkAgentCloudserviceGke": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentCloudserviceGke",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentCloudserviceGke",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 637,
+      },
+      "name": "LaceworkAgentCloudserviceGke",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentCloudserviceGke#autopilot",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 641,
+          },
+          "name": "autopilot",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentCloudserviceGke",
+    },
+    "lacework-agent.LaceworkAgentClusterAgent": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentClusterAgent",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentClusterAgent",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 319,
+      },
+      "name": "LaceworkAgentClusterAgent",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgent#enable",
+            },
+            "summary": "Enable cluster agent.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 330,
+          },
+          "name": "enable",
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgent#image",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 323,
+          },
+          "name": "image",
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentClusterAgentImage",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgent#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 365,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgent#clusterRegion",
+            },
+            "summary": "Kubernetes cluster cloud region.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 344,
+          },
+          "name": "clusterRegion",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgent#clusterType",
+            },
+            "summary": "Kubernetes cluster type.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 337,
+          },
+          "name": "clusterType",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgent#scrapeInitialDelayMins",
+            },
+            "summary": "Cluster mode agent's initial delay of cluster scraping after startup in minutes.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 351,
+          },
+          "name": "scrapeInitialDelayMins",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgent#scrapeIntervalMins",
+            },
+            "summary": "Cluster mode agent's scrape interval in minutes.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 358,
+          },
+          "name": "scrapeIntervalMins",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentClusterAgent",
+    },
+    "lacework-agent.LaceworkAgentClusterAgentImage": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentClusterAgentImage",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentClusterAgentImage",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 683,
+      },
+      "name": "LaceworkAgentClusterAgentImage",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgentImage#pullPolicy",
+            },
+            "default": "Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+            "remarks": "One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+Possible enum values:
+- \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+- \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+- \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+            "summary": "Image pull policy.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 702,
+          },
+          "name": "pullPolicy",
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentClusterAgentImagePullPolicy",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgentImage#registry",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 707,
+          },
+          "name": "registry",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgentImage#repository",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 712,
+          },
+          "name": "repository",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgentImage#tag",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 717,
+          },
+          "name": "tag",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgentImage#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 724,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgentImage#imagePullSecrets",
+            },
+            "remarks": "If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+            "summary": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 689,
+          },
+          "name": "imagePullSecrets",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1LocalObjectReference",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentClusterAgentImage",
+    },
+    "lacework-agent.LaceworkAgentClusterAgentImagePullPolicy": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentClusterAgentImagePullPolicy",
+        },
+        "default": "Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+        "remarks": "One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+Possible enum values:
+- \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+- \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+- \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+        "summary": "Image pull policy.",
+      },
+      "fqn": "lacework-agent.LaceworkAgentClusterAgentImagePullPolicy",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1021,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "Always.",
+          },
+          "name": "ALWAYS",
+        },
+        Object {
+          "docs": Object {
+            "summary": "IfNotPresent.",
+          },
+          "name": "IF_NOT_PRESENT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Never.",
+          },
+          "name": "NEVER",
+        },
+      ],
+      "name": "LaceworkAgentClusterAgentImagePullPolicy",
+      "symbolId": "lacework-agent:LaceworkAgentClusterAgentImagePullPolicy",
+    },
+    "lacework-agent.LaceworkAgentDaemonset": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentDaemonset",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentDaemonset",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 153,
+      },
+      "name": "LaceworkAgentDaemonset",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDaemonset#affinity",
+            },
+            "summary": "If specified, the pod's scheduling constraints.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 159,
+          },
+          "name": "affinity",
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1Affinity",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDaemonset#updateStrategy",
+            },
+            "summary": "An update strategy to replace existing DaemonSet pods with new pods.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 166,
+          },
+          "name": "updateStrategy",
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategy",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentDaemonset",
+    },
+    "lacework-agent.LaceworkAgentDatacollector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentDatacollector",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentDatacollector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 246,
+      },
+      "name": "LaceworkAgentDatacollector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDatacollector#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 259,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDatacollector#enable",
+            },
+            "summary": "Enable lacework datacollector.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 252,
+          },
+          "name": "enable",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentDatacollector",
+    },
+    "lacework-agent.LaceworkAgentDeployment": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentDeployment",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentDeployment",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 173,
+      },
+      "name": "LaceworkAgentDeployment",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDeployment#affinity",
+            },
+            "summary": "If specified, the pod's scheduling constraints.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 179,
+          },
+          "name": "affinity",
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1Affinity",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDeployment#updateStrategy",
+            },
+            "summary": "An update strategy to replace existing DaemonSet pods with new pods.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 186,
+          },
+          "name": "updateStrategy",
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategy",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDeployment#priorityClassCreate",
+            },
+            "summary": "If specified, a priority class is created and used to deploy agent.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 207,
+          },
+          "name": "priorityClassCreate",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDeployment#priorityClassName",
+            },
+            "remarks": "\\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+            "summary": "If specified, indicates the pod's priority.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 200,
+          },
+          "name": "priorityClassName",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDeployment#priorityClassPreemptionPolicy",
+            },
+            "summary": "If specified, it determines if agent pod can preempt a pod with a lower a priority.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 214,
+          },
+          "name": "priorityClassPreemptionPolicy",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDeployment#priorityClassValue",
+            },
+            "summary": "If specified, it represents the priority class value to use.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 221,
+          },
+          "name": "priorityClassValue",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDeployment#resources",
+            },
+            "remarks": "Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+            "summary": "Compute Resources required by this container.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 193,
+          },
+          "name": "resources",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1ResourceRequirements",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDeployment#tolerations",
+            },
+            "summary": "If specified, the pod's tolerations.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 228,
+          },
+          "name": "tolerations",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1Toleration",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentDeployment",
+    },
+    "lacework-agent.LaceworkAgentImage": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentImage",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentImage",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 266,
+      },
+      "name": "LaceworkAgentImage",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentImage#pullPolicy",
+            },
+            "default": "Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+            "remarks": "One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+Possible enum values:
+- \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+- \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+- \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+            "summary": "Image pull policy.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 285,
+          },
+          "name": "pullPolicy",
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentImagePullPolicy",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentImage#registry",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 290,
+          },
+          "name": "registry",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentImage#repository",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 295,
+          },
+          "name": "repository",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentImage#tag",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 300,
+          },
+          "name": "tag",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentImage#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 312,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentImage#imagePullSecrets",
+            },
+            "remarks": "If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+            "summary": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 272,
+          },
+          "name": "imagePullSecrets",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1LocalObjectReference",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentImage#overrideValue",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 305,
+          },
+          "name": "overrideValue",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentImage",
+    },
+    "lacework-agent.LaceworkAgentImagePullPolicy": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentImagePullPolicy",
+        },
+        "default": "Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+        "remarks": "One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+Possible enum values:
+- \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+- \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+- \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+        "summary": "Image pull policy.",
+      },
+      "fqn": "lacework-agent.LaceworkAgentImagePullPolicy",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 671,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "Always.",
+          },
+          "name": "ALWAYS",
+        },
+        Object {
+          "docs": Object {
+            "summary": "IfNotPresent.",
+          },
+          "name": "IF_NOT_PRESENT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Never.",
+          },
+          "name": "NEVER",
+        },
+      ],
+      "name": "LaceworkAgentImagePullPolicy",
+      "symbolId": "lacework-agent:LaceworkAgentImagePullPolicy",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfig": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfig",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfig",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 372,
+      },
+      "name": "LaceworkAgentLaceworkConfig",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#accessToken",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 376,
+          },
+          "name": "accessToken",
+          "type": Object {
+            "primitive": "any",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 499,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#annotations",
+            },
+            "remarks": "They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+            "summary": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 388,
+          },
+          "name": "annotations",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#anonymizeIncoming",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 381,
+          },
+          "name": "anonymizeIncoming",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigAnonymizeIncoming",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#autoUpgrade",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 393,
+          },
+          "name": "autoUpgrade",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigAutoUpgrade",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#cmdlinefilter",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 398,
+          },
+          "name": "cmdlinefilter",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigCmdlinefilter",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#codeaware",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 403,
+          },
+          "name": "codeaware",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigCodeaware",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#containerEngineEndpoint",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 408,
+          },
+          "name": "containerEngineEndpoint",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#containerRuntime",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 413,
+          },
+          "name": "containerRuntime",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#datacollector",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 418,
+          },
+          "name": "datacollector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigDatacollector",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#env",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 447,
+          },
+          "name": "env",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#fim",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 452,
+          },
+          "name": "fim",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigFim",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#k8sNodeScrapeIntervalMins",
+            },
+            "summary": "Kubernetes node's scrape interval in minutes.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 425,
+          },
+          "name": "k8SNodeScrapeIntervalMins",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#kubernetesCluster",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 430,
+          },
+          "name": "kubernetesCluster",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#labels",
+            },
+            "remarks": "May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+            "summary": "Map of string keys and values that can be used to organize and categorize (scope and select) objects.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 437,
+          },
+          "name": "labels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#metadataRequestInterval",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 442,
+          },
+          "name": "metadataRequestInterval",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#packagescan",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 457,
+          },
+          "name": "packagescan",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigPackagescan",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#perfmode",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 492,
+          },
+          "name": "perfmode",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#procscan",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 462,
+          },
+          "name": "procscan",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigProcscan",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#proxyUrl",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 467,
+          },
+          "name": "proxyUrl",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#serverUrl",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 472,
+          },
+          "name": "serverUrl",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#serviceAccountName",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 477,
+          },
+          "name": "serviceAccountName",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#stdoutLogging",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 482,
+          },
+          "name": "stdoutLogging",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#tags",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 487,
+          },
+          "name": "tags",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfig",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigAnonymizeIncoming": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigAnonymizeIncoming",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigAnonymizeIncoming",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 731,
+      },
+      "name": "LaceworkAgentLaceworkConfigAnonymizeIncoming",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigAnonymizeIncoming#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 742,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigAnonymizeIncoming#netmask",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 735,
+          },
+          "name": "netmask",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigAnonymizeIncoming",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigAutoUpgrade": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigAutoUpgrade",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigAutoUpgrade",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 749,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "disable.",
+          },
+          "name": "DISABLE",
+        },
+        Object {
+          "docs": Object {
+            "summary": "enable.",
+          },
+          "name": "ENABLE",
+        },
+      ],
+      "name": "LaceworkAgentLaceworkConfigAutoUpgrade",
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigAutoUpgrade",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigCmdlinefilter": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigCmdlinefilter",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigCmdlinefilter",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 759,
+      },
+      "name": "LaceworkAgentLaceworkConfigCmdlinefilter",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigCmdlinefilter#allow",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 763,
+          },
+          "name": "allow",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigCmdlinefilter#disallow",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 768,
+          },
+          "name": "disallow",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigCmdlinefilter",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigCodeaware": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigCodeaware",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigCodeaware",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 775,
+      },
+      "name": "LaceworkAgentLaceworkConfigCodeaware",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigCodeaware#enable",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 779,
+          },
+          "name": "enable",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigCodeaware",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigDatacollector": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigDatacollector",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigDatacollector",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 786,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "disable.",
+          },
+          "name": "DISABLE",
+        },
+        Object {
+          "docs": Object {
+            "summary": "enable.",
+          },
+          "name": "ENABLE",
+        },
+      ],
+      "name": "LaceworkAgentLaceworkConfigDatacollector",
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigDatacollector",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigFim": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigFim",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigFim",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 796,
+      },
+      "name": "LaceworkAgentLaceworkConfigFim",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigFim#enable",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 810,
+          },
+          "name": "enable",
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigFim#fileIgnore",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 815,
+          },
+          "name": "fileIgnore",
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigFim#filePath",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 820,
+          },
+          "name": "filePath",
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigFim#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 837,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigFim#coolingPeriod",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 800,
+          },
+          "name": "coolingPeriod",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigFim#crawlInterval",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 805,
+          },
+          "name": "crawlInterval",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigFim#noAtime",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 825,
+          },
+          "name": "noAtime",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigFim#runAt",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 830,
+          },
+          "name": "runAt",
+          "optional": true,
+          "type": Object {
+            "primitive": "any",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigFim",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigPackagescan": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigPackagescan",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigPackagescan",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 844,
+      },
+      "name": "LaceworkAgentLaceworkConfigPackagescan",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigPackagescan#enable",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 848,
+          },
+          "name": "enable",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigPackagescan#interval",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 853,
+          },
+          "name": "interval",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigPackagescan",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigProcscan": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigProcscan",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigProcscan",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 860,
+      },
+      "name": "LaceworkAgentLaceworkConfigProcscan",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigProcscan#enable",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 864,
+          },
+          "name": "enable",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigProcscan#interval",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 869,
+          },
+          "name": "interval",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigProcscan",
+    },
+    "lacework-agent.Laceworkagent": Object {
+      "assembly": "lacework-agent",
+      "base": "constructs.Construct",
+      "fqn": "lacework-agent.Laceworkagent",
+      "initializer": Object {
+        "locationInModule": Object {
+          "filename": "lacework-agent.ts",
+          "line": 14,
+        },
+        "parameters": Array [
+          Object {
+            "name": "scope",
+            "type": Object {
+              "fqn": "constructs.Construct",
+            },
+          },
+          Object {
+            "name": "id",
+            "type": Object {
+              "primitive": "string",
+            },
+          },
+          Object {
+            "name": "props",
+            "type": Object {
+              "fqn": "lacework-agent.LaceworkagentProps",
+            },
+          },
+        ],
+      },
+      "kind": "class",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 13,
+      },
+      "name": "Laceworkagent",
+      "symbolId": "lacework-agent:Laceworkagent",
+    },
+    "lacework-agent.LaceworkagentProps": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "fqn": "lacework-agent.LaceworkagentProps",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 5,
+      },
+      "name": "LaceworkagentProps",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 10,
+          },
+          "name": "values",
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkagentValues",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 8,
+          },
+          "name": "helmExecutable",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 9,
+          },
+          "name": "helmFlags",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 6,
+          },
+          "name": "namespace",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 7,
+          },
+          "name": "releaseName",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkagentProps",
+    },
+    "lacework-agent.LaceworkagentValues": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "lacework-agent",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkagentValues",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 58,
+      },
+      "name": "LaceworkagentValues",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#laceworkConfig",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 97,
+          },
+          "name": "laceworkConfig",
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfig",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 146,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#cloudservice",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 77,
+          },
+          "name": "cloudservice",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentCloudservice",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#clusterAgent",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 92,
+          },
+          "name": "clusterAgent",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentClusterAgent",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#daemonset",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 67,
+          },
+          "name": "daemonset",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentDaemonset",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#datacollector",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 82,
+          },
+          "name": "datacollector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentDatacollector",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#deployment",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 72,
+          },
+          "name": "deployment",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentDeployment",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#global",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 62,
+          },
+          "name": "global",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#image",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 87,
+          },
+          "name": "image",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentImage",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#priorityClassCreate",
+            },
+            "summary": "If specified, a priority class is created and used to deploy agent.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 118,
+          },
+          "name": "priorityClassCreate",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#priorityClassName",
+            },
+            "remarks": "\\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+            "summary": "If specified, indicates the pod's priority.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 111,
+          },
+          "name": "priorityClassName",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#priorityClassPreemptionPolicy",
+            },
+            "summary": "If specified, it determines if agent pod can preempt a pod with a lower a priority.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 125,
+          },
+          "name": "priorityClassPreemptionPolicy",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#priorityClassValue",
+            },
+            "summary": "If specified, it represents the priority class value to use.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 132,
+          },
+          "name": "priorityClassValue",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#resources",
+            },
+            "remarks": "Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+            "summary": "Compute Resources required by this container.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 104,
+          },
+          "name": "resources",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1ResourceRequirements",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#tolerations",
+            },
+            "summary": "If specified, the pod's tolerations.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 139,
+          },
+          "name": "tolerations",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1Toleration",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkagentValues",
+    },
+  },
+  "version": "0.0.0",
+}
+`;
+
+exports[`importing helm chart helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0 with python lanugage 2`] = `
+Object {
+  "lacework_agent/__init__.py": "import abc
+import builtins
+import datetime
+import enum
+import typing
+
+import jsii
+import publication
+import typing_extensions
+
+from typeguard import check_type
+
+from ._jsii import *
+
+import constructs as _constructs_77d1e7e8
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1Affinity\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"node_affinity\\": \\"nodeAffinity\\",
+        \\"pod_affinity\\": \\"podAffinity\\",
+        \\"pod_anti_affinity\\": \\"podAntiAffinity\\",
+    },
+)
+class IoK8SApiCoreV1Affinity:
+    def __init__(
+        self,
+        *,
+        node_affinity: typing.Optional[typing.Union[\\"IoK8SApiCoreV1AffinityNodeAffinity\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        pod_affinity: typing.Optional[typing.Union[\\"IoK8SApiCoreV1AffinityPodAffinity\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        pod_anti_affinity: typing.Optional[typing.Union[\\"IoK8SApiCoreV1AffinityPodAntiAffinity\\", typing.Dict[builtins.str, typing.Any]]] = None,
+    ) -> None:
+        '''Affinity is a group of affinity scheduling rules.
+
+        :param node_affinity: Node affinity is a group of node affinity scheduling rules.
+        :param pod_affinity: Pod affinity is a group of inter pod affinity scheduling rules.
+        :param pod_anti_affinity: Pod anti affinity is a group of inter pod anti affinity scheduling rules.
+
+        :schema: io.k8s.api.core.v1.Affinity
+        '''
+        if isinstance(node_affinity, dict):
+            node_affinity = IoK8SApiCoreV1AffinityNodeAffinity(**node_affinity)
+        if isinstance(pod_affinity, dict):
+            pod_affinity = IoK8SApiCoreV1AffinityPodAffinity(**pod_affinity)
+        if isinstance(pod_anti_affinity, dict):
+            pod_anti_affinity = IoK8SApiCoreV1AffinityPodAntiAffinity(**pod_anti_affinity)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__dcbd3c1d64c57915cdfe4d3e9c252dc593c38b7af2c271606308ad2dd0688fca)
+            check_type(argname=\\"argument node_affinity\\", value=node_affinity, expected_type=type_hints[\\"node_affinity\\"])
+            check_type(argname=\\"argument pod_affinity\\", value=pod_affinity, expected_type=type_hints[\\"pod_affinity\\"])
+            check_type(argname=\\"argument pod_anti_affinity\\", value=pod_anti_affinity, expected_type=type_hints[\\"pod_anti_affinity\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if node_affinity is not None:
+            self._values[\\"node_affinity\\"] = node_affinity
+        if pod_affinity is not None:
+            self._values[\\"pod_affinity\\"] = pod_affinity
+        if pod_anti_affinity is not None:
+            self._values[\\"pod_anti_affinity\\"] = pod_anti_affinity
+
+    @builtins.property
+    def node_affinity(self) -> typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinity\\"]:
+        '''Node affinity is a group of node affinity scheduling rules.
+
+        :schema: io.k8s.api.core.v1.Affinity#nodeAffinity
+        '''
+        result = self._values.get(\\"node_affinity\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinity\\"], result)
+
+    @builtins.property
+    def pod_affinity(self) -> typing.Optional[\\"IoK8SApiCoreV1AffinityPodAffinity\\"]:
+        '''Pod affinity is a group of inter pod affinity scheduling rules.
+
+        :schema: io.k8s.api.core.v1.Affinity#podAffinity
+        '''
+        result = self._values.get(\\"pod_affinity\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityPodAffinity\\"], result)
+
+    @builtins.property
+    def pod_anti_affinity(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityPodAntiAffinity\\"]:
+        '''Pod anti affinity is a group of inter pod anti affinity scheduling rules.
+
+        :schema: io.k8s.api.core.v1.Affinity#podAntiAffinity
+        '''
+        result = self._values.get(\\"pod_anti_affinity\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityPodAntiAffinity\\"], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1Affinity(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityNodeAffinity\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"preferred_during_scheduling_ignored_during_execution\\": \\"preferredDuringSchedulingIgnoredDuringExecution\\",
+        \\"required_during_scheduling_ignored_during_execution\\": \\"requiredDuringSchedulingIgnoredDuringExecution\\",
+    },
+)
+class IoK8SApiCoreV1AffinityNodeAffinity:
+    def __init__(
+        self,
+        *,
+        preferred_during_scheduling_ignored_during_execution: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+        required_during_scheduling_ignored_during_execution: typing.Optional[typing.Union[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution\\", typing.Dict[builtins.str, typing.Any]]] = None,
+    ) -> None:
+        '''Node affinity is a group of node affinity scheduling rules.
+
+        :param preferred_during_scheduling_ignored_during_execution: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+        :param required_during_scheduling_ignored_during_execution: A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinity
+        '''
+        if isinstance(required_during_scheduling_ignored_during_execution, dict):
+            required_during_scheduling_ignored_during_execution = IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution(**required_during_scheduling_ignored_during_execution)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__83fb7082ba953b5b9e787cc0ee59a9bef2197db6a48b11240fdf117606315a5a)
+            check_type(argname=\\"argument preferred_during_scheduling_ignored_during_execution\\", value=preferred_during_scheduling_ignored_during_execution, expected_type=type_hints[\\"preferred_during_scheduling_ignored_during_execution\\"])
+            check_type(argname=\\"argument required_during_scheduling_ignored_during_execution\\", value=required_during_scheduling_ignored_during_execution, expected_type=type_hints[\\"required_during_scheduling_ignored_during_execution\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if preferred_during_scheduling_ignored_during_execution is not None:
+            self._values[\\"preferred_during_scheduling_ignored_during_execution\\"] = preferred_during_scheduling_ignored_during_execution
+        if required_during_scheduling_ignored_during_execution is not None:
+            self._values[\\"required_during_scheduling_ignored_during_execution\\"] = required_during_scheduling_ignored_during_execution
+
+    @builtins.property
+    def preferred_during_scheduling_ignored_during_execution(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution\\"]]:
+        '''The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.
+
+        The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinity#preferredDuringSchedulingIgnoredDuringExecution
+        '''
+        result = self._values.get(\\"preferred_during_scheduling_ignored_during_execution\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution\\"]], result)
+
+    @builtins.property
+    def required_during_scheduling_ignored_during_execution(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution\\"]:
+        '''A node selector represents the union of the results of one or more label queries over a set of nodes;
+
+        that is, it represents the OR of the selectors represented by the node selector terms.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinity#requiredDuringSchedulingIgnoredDuringExecution
+        '''
+        result = self._values.get(\\"required_during_scheduling_ignored_during_execution\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution\\"], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityNodeAffinity(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"preference\\": \\"preference\\", \\"weight\\": \\"weight\\"},
+)
+class IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution:
+    def __init__(
+        self,
+        *,
+        preference: typing.Optional[typing.Union[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        weight: typing.Optional[jsii.Number] = None,
+    ) -> None:
+        '''An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+
+        :param preference: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+        :param weight: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution
+        '''
+        if isinstance(preference, dict):
+            preference = IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference(**preference)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__3bc3a7ad7604790369045dfb4698addef29a8a8a6153811d9f7dd8f99e3ee359)
+            check_type(argname=\\"argument preference\\", value=preference, expected_type=type_hints[\\"preference\\"])
+            check_type(argname=\\"argument weight\\", value=weight, expected_type=type_hints[\\"weight\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if preference is not None:
+            self._values[\\"preference\\"] = preference
+        if weight is not None:
+            self._values[\\"weight\\"] = weight
+
+    @builtins.property
+    def preference(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference\\"]:
+        '''A null or empty node selector term matches no objects.
+
+        The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution#preference
+        '''
+        result = self._values.get(\\"preference\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference\\"], result)
+
+    @builtins.property
+    def weight(self) -> typing.Optional[jsii.Number]:
+        '''Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
+        '''
+        result = self._values.get(\\"weight\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"match_expressions\\": \\"matchExpressions\\",
+        \\"match_fields\\": \\"matchFields\\",
+    },
+)
+class IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference:
+    def __init__(
+        self,
+        *,
+        match_expressions: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+        match_fields: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+    ) -> None:
+        '''A null or empty node selector term matches no objects.
+
+        The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+
+        :param match_expressions: A list of node selector requirements by node's labels.
+        :param match_fields: A list of node selector requirements by node's fields.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__41dee617dee988ead026c7bad2ebb4fae531007cc7f48f0db25cfa20dca41762)
+            check_type(argname=\\"argument match_expressions\\", value=match_expressions, expected_type=type_hints[\\"match_expressions\\"])
+            check_type(argname=\\"argument match_fields\\", value=match_fields, expected_type=type_hints[\\"match_fields\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if match_expressions is not None:
+            self._values[\\"match_expressions\\"] = match_expressions
+        if match_fields is not None:
+            self._values[\\"match_fields\\"] = match_fields
+
+    @builtins.property
+    def match_expressions(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions\\"]]:
+        '''A list of node selector requirements by node's labels.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference#matchExpressions
+        '''
+        result = self._values.get(\\"match_expressions\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions\\"]], result)
+
+    @builtins.property
+    def match_fields(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields\\"]]:
+        '''A list of node selector requirements by node's fields.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference#matchFields
+        '''
+        result = self._values.get(\\"match_fields\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields\\"]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"key\\": \\"key\\", \\"operator\\": \\"operator\\", \\"values\\": \\"values\\"},
+)
+class IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions:
+    def __init__(
+        self,
+        *,
+        key: typing.Optional[builtins.str] = None,
+        operator: typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator\\"] = None,
+        values: typing.Optional[typing.Sequence[builtins.str]] = None,
+    ) -> None:
+        '''A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+        :param key: The label key that the selector applies to.
+        :param operator: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt. Possible enum values: - \`\`\\"DoesNotExist\\"\`\` - \`\`\\"Exists\\"\`\` - \`\`\\"Gt\\"\`\` - \`\`\\"In\\"\`\` - \`\`\\"Lt\\"\`\` - \`\`\\"NotIn\\"\`\`
+        :param values: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__3730cdd540fb8e7d48cf1be08570870a521033bbdb76cecc74c8fb287aebc010)
+            check_type(argname=\\"argument key\\", value=key, expected_type=type_hints[\\"key\\"])
+            check_type(argname=\\"argument operator\\", value=operator, expected_type=type_hints[\\"operator\\"])
+            check_type(argname=\\"argument values\\", value=values, expected_type=type_hints[\\"values\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if key is not None:
+            self._values[\\"key\\"] = key
+        if operator is not None:
+            self._values[\\"operator\\"] = operator
+        if values is not None:
+            self._values[\\"values\\"] = values
+
+    @builtins.property
+    def key(self) -> typing.Optional[builtins.str]:
+        '''The label key that the selector applies to.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#key
+        '''
+        result = self._values.get(\\"key\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def operator(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator\\"]:
+        '''Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+        Possible enum values:
+
+        - \`\`\\"DoesNotExist\\"\`\`
+        - \`\`\\"Exists\\"\`\`
+        - \`\`\\"Gt\\"\`\`
+        - \`\`\\"In\\"\`\`
+        - \`\`\\"Lt\\"\`\`
+        - \`\`\\"NotIn\\"\`\`
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#operator
+        '''
+        result = self._values.get(\\"operator\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator\\"], result)
+
+    @builtins.property
+    def values(self) -> typing.Optional[typing.List[builtins.str]]:
+        '''An array of string values.
+
+        If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#values
+        '''
+        result = self._values.get(\\"values\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.enum(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator\\"
+)
+class IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator(
+    enum.Enum,
+):
+    '''Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+    Possible enum values:
+
+    - \`\`\\"DoesNotExist\\"\`\`
+    - \`\`\\"Exists\\"\`\`
+    - \`\`\\"Gt\\"\`\`
+    - \`\`\\"In\\"\`\`
+    - \`\`\\"Lt\\"\`\`
+    - \`\`\\"NotIn\\"\`\`
+
+    :schema: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator
+    '''
+
+    DOES_NOT_EXIST = \\"DOES_NOT_EXIST\\"
+    '''DoesNotExist.'''
+    EXISTS = \\"EXISTS\\"
+    '''Exists.'''
+    GT = \\"GT\\"
+    '''Gt.'''
+    IN = \\"IN\\"
+    '''In.'''
+    LT = \\"LT\\"
+    '''Lt.'''
+    NOT_IN = \\"NOT_IN\\"
+    '''NotIn.'''
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"key\\": \\"key\\", \\"operator\\": \\"operator\\", \\"values\\": \\"values\\"},
+)
+class IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields:
+    def __init__(
+        self,
+        *,
+        key: typing.Optional[builtins.str] = None,
+        operator: typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator\\"] = None,
+        values: typing.Optional[typing.Sequence[builtins.str]] = None,
+    ) -> None:
+        '''A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+        :param key: The label key that the selector applies to.
+        :param operator: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt. Possible enum values: - \`\`\\"DoesNotExist\\"\`\` - \`\`\\"Exists\\"\`\` - \`\`\\"Gt\\"\`\` - \`\`\\"In\\"\`\` - \`\`\\"Lt\\"\`\` - \`\`\\"NotIn\\"\`\`
+        :param values: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__7b9dade3151f99e1afdce33c41e3c8dd8d3c83a16e10b28ddaf5ea28a3e22ada)
+            check_type(argname=\\"argument key\\", value=key, expected_type=type_hints[\\"key\\"])
+            check_type(argname=\\"argument operator\\", value=operator, expected_type=type_hints[\\"operator\\"])
+            check_type(argname=\\"argument values\\", value=values, expected_type=type_hints[\\"values\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if key is not None:
+            self._values[\\"key\\"] = key
+        if operator is not None:
+            self._values[\\"operator\\"] = operator
+        if values is not None:
+            self._values[\\"values\\"] = values
+
+    @builtins.property
+    def key(self) -> typing.Optional[builtins.str]:
+        '''The label key that the selector applies to.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#key
+        '''
+        result = self._values.get(\\"key\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def operator(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator\\"]:
+        '''Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+        Possible enum values:
+
+        - \`\`\\"DoesNotExist\\"\`\`
+        - \`\`\\"Exists\\"\`\`
+        - \`\`\\"Gt\\"\`\`
+        - \`\`\\"In\\"\`\`
+        - \`\`\\"Lt\\"\`\`
+        - \`\`\\"NotIn\\"\`\`
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#operator
+        '''
+        result = self._values.get(\\"operator\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator\\"], result)
+
+    @builtins.property
+    def values(self) -> typing.Optional[typing.List[builtins.str]]:
+        '''An array of string values.
+
+        If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#values
+        '''
+        result = self._values.get(\\"values\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.enum(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator\\"
+)
+class IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator(
+    enum.Enum,
+):
+    '''Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+    Possible enum values:
+
+    - \`\`\\"DoesNotExist\\"\`\`
+    - \`\`\\"Exists\\"\`\`
+    - \`\`\\"Gt\\"\`\`
+    - \`\`\\"In\\"\`\`
+    - \`\`\\"Lt\\"\`\`
+    - \`\`\\"NotIn\\"\`\`
+
+    :schema: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator
+    '''
+
+    DOES_NOT_EXIST = \\"DOES_NOT_EXIST\\"
+    '''DoesNotExist.'''
+    EXISTS = \\"EXISTS\\"
+    '''Exists.'''
+    GT = \\"GT\\"
+    '''Gt.'''
+    IN = \\"IN\\"
+    '''In.'''
+    LT = \\"LT\\"
+    '''Lt.'''
+    NOT_IN = \\"NOT_IN\\"
+    '''NotIn.'''
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"node_selector_terms\\": \\"nodeSelectorTerms\\"},
+)
+class IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution:
+    def __init__(
+        self,
+        *,
+        node_selector_terms: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+    ) -> None:
+        '''A node selector represents the union of the results of one or more label queries over a set of nodes;
+
+        that is, it represents the OR of the selectors represented by the node selector terms.
+
+        :param node_selector_terms: Required. A list of node selector terms. The terms are ORed.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__9acfa843b7229c0e9ad74630682849efa291d2c9468e4afb8a72503609d4a5d6)
+            check_type(argname=\\"argument node_selector_terms\\", value=node_selector_terms, expected_type=type_hints[\\"node_selector_terms\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if node_selector_terms is not None:
+            self._values[\\"node_selector_terms\\"] = node_selector_terms
+
+    @builtins.property
+    def node_selector_terms(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms\\"]]:
+        '''Required.
+
+        A list of node selector terms. The terms are ORed.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution#nodeSelectorTerms
+        '''
+        result = self._values.get(\\"node_selector_terms\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms\\"]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"match_expressions\\": \\"matchExpressions\\",
+        \\"match_fields\\": \\"matchFields\\",
+    },
+)
+class IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms:
+    def __init__(
+        self,
+        *,
+        match_expressions: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+        match_fields: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+    ) -> None:
+        '''A null or empty node selector term matches no objects.
+
+        The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+
+        :param match_expressions: A list of node selector requirements by node's labels.
+        :param match_fields: A list of node selector requirements by node's fields.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__2985f1fb46d7d123a1304f37a4bdd1cb669f518ddebf14def78cd809166f7135)
+            check_type(argname=\\"argument match_expressions\\", value=match_expressions, expected_type=type_hints[\\"match_expressions\\"])
+            check_type(argname=\\"argument match_fields\\", value=match_fields, expected_type=type_hints[\\"match_fields\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if match_expressions is not None:
+            self._values[\\"match_expressions\\"] = match_expressions
+        if match_fields is not None:
+            self._values[\\"match_fields\\"] = match_fields
+
+    @builtins.property
+    def match_expressions(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions\\"]]:
+        '''A list of node selector requirements by node's labels.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms#matchExpressions
+        '''
+        result = self._values.get(\\"match_expressions\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions\\"]], result)
+
+    @builtins.property
+    def match_fields(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields\\"]]:
+        '''A list of node selector requirements by node's fields.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms#matchFields
+        '''
+        result = self._values.get(\\"match_fields\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields\\"]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"key\\": \\"key\\", \\"operator\\": \\"operator\\", \\"values\\": \\"values\\"},
+)
+class IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions:
+    def __init__(
+        self,
+        *,
+        key: typing.Optional[builtins.str] = None,
+        operator: typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator\\"] = None,
+        values: typing.Optional[typing.Sequence[builtins.str]] = None,
+    ) -> None:
+        '''A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+        :param key: The label key that the selector applies to.
+        :param operator: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt. Possible enum values: - \`\`\\"DoesNotExist\\"\`\` - \`\`\\"Exists\\"\`\` - \`\`\\"Gt\\"\`\` - \`\`\\"In\\"\`\` - \`\`\\"Lt\\"\`\` - \`\`\\"NotIn\\"\`\`
+        :param values: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__2eef7443ccd6b5aaac15c30182a3aaae735d74ec9a15de2a348964115b0f1bad)
+            check_type(argname=\\"argument key\\", value=key, expected_type=type_hints[\\"key\\"])
+            check_type(argname=\\"argument operator\\", value=operator, expected_type=type_hints[\\"operator\\"])
+            check_type(argname=\\"argument values\\", value=values, expected_type=type_hints[\\"values\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if key is not None:
+            self._values[\\"key\\"] = key
+        if operator is not None:
+            self._values[\\"operator\\"] = operator
+        if values is not None:
+            self._values[\\"values\\"] = values
+
+    @builtins.property
+    def key(self) -> typing.Optional[builtins.str]:
+        '''The label key that the selector applies to.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#key
+        '''
+        result = self._values.get(\\"key\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def operator(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator\\"]:
+        '''Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+        Possible enum values:
+
+        - \`\`\\"DoesNotExist\\"\`\`
+        - \`\`\\"Exists\\"\`\`
+        - \`\`\\"Gt\\"\`\`
+        - \`\`\\"In\\"\`\`
+        - \`\`\\"Lt\\"\`\`
+        - \`\`\\"NotIn\\"\`\`
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#operator
+        '''
+        result = self._values.get(\\"operator\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator\\"], result)
+
+    @builtins.property
+    def values(self) -> typing.Optional[typing.List[builtins.str]]:
+        '''An array of string values.
+
+        If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#values
+        '''
+        result = self._values.get(\\"values\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.enum(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator\\"
+)
+class IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator(
+    enum.Enum,
+):
+    '''Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+    Possible enum values:
+
+    - \`\`\\"DoesNotExist\\"\`\`
+    - \`\`\\"Exists\\"\`\`
+    - \`\`\\"Gt\\"\`\`
+    - \`\`\\"In\\"\`\`
+    - \`\`\\"Lt\\"\`\`
+    - \`\`\\"NotIn\\"\`\`
+
+    :schema: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator
+    '''
+
+    DOES_NOT_EXIST = \\"DOES_NOT_EXIST\\"
+    '''DoesNotExist.'''
+    EXISTS = \\"EXISTS\\"
+    '''Exists.'''
+    GT = \\"GT\\"
+    '''Gt.'''
+    IN = \\"IN\\"
+    '''In.'''
+    LT = \\"LT\\"
+    '''Lt.'''
+    NOT_IN = \\"NOT_IN\\"
+    '''NotIn.'''
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"key\\": \\"key\\", \\"operator\\": \\"operator\\", \\"values\\": \\"values\\"},
+)
+class IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields:
+    def __init__(
+        self,
+        *,
+        key: typing.Optional[builtins.str] = None,
+        operator: typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator\\"] = None,
+        values: typing.Optional[typing.Sequence[builtins.str]] = None,
+    ) -> None:
+        '''A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+        :param key: The label key that the selector applies to.
+        :param operator: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt. Possible enum values: - \`\`\\"DoesNotExist\\"\`\` - \`\`\\"Exists\\"\`\` - \`\`\\"Gt\\"\`\` - \`\`\\"In\\"\`\` - \`\`\\"Lt\\"\`\` - \`\`\\"NotIn\\"\`\`
+        :param values: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__9ec67c499846b6a293071ecb3ec3a0f941758830e6820225b2170274524e6b3a)
+            check_type(argname=\\"argument key\\", value=key, expected_type=type_hints[\\"key\\"])
+            check_type(argname=\\"argument operator\\", value=operator, expected_type=type_hints[\\"operator\\"])
+            check_type(argname=\\"argument values\\", value=values, expected_type=type_hints[\\"values\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if key is not None:
+            self._values[\\"key\\"] = key
+        if operator is not None:
+            self._values[\\"operator\\"] = operator
+        if values is not None:
+            self._values[\\"values\\"] = values
+
+    @builtins.property
+    def key(self) -> typing.Optional[builtins.str]:
+        '''The label key that the selector applies to.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#key
+        '''
+        result = self._values.get(\\"key\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def operator(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator\\"]:
+        '''Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+        Possible enum values:
+
+        - \`\`\\"DoesNotExist\\"\`\`
+        - \`\`\\"Exists\\"\`\`
+        - \`\`\\"Gt\\"\`\`
+        - \`\`\\"In\\"\`\`
+        - \`\`\\"Lt\\"\`\`
+        - \`\`\\"NotIn\\"\`\`
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#operator
+        '''
+        result = self._values.get(\\"operator\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator\\"], result)
+
+    @builtins.property
+    def values(self) -> typing.Optional[typing.List[builtins.str]]:
+        '''An array of string values.
+
+        If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#values
+        '''
+        result = self._values.get(\\"values\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.enum(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator\\"
+)
+class IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator(
+    enum.Enum,
+):
+    '''Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+    Possible enum values:
+
+    - \`\`\\"DoesNotExist\\"\`\`
+    - \`\`\\"Exists\\"\`\`
+    - \`\`\\"Gt\\"\`\`
+    - \`\`\\"In\\"\`\`
+    - \`\`\\"Lt\\"\`\`
+    - \`\`\\"NotIn\\"\`\`
+
+    :schema: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator
+    '''
+
+    DOES_NOT_EXIST = \\"DOES_NOT_EXIST\\"
+    '''DoesNotExist.'''
+    EXISTS = \\"EXISTS\\"
+    '''Exists.'''
+    GT = \\"GT\\"
+    '''Gt.'''
+    IN = \\"IN\\"
+    '''In.'''
+    LT = \\"LT\\"
+    '''Lt.'''
+    NOT_IN = \\"NOT_IN\\"
+    '''NotIn.'''
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAffinity\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"preferred_during_scheduling_ignored_during_execution\\": \\"preferredDuringSchedulingIgnoredDuringExecution\\",
+        \\"required_during_scheduling_ignored_during_execution\\": \\"requiredDuringSchedulingIgnoredDuringExecution\\",
+    },
+)
+class IoK8SApiCoreV1AffinityPodAffinity:
+    def __init__(
+        self,
+        *,
+        preferred_during_scheduling_ignored_during_execution: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+        required_during_scheduling_ignored_during_execution: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+    ) -> None:
+        '''Pod affinity is a group of inter pod affinity scheduling rules.
+
+        :param preferred_during_scheduling_ignored_during_execution: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+        :param required_during_scheduling_ignored_during_execution: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinity
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__ecd2363c495f3d762f767f20f3b220c8eb4d1138684a8c2cf0ffa57e67d7aeeb)
+            check_type(argname=\\"argument preferred_during_scheduling_ignored_during_execution\\", value=preferred_during_scheduling_ignored_during_execution, expected_type=type_hints[\\"preferred_during_scheduling_ignored_during_execution\\"])
+            check_type(argname=\\"argument required_during_scheduling_ignored_during_execution\\", value=required_during_scheduling_ignored_during_execution, expected_type=type_hints[\\"required_during_scheduling_ignored_during_execution\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if preferred_during_scheduling_ignored_during_execution is not None:
+            self._values[\\"preferred_during_scheduling_ignored_during_execution\\"] = preferred_during_scheduling_ignored_during_execution
+        if required_during_scheduling_ignored_during_execution is not None:
+            self._values[\\"required_during_scheduling_ignored_during_execution\\"] = required_during_scheduling_ignored_during_execution
+
+    @builtins.property
+    def preferred_during_scheduling_ignored_during_execution(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution\\"]]:
+        '''The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.
+
+        The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinity#preferredDuringSchedulingIgnoredDuringExecution
+        '''
+        result = self._values.get(\\"preferred_during_scheduling_ignored_during_execution\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution\\"]], result)
+
+    @builtins.property
+    def required_during_scheduling_ignored_during_execution(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution\\"]]:
+        '''If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node.
+
+        If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinity#requiredDuringSchedulingIgnoredDuringExecution
+        '''
+        result = self._values.get(\\"required_during_scheduling_ignored_during_execution\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution\\"]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAffinity(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"pod_affinity_term\\": \\"podAffinityTerm\\", \\"weight\\": \\"weight\\"},
+)
+class IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution:
+    def __init__(
+        self,
+        *,
+        pod_affinity_term: typing.Optional[typing.Union[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        weight: typing.Optional[jsii.Number] = None,
+    ) -> None:
+        '''The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s).
+
+        :param pod_affinity_term: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key matches that of any node on which a pod of the set of pods is running.
+        :param weight: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution
+        '''
+        if isinstance(pod_affinity_term, dict):
+            pod_affinity_term = IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm(**pod_affinity_term)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__73fb8396890742e720d837189aebf4ac5e0bc16c2f01edcaf5364c545a74c0a1)
+            check_type(argname=\\"argument pod_affinity_term\\", value=pod_affinity_term, expected_type=type_hints[\\"pod_affinity_term\\"])
+            check_type(argname=\\"argument weight\\", value=weight, expected_type=type_hints[\\"weight\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if pod_affinity_term is not None:
+            self._values[\\"pod_affinity_term\\"] = pod_affinity_term
+        if weight is not None:
+            self._values[\\"weight\\"] = weight
+
+    @builtins.property
+    def pod_affinity_term(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm\\"]:
+        '''Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key  matches that of any node on which a pod of the set of pods is running.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution#podAffinityTerm
+        '''
+        result = self._values.get(\\"pod_affinity_term\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm\\"], result)
+
+    @builtins.property
+    def weight(self) -> typing.Optional[jsii.Number]:
+        '''weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
+        '''
+        result = self._values.get(\\"weight\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"topology_key\\": \\"topologyKey\\",
+        \\"label_selector\\": \\"labelSelector\\",
+        \\"namespaces\\": \\"namespaces\\",
+        \\"namespace_selector\\": \\"namespaceSelector\\",
+    },
+)
+class IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm:
+    def __init__(
+        self,
+        *,
+        topology_key: builtins.str,
+        label_selector: typing.Optional[typing.Union[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        namespaces: typing.Optional[typing.Sequence[builtins.str]] = None,
+        namespace_selector: typing.Optional[typing.Union[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector\\", typing.Dict[builtins.str, typing.Any]]] = None,
+    ) -> None:
+        '''Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key  matches that of any node on which a pod of the set of pods is running.
+
+        :param topology_key: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+        :param label_selector: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+        :param namespaces: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+        :param namespace_selector: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm
+        '''
+        if isinstance(label_selector, dict):
+            label_selector = IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector(**label_selector)
+        if isinstance(namespace_selector, dict):
+            namespace_selector = IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector(**namespace_selector)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__b8dcc9ff575d6ba789f0a4bf1a9431102f18c195a13405596170979aca3a6cb2)
+            check_type(argname=\\"argument topology_key\\", value=topology_key, expected_type=type_hints[\\"topology_key\\"])
+            check_type(argname=\\"argument label_selector\\", value=label_selector, expected_type=type_hints[\\"label_selector\\"])
+            check_type(argname=\\"argument namespaces\\", value=namespaces, expected_type=type_hints[\\"namespaces\\"])
+            check_type(argname=\\"argument namespace_selector\\", value=namespace_selector, expected_type=type_hints[\\"namespace_selector\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {
+            \\"topology_key\\": topology_key,
+        }
+        if label_selector is not None:
+            self._values[\\"label_selector\\"] = label_selector
+        if namespaces is not None:
+            self._values[\\"namespaces\\"] = namespaces
+        if namespace_selector is not None:
+            self._values[\\"namespace_selector\\"] = namespace_selector
+
+    @builtins.property
+    def topology_key(self) -> builtins.str:
+        '''This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running.
+
+        Empty topologyKey is not allowed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#topologyKey
+        '''
+        result = self._values.get(\\"topology_key\\")
+        assert result is not None, \\"Required property 'topology_key' is missing\\"
+        return typing.cast(builtins.str, result)
+
+    @builtins.property
+    def label_selector(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector\\"]:
+        '''A label selector is a label query over a set of resources.
+
+        The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#labelSelector
+        '''
+        result = self._values.get(\\"label_selector\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector\\"], result)
+
+    @builtins.property
+    def namespaces(self) -> typing.Optional[typing.List[builtins.str]]:
+        '''namespaces specifies a static list of namespace names that the term applies to.
+
+        The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaces
+        '''
+        result = self._values.get(\\"namespaces\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    @builtins.property
+    def namespace_selector(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector\\"]:
+        '''A label selector is a label query over a set of resources.
+
+        The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaceSelector
+        '''
+        result = self._values.get(\\"namespace_selector\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector\\"], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"match_expressions\\": \\"matchExpressions\\",
+        \\"match_labels\\": \\"matchLabels\\",
+    },
+)
+class IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector:
+    def __init__(
+        self,
+        *,
+        match_expressions: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+        match_labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+    ) -> None:
+        '''A label selector is a label query over a set of resources.
+
+        The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :param match_expressions: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+        :param match_labels: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__40cfaac301cd989c2a2863d9bcefa06dbd6fbab7916f86ca78ccf892347ffafb)
+            check_type(argname=\\"argument match_expressions\\", value=match_expressions, expected_type=type_hints[\\"match_expressions\\"])
+            check_type(argname=\\"argument match_labels\\", value=match_labels, expected_type=type_hints[\\"match_labels\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if match_expressions is not None:
+            self._values[\\"match_expressions\\"] = match_expressions
+        if match_labels is not None:
+            self._values[\\"match_labels\\"] = match_labels
+
+    @builtins.property
+    def match_expressions(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions\\"]]:
+        '''matchExpressions is a list of label selector requirements.
+
+        The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchExpressions
+        '''
+        result = self._values.get(\\"match_expressions\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions\\"]], result)
+
+    @builtins.property
+    def match_labels(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, builtins.str]]:
+        '''matchLabels is a map of {key,value} pairs.
+
+        A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchLabels
+        '''
+        result = self._values.get(\\"match_labels\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"key\\": \\"key\\", \\"operator\\": \\"operator\\", \\"values\\": \\"values\\"},
+)
+class IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions:
+    def __init__(
+        self,
+        *,
+        key: typing.Optional[builtins.str] = None,
+        operator: typing.Optional[builtins.str] = None,
+        values: typing.Optional[typing.Sequence[builtins.str]] = None,
+    ) -> None:
+        '''A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+        :param key: key is the label key that the selector applies to.
+        :param operator: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+        :param values: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__2b198777efafa2bcf798a86663d42e7d69dea513909618f4a7ba62c47966529f)
+            check_type(argname=\\"argument key\\", value=key, expected_type=type_hints[\\"key\\"])
+            check_type(argname=\\"argument operator\\", value=operator, expected_type=type_hints[\\"operator\\"])
+            check_type(argname=\\"argument values\\", value=values, expected_type=type_hints[\\"values\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if key is not None:
+            self._values[\\"key\\"] = key
+        if operator is not None:
+            self._values[\\"operator\\"] = operator
+        if values is not None:
+            self._values[\\"values\\"] = values
+
+    @builtins.property
+    def key(self) -> typing.Optional[builtins.str]:
+        '''key is the label key that the selector applies to.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#key
+        '''
+        result = self._values.get(\\"key\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def operator(self) -> typing.Optional[builtins.str]:
+        '''operator represents a key's relationship to a set of values.
+
+        Valid operators are In, NotIn, Exists and DoesNotExist.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#operator
+        '''
+        result = self._values.get(\\"operator\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def values(self) -> typing.Optional[typing.List[builtins.str]]:
+        '''values is an array of string values.
+
+        If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#values
+        '''
+        result = self._values.get(\\"values\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"match_expressions\\": \\"matchExpressions\\",
+        \\"match_labels\\": \\"matchLabels\\",
+    },
+)
+class IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector:
+    def __init__(
+        self,
+        *,
+        match_expressions: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+        match_labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+    ) -> None:
+        '''A label selector is a label query over a set of resources.
+
+        The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :param match_expressions: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+        :param match_labels: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__1d7a88051a5ab512c4e0d9b5fbed96bb1f36fd6ae3201420ace8e2be23a019b2)
+            check_type(argname=\\"argument match_expressions\\", value=match_expressions, expected_type=type_hints[\\"match_expressions\\"])
+            check_type(argname=\\"argument match_labels\\", value=match_labels, expected_type=type_hints[\\"match_labels\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if match_expressions is not None:
+            self._values[\\"match_expressions\\"] = match_expressions
+        if match_labels is not None:
+            self._values[\\"match_labels\\"] = match_labels
+
+    @builtins.property
+    def match_expressions(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions\\"]]:
+        '''matchExpressions is a list of label selector requirements.
+
+        The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchExpressions
+        '''
+        result = self._values.get(\\"match_expressions\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions\\"]], result)
+
+    @builtins.property
+    def match_labels(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, builtins.str]]:
+        '''matchLabels is a map of {key,value} pairs.
+
+        A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchLabels
+        '''
+        result = self._values.get(\\"match_labels\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"key\\": \\"key\\", \\"operator\\": \\"operator\\", \\"values\\": \\"values\\"},
+)
+class IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions:
+    def __init__(
+        self,
+        *,
+        key: typing.Optional[builtins.str] = None,
+        operator: typing.Optional[builtins.str] = None,
+        values: typing.Optional[typing.Sequence[builtins.str]] = None,
+    ) -> None:
+        '''A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+        :param key: key is the label key that the selector applies to.
+        :param operator: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+        :param values: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__bbd3a72a8cffc689f71da929f6797f32d6f852fa2e1e9d97277ed0eddeaad132)
+            check_type(argname=\\"argument key\\", value=key, expected_type=type_hints[\\"key\\"])
+            check_type(argname=\\"argument operator\\", value=operator, expected_type=type_hints[\\"operator\\"])
+            check_type(argname=\\"argument values\\", value=values, expected_type=type_hints[\\"values\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if key is not None:
+            self._values[\\"key\\"] = key
+        if operator is not None:
+            self._values[\\"operator\\"] = operator
+        if values is not None:
+            self._values[\\"values\\"] = values
+
+    @builtins.property
+    def key(self) -> typing.Optional[builtins.str]:
+        '''key is the label key that the selector applies to.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#key
+        '''
+        result = self._values.get(\\"key\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def operator(self) -> typing.Optional[builtins.str]:
+        '''operator represents a key's relationship to a set of values.
+
+        Valid operators are In, NotIn, Exists and DoesNotExist.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#operator
+        '''
+        result = self._values.get(\\"operator\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def values(self) -> typing.Optional[typing.List[builtins.str]]:
+        '''values is an array of string values.
+
+        If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#values
+        '''
+        result = self._values.get(\\"values\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"label_selector\\": \\"labelSelector\\",
+        \\"namespaces\\": \\"namespaces\\",
+        \\"namespace_selector\\": \\"namespaceSelector\\",
+        \\"topology_key\\": \\"topologyKey\\",
+    },
+)
+class IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution:
+    def __init__(
+        self,
+        *,
+        label_selector: typing.Optional[typing.Union[\\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        namespaces: typing.Optional[typing.Sequence[builtins.str]] = None,
+        namespace_selector: typing.Optional[typing.Union[\\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        topology_key: typing.Optional[builtins.str] = None,
+    ) -> None:
+        '''Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key  matches that of any node on which a pod of the set of pods is running.
+
+        :param label_selector: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+        :param namespaces: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+        :param namespace_selector: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+        :param topology_key: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution
+        '''
+        if isinstance(label_selector, dict):
+            label_selector = IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector(**label_selector)
+        if isinstance(namespace_selector, dict):
+            namespace_selector = IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector(**namespace_selector)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__2a6d00d95d2d04eea9613de1c7903d2e66e53fac220751130ed1b8dc64a5e972)
+            check_type(argname=\\"argument label_selector\\", value=label_selector, expected_type=type_hints[\\"label_selector\\"])
+            check_type(argname=\\"argument namespaces\\", value=namespaces, expected_type=type_hints[\\"namespaces\\"])
+            check_type(argname=\\"argument namespace_selector\\", value=namespace_selector, expected_type=type_hints[\\"namespace_selector\\"])
+            check_type(argname=\\"argument topology_key\\", value=topology_key, expected_type=type_hints[\\"topology_key\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if label_selector is not None:
+            self._values[\\"label_selector\\"] = label_selector
+        if namespaces is not None:
+            self._values[\\"namespaces\\"] = namespaces
+        if namespace_selector is not None:
+            self._values[\\"namespace_selector\\"] = namespace_selector
+        if topology_key is not None:
+            self._values[\\"topology_key\\"] = topology_key
+
+    @builtins.property
+    def label_selector(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector\\"]:
+        '''A label selector is a label query over a set of resources.
+
+        The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#labelSelector
+        '''
+        result = self._values.get(\\"label_selector\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector\\"], result)
+
+    @builtins.property
+    def namespaces(self) -> typing.Optional[typing.List[builtins.str]]:
+        '''namespaces specifies a static list of namespace names that the term applies to.
+
+        The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaces
+        '''
+        result = self._values.get(\\"namespaces\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    @builtins.property
+    def namespace_selector(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector\\"]:
+        '''A label selector is a label query over a set of resources.
+
+        The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaceSelector
+        '''
+        result = self._values.get(\\"namespace_selector\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector\\"], result)
+
+    @builtins.property
+    def topology_key(self) -> typing.Optional[builtins.str]:
+        '''This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running.
+
+        Empty topologyKey is not allowed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#topologyKey
+        '''
+        result = self._values.get(\\"topology_key\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"match_expressions\\": \\"matchExpressions\\",
+        \\"match_labels\\": \\"matchLabels\\",
+    },
+)
+class IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector:
+    def __init__(
+        self,
+        *,
+        match_expressions: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+        match_labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+    ) -> None:
+        '''A label selector is a label query over a set of resources.
+
+        The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :param match_expressions: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+        :param match_labels: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__94286539963b88ed2abd60f58ddf76d754b62bbca1e65881e343f4dc1a75ecae)
+            check_type(argname=\\"argument match_expressions\\", value=match_expressions, expected_type=type_hints[\\"match_expressions\\"])
+            check_type(argname=\\"argument match_labels\\", value=match_labels, expected_type=type_hints[\\"match_labels\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if match_expressions is not None:
+            self._values[\\"match_expressions\\"] = match_expressions
+        if match_labels is not None:
+            self._values[\\"match_labels\\"] = match_labels
+
+    @builtins.property
+    def match_expressions(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions\\"]]:
+        '''matchExpressions is a list of label selector requirements.
+
+        The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchExpressions
+        '''
+        result = self._values.get(\\"match_expressions\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions\\"]], result)
+
+    @builtins.property
+    def match_labels(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, builtins.str]]:
+        '''matchLabels is a map of {key,value} pairs.
+
+        A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchLabels
+        '''
+        result = self._values.get(\\"match_labels\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"key\\": \\"key\\", \\"operator\\": \\"operator\\", \\"values\\": \\"values\\"},
+)
+class IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions:
+    def __init__(
+        self,
+        *,
+        key: typing.Optional[builtins.str] = None,
+        operator: typing.Optional[builtins.str] = None,
+        values: typing.Optional[typing.Sequence[builtins.str]] = None,
+    ) -> None:
+        '''A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+        :param key: key is the label key that the selector applies to.
+        :param operator: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+        :param values: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__de7b755055a8d366bf9836a2f930f13b4b5936266e2bf73587ed60ba8b4b2a8c)
+            check_type(argname=\\"argument key\\", value=key, expected_type=type_hints[\\"key\\"])
+            check_type(argname=\\"argument operator\\", value=operator, expected_type=type_hints[\\"operator\\"])
+            check_type(argname=\\"argument values\\", value=values, expected_type=type_hints[\\"values\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if key is not None:
+            self._values[\\"key\\"] = key
+        if operator is not None:
+            self._values[\\"operator\\"] = operator
+        if values is not None:
+            self._values[\\"values\\"] = values
+
+    @builtins.property
+    def key(self) -> typing.Optional[builtins.str]:
+        '''key is the label key that the selector applies to.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#key
+        '''
+        result = self._values.get(\\"key\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def operator(self) -> typing.Optional[builtins.str]:
+        '''operator represents a key's relationship to a set of values.
+
+        Valid operators are In, NotIn, Exists and DoesNotExist.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#operator
+        '''
+        result = self._values.get(\\"operator\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def values(self) -> typing.Optional[typing.List[builtins.str]]:
+        '''values is an array of string values.
+
+        If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#values
+        '''
+        result = self._values.get(\\"values\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"match_expressions\\": \\"matchExpressions\\",
+        \\"match_labels\\": \\"matchLabels\\",
+    },
+)
+class IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector:
+    def __init__(
+        self,
+        *,
+        match_expressions: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+        match_labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+    ) -> None:
+        '''A label selector is a label query over a set of resources.
+
+        The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :param match_expressions: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+        :param match_labels: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__216dabe6923643276c2131b29326ded426ee439ab42adc975360c3f53dea4682)
+            check_type(argname=\\"argument match_expressions\\", value=match_expressions, expected_type=type_hints[\\"match_expressions\\"])
+            check_type(argname=\\"argument match_labels\\", value=match_labels, expected_type=type_hints[\\"match_labels\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if match_expressions is not None:
+            self._values[\\"match_expressions\\"] = match_expressions
+        if match_labels is not None:
+            self._values[\\"match_labels\\"] = match_labels
+
+    @builtins.property
+    def match_expressions(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions\\"]]:
+        '''matchExpressions is a list of label selector requirements.
+
+        The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchExpressions
+        '''
+        result = self._values.get(\\"match_expressions\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions\\"]], result)
+
+    @builtins.property
+    def match_labels(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, builtins.str]]:
+        '''matchLabels is a map of {key,value} pairs.
+
+        A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchLabels
+        '''
+        result = self._values.get(\\"match_labels\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"key\\": \\"key\\", \\"operator\\": \\"operator\\", \\"values\\": \\"values\\"},
+)
+class IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions:
+    def __init__(
+        self,
+        *,
+        key: typing.Optional[builtins.str] = None,
+        operator: typing.Optional[builtins.str] = None,
+        values: typing.Optional[typing.Sequence[builtins.str]] = None,
+    ) -> None:
+        '''A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+        :param key: key is the label key that the selector applies to.
+        :param operator: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+        :param values: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__3ea0d99f7344162148befe0c73dc109ce6af186931d8630c3aab4a07df5a590a)
+            check_type(argname=\\"argument key\\", value=key, expected_type=type_hints[\\"key\\"])
+            check_type(argname=\\"argument operator\\", value=operator, expected_type=type_hints[\\"operator\\"])
+            check_type(argname=\\"argument values\\", value=values, expected_type=type_hints[\\"values\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if key is not None:
+            self._values[\\"key\\"] = key
+        if operator is not None:
+            self._values[\\"operator\\"] = operator
+        if values is not None:
+            self._values[\\"values\\"] = values
+
+    @builtins.property
+    def key(self) -> typing.Optional[builtins.str]:
+        '''key is the label key that the selector applies to.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#key
+        '''
+        result = self._values.get(\\"key\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def operator(self) -> typing.Optional[builtins.str]:
+        '''operator represents a key's relationship to a set of values.
+
+        Valid operators are In, NotIn, Exists and DoesNotExist.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#operator
+        '''
+        result = self._values.get(\\"operator\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def values(self) -> typing.Optional[typing.List[builtins.str]]:
+        '''values is an array of string values.
+
+        If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#values
+        '''
+        result = self._values.get(\\"values\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinity\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"preferred_during_scheduling_ignored_during_execution\\": \\"preferredDuringSchedulingIgnoredDuringExecution\\",
+        \\"required_during_scheduling_ignored_during_execution\\": \\"requiredDuringSchedulingIgnoredDuringExecution\\",
+    },
+)
+class IoK8SApiCoreV1AffinityPodAntiAffinity:
+    def __init__(
+        self,
+        *,
+        preferred_during_scheduling_ignored_during_execution: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+        required_during_scheduling_ignored_during_execution: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+    ) -> None:
+        '''Pod anti affinity is a group of inter pod anti affinity scheduling rules.
+
+        :param preferred_during_scheduling_ignored_during_execution: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+        :param required_during_scheduling_ignored_during_execution: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinity
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__b88eace380f44c65d21d90d3a959666edb3c888eb5a8b0fe785c3aaa22d86421)
+            check_type(argname=\\"argument preferred_during_scheduling_ignored_during_execution\\", value=preferred_during_scheduling_ignored_during_execution, expected_type=type_hints[\\"preferred_during_scheduling_ignored_during_execution\\"])
+            check_type(argname=\\"argument required_during_scheduling_ignored_during_execution\\", value=required_during_scheduling_ignored_during_execution, expected_type=type_hints[\\"required_during_scheduling_ignored_during_execution\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if preferred_during_scheduling_ignored_during_execution is not None:
+            self._values[\\"preferred_during_scheduling_ignored_during_execution\\"] = preferred_during_scheduling_ignored_during_execution
+        if required_during_scheduling_ignored_during_execution is not None:
+            self._values[\\"required_during_scheduling_ignored_during_execution\\"] = required_during_scheduling_ignored_during_execution
+
+    @builtins.property
+    def preferred_during_scheduling_ignored_during_execution(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution\\"]]:
+        '''The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.
+
+        The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinity#preferredDuringSchedulingIgnoredDuringExecution
+        '''
+        result = self._values.get(\\"preferred_during_scheduling_ignored_during_execution\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution\\"]], result)
+
+    @builtins.property
+    def required_during_scheduling_ignored_during_execution(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution\\"]]:
+        '''If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node.
+
+        If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinity#requiredDuringSchedulingIgnoredDuringExecution
+        '''
+        result = self._values.get(\\"required_during_scheduling_ignored_during_execution\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution\\"]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAntiAffinity(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"pod_affinity_term\\": \\"podAffinityTerm\\", \\"weight\\": \\"weight\\"},
+)
+class IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution:
+    def __init__(
+        self,
+        *,
+        pod_affinity_term: typing.Optional[typing.Union[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        weight: typing.Optional[jsii.Number] = None,
+    ) -> None:
+        '''The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s).
+
+        :param pod_affinity_term: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key matches that of any node on which a pod of the set of pods is running.
+        :param weight: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution
+        '''
+        if isinstance(pod_affinity_term, dict):
+            pod_affinity_term = IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm(**pod_affinity_term)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__3b5279544107027f249afe15ae53a3f9fc003336039ae784915c7894311253c0)
+            check_type(argname=\\"argument pod_affinity_term\\", value=pod_affinity_term, expected_type=type_hints[\\"pod_affinity_term\\"])
+            check_type(argname=\\"argument weight\\", value=weight, expected_type=type_hints[\\"weight\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if pod_affinity_term is not None:
+            self._values[\\"pod_affinity_term\\"] = pod_affinity_term
+        if weight is not None:
+            self._values[\\"weight\\"] = weight
+
+    @builtins.property
+    def pod_affinity_term(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm\\"]:
+        '''Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key  matches that of any node on which a pod of the set of pods is running.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution#podAffinityTerm
+        '''
+        result = self._values.get(\\"pod_affinity_term\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm\\"], result)
+
+    @builtins.property
+    def weight(self) -> typing.Optional[jsii.Number]:
+        '''weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
+        '''
+        result = self._values.get(\\"weight\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"topology_key\\": \\"topologyKey\\",
+        \\"label_selector\\": \\"labelSelector\\",
+        \\"namespaces\\": \\"namespaces\\",
+        \\"namespace_selector\\": \\"namespaceSelector\\",
+    },
+)
+class IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm:
+    def __init__(
+        self,
+        *,
+        topology_key: builtins.str,
+        label_selector: typing.Optional[typing.Union[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        namespaces: typing.Optional[typing.Sequence[builtins.str]] = None,
+        namespace_selector: typing.Optional[typing.Union[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector\\", typing.Dict[builtins.str, typing.Any]]] = None,
+    ) -> None:
+        '''Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key  matches that of any node on which a pod of the set of pods is running.
+
+        :param topology_key: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+        :param label_selector: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+        :param namespaces: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+        :param namespace_selector: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm
+        '''
+        if isinstance(label_selector, dict):
+            label_selector = IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector(**label_selector)
+        if isinstance(namespace_selector, dict):
+            namespace_selector = IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector(**namespace_selector)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__d6879ad10b0b3bf32416b947889ea0fafb9697033bd98f9280aa3d9dac126887)
+            check_type(argname=\\"argument topology_key\\", value=topology_key, expected_type=type_hints[\\"topology_key\\"])
+            check_type(argname=\\"argument label_selector\\", value=label_selector, expected_type=type_hints[\\"label_selector\\"])
+            check_type(argname=\\"argument namespaces\\", value=namespaces, expected_type=type_hints[\\"namespaces\\"])
+            check_type(argname=\\"argument namespace_selector\\", value=namespace_selector, expected_type=type_hints[\\"namespace_selector\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {
+            \\"topology_key\\": topology_key,
+        }
+        if label_selector is not None:
+            self._values[\\"label_selector\\"] = label_selector
+        if namespaces is not None:
+            self._values[\\"namespaces\\"] = namespaces
+        if namespace_selector is not None:
+            self._values[\\"namespace_selector\\"] = namespace_selector
+
+    @builtins.property
+    def topology_key(self) -> builtins.str:
+        '''This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running.
+
+        Empty topologyKey is not allowed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#topologyKey
+        '''
+        result = self._values.get(\\"topology_key\\")
+        assert result is not None, \\"Required property 'topology_key' is missing\\"
+        return typing.cast(builtins.str, result)
+
+    @builtins.property
+    def label_selector(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector\\"]:
+        '''A label selector is a label query over a set of resources.
+
+        The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#labelSelector
+        '''
+        result = self._values.get(\\"label_selector\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector\\"], result)
+
+    @builtins.property
+    def namespaces(self) -> typing.Optional[typing.List[builtins.str]]:
+        '''namespaces specifies a static list of namespace names that the term applies to.
+
+        The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaces
+        '''
+        result = self._values.get(\\"namespaces\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    @builtins.property
+    def namespace_selector(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector\\"]:
+        '''A label selector is a label query over a set of resources.
+
+        The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaceSelector
+        '''
+        result = self._values.get(\\"namespace_selector\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector\\"], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"match_expressions\\": \\"matchExpressions\\",
+        \\"match_labels\\": \\"matchLabels\\",
+    },
+)
+class IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector:
+    def __init__(
+        self,
+        *,
+        match_expressions: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+        match_labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+    ) -> None:
+        '''A label selector is a label query over a set of resources.
+
+        The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :param match_expressions: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+        :param match_labels: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__779e9109822ded6fb329c314168503867d9f0a2da63eb380b58847710fc7c54c)
+            check_type(argname=\\"argument match_expressions\\", value=match_expressions, expected_type=type_hints[\\"match_expressions\\"])
+            check_type(argname=\\"argument match_labels\\", value=match_labels, expected_type=type_hints[\\"match_labels\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if match_expressions is not None:
+            self._values[\\"match_expressions\\"] = match_expressions
+        if match_labels is not None:
+            self._values[\\"match_labels\\"] = match_labels
+
+    @builtins.property
+    def match_expressions(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions\\"]]:
+        '''matchExpressions is a list of label selector requirements.
+
+        The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchExpressions
+        '''
+        result = self._values.get(\\"match_expressions\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions\\"]], result)
+
+    @builtins.property
+    def match_labels(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, builtins.str]]:
+        '''matchLabels is a map of {key,value} pairs.
+
+        A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchLabels
+        '''
+        result = self._values.get(\\"match_labels\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"key\\": \\"key\\", \\"operator\\": \\"operator\\", \\"values\\": \\"values\\"},
+)
+class IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions:
+    def __init__(
+        self,
+        *,
+        key: typing.Optional[builtins.str] = None,
+        operator: typing.Optional[builtins.str] = None,
+        values: typing.Optional[typing.Sequence[builtins.str]] = None,
+    ) -> None:
+        '''A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+        :param key: key is the label key that the selector applies to.
+        :param operator: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+        :param values: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__fbe1868dfaa4ea324e7b51741dc160ac660e7aead3d6ad63309f8527b880a9ee)
+            check_type(argname=\\"argument key\\", value=key, expected_type=type_hints[\\"key\\"])
+            check_type(argname=\\"argument operator\\", value=operator, expected_type=type_hints[\\"operator\\"])
+            check_type(argname=\\"argument values\\", value=values, expected_type=type_hints[\\"values\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if key is not None:
+            self._values[\\"key\\"] = key
+        if operator is not None:
+            self._values[\\"operator\\"] = operator
+        if values is not None:
+            self._values[\\"values\\"] = values
+
+    @builtins.property
+    def key(self) -> typing.Optional[builtins.str]:
+        '''key is the label key that the selector applies to.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#key
+        '''
+        result = self._values.get(\\"key\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def operator(self) -> typing.Optional[builtins.str]:
+        '''operator represents a key's relationship to a set of values.
+
+        Valid operators are In, NotIn, Exists and DoesNotExist.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#operator
+        '''
+        result = self._values.get(\\"operator\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def values(self) -> typing.Optional[typing.List[builtins.str]]:
+        '''values is an array of string values.
+
+        If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#values
+        '''
+        result = self._values.get(\\"values\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"match_expressions\\": \\"matchExpressions\\",
+        \\"match_labels\\": \\"matchLabels\\",
+    },
+)
+class IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector:
+    def __init__(
+        self,
+        *,
+        match_expressions: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+        match_labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+    ) -> None:
+        '''A label selector is a label query over a set of resources.
+
+        The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :param match_expressions: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+        :param match_labels: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__68e47b2143b4877a3368c835d90e670218ba9b3c952ba8824d9a815404577149)
+            check_type(argname=\\"argument match_expressions\\", value=match_expressions, expected_type=type_hints[\\"match_expressions\\"])
+            check_type(argname=\\"argument match_labels\\", value=match_labels, expected_type=type_hints[\\"match_labels\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if match_expressions is not None:
+            self._values[\\"match_expressions\\"] = match_expressions
+        if match_labels is not None:
+            self._values[\\"match_labels\\"] = match_labels
+
+    @builtins.property
+    def match_expressions(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions\\"]]:
+        '''matchExpressions is a list of label selector requirements.
+
+        The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchExpressions
+        '''
+        result = self._values.get(\\"match_expressions\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions\\"]], result)
+
+    @builtins.property
+    def match_labels(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, builtins.str]]:
+        '''matchLabels is a map of {key,value} pairs.
+
+        A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchLabels
+        '''
+        result = self._values.get(\\"match_labels\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"key\\": \\"key\\", \\"operator\\": \\"operator\\", \\"values\\": \\"values\\"},
+)
+class IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions:
+    def __init__(
+        self,
+        *,
+        key: typing.Optional[builtins.str] = None,
+        operator: typing.Optional[builtins.str] = None,
+        values: typing.Optional[typing.Sequence[builtins.str]] = None,
+    ) -> None:
+        '''A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+        :param key: key is the label key that the selector applies to.
+        :param operator: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+        :param values: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__22b27419d7799ad450b94ff5f87bc58d4744c4e0c666e3767b396de0204de11a)
+            check_type(argname=\\"argument key\\", value=key, expected_type=type_hints[\\"key\\"])
+            check_type(argname=\\"argument operator\\", value=operator, expected_type=type_hints[\\"operator\\"])
+            check_type(argname=\\"argument values\\", value=values, expected_type=type_hints[\\"values\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if key is not None:
+            self._values[\\"key\\"] = key
+        if operator is not None:
+            self._values[\\"operator\\"] = operator
+        if values is not None:
+            self._values[\\"values\\"] = values
+
+    @builtins.property
+    def key(self) -> typing.Optional[builtins.str]:
+        '''key is the label key that the selector applies to.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#key
+        '''
+        result = self._values.get(\\"key\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def operator(self) -> typing.Optional[builtins.str]:
+        '''operator represents a key's relationship to a set of values.
+
+        Valid operators are In, NotIn, Exists and DoesNotExist.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#operator
+        '''
+        result = self._values.get(\\"operator\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def values(self) -> typing.Optional[typing.List[builtins.str]]:
+        '''values is an array of string values.
+
+        If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#values
+        '''
+        result = self._values.get(\\"values\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"label_selector\\": \\"labelSelector\\",
+        \\"namespaces\\": \\"namespaces\\",
+        \\"namespace_selector\\": \\"namespaceSelector\\",
+        \\"topology_key\\": \\"topologyKey\\",
+    },
+)
+class IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution:
+    def __init__(
+        self,
+        *,
+        label_selector: typing.Optional[typing.Union[\\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        namespaces: typing.Optional[typing.Sequence[builtins.str]] = None,
+        namespace_selector: typing.Optional[typing.Union[\\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        topology_key: typing.Optional[builtins.str] = None,
+    ) -> None:
+        '''Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key  matches that of any node on which a pod of the set of pods is running.
+
+        :param label_selector: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+        :param namespaces: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+        :param namespace_selector: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+        :param topology_key: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution
+        '''
+        if isinstance(label_selector, dict):
+            label_selector = IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector(**label_selector)
+        if isinstance(namespace_selector, dict):
+            namespace_selector = IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector(**namespace_selector)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__63f8c333243eb40563cc7d45ef1b7e6e5b9d38ad721d1418adf58e94b7bf4acb)
+            check_type(argname=\\"argument label_selector\\", value=label_selector, expected_type=type_hints[\\"label_selector\\"])
+            check_type(argname=\\"argument namespaces\\", value=namespaces, expected_type=type_hints[\\"namespaces\\"])
+            check_type(argname=\\"argument namespace_selector\\", value=namespace_selector, expected_type=type_hints[\\"namespace_selector\\"])
+            check_type(argname=\\"argument topology_key\\", value=topology_key, expected_type=type_hints[\\"topology_key\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if label_selector is not None:
+            self._values[\\"label_selector\\"] = label_selector
+        if namespaces is not None:
+            self._values[\\"namespaces\\"] = namespaces
+        if namespace_selector is not None:
+            self._values[\\"namespace_selector\\"] = namespace_selector
+        if topology_key is not None:
+            self._values[\\"topology_key\\"] = topology_key
+
+    @builtins.property
+    def label_selector(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector\\"]:
+        '''A label selector is a label query over a set of resources.
+
+        The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#labelSelector
+        '''
+        result = self._values.get(\\"label_selector\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector\\"], result)
+
+    @builtins.property
+    def namespaces(self) -> typing.Optional[typing.List[builtins.str]]:
+        '''namespaces specifies a static list of namespace names that the term applies to.
+
+        The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaces
+        '''
+        result = self._values.get(\\"namespaces\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    @builtins.property
+    def namespace_selector(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector\\"]:
+        '''A label selector is a label query over a set of resources.
+
+        The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaceSelector
+        '''
+        result = self._values.get(\\"namespace_selector\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector\\"], result)
+
+    @builtins.property
+    def topology_key(self) -> typing.Optional[builtins.str]:
+        '''This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running.
+
+        Empty topologyKey is not allowed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#topologyKey
+        '''
+        result = self._values.get(\\"topology_key\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"match_expressions\\": \\"matchExpressions\\",
+        \\"match_labels\\": \\"matchLabels\\",
+    },
+)
+class IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector:
+    def __init__(
+        self,
+        *,
+        match_expressions: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+        match_labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+    ) -> None:
+        '''A label selector is a label query over a set of resources.
+
+        The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :param match_expressions: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+        :param match_labels: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__0fc9c7df6b2de294ab5354d9cf7c44bbfcc94265b47418f00cafe7ecdf36144c)
+            check_type(argname=\\"argument match_expressions\\", value=match_expressions, expected_type=type_hints[\\"match_expressions\\"])
+            check_type(argname=\\"argument match_labels\\", value=match_labels, expected_type=type_hints[\\"match_labels\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if match_expressions is not None:
+            self._values[\\"match_expressions\\"] = match_expressions
+        if match_labels is not None:
+            self._values[\\"match_labels\\"] = match_labels
+
+    @builtins.property
+    def match_expressions(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions\\"]]:
+        '''matchExpressions is a list of label selector requirements.
+
+        The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchExpressions
+        '''
+        result = self._values.get(\\"match_expressions\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions\\"]], result)
+
+    @builtins.property
+    def match_labels(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, builtins.str]]:
+        '''matchLabels is a map of {key,value} pairs.
+
+        A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchLabels
+        '''
+        result = self._values.get(\\"match_labels\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"key\\": \\"key\\", \\"operator\\": \\"operator\\", \\"values\\": \\"values\\"},
+)
+class IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions:
+    def __init__(
+        self,
+        *,
+        key: typing.Optional[builtins.str] = None,
+        operator: typing.Optional[builtins.str] = None,
+        values: typing.Optional[typing.Sequence[builtins.str]] = None,
+    ) -> None:
+        '''A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+        :param key: key is the label key that the selector applies to.
+        :param operator: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+        :param values: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__ed3918916c6e7886791cf2a5252525faa2413def1916ebb4df746a8a27cbb1e7)
+            check_type(argname=\\"argument key\\", value=key, expected_type=type_hints[\\"key\\"])
+            check_type(argname=\\"argument operator\\", value=operator, expected_type=type_hints[\\"operator\\"])
+            check_type(argname=\\"argument values\\", value=values, expected_type=type_hints[\\"values\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if key is not None:
+            self._values[\\"key\\"] = key
+        if operator is not None:
+            self._values[\\"operator\\"] = operator
+        if values is not None:
+            self._values[\\"values\\"] = values
+
+    @builtins.property
+    def key(self) -> typing.Optional[builtins.str]:
+        '''key is the label key that the selector applies to.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#key
+        '''
+        result = self._values.get(\\"key\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def operator(self) -> typing.Optional[builtins.str]:
+        '''operator represents a key's relationship to a set of values.
+
+        Valid operators are In, NotIn, Exists and DoesNotExist.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#operator
+        '''
+        result = self._values.get(\\"operator\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def values(self) -> typing.Optional[typing.List[builtins.str]]:
+        '''values is an array of string values.
+
+        If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#values
+        '''
+        result = self._values.get(\\"values\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"match_expressions\\": \\"matchExpressions\\",
+        \\"match_labels\\": \\"matchLabels\\",
+    },
+)
+class IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector:
+    def __init__(
+        self,
+        *,
+        match_expressions: typing.Optional[typing.Sequence[typing.Union[\\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions\\", typing.Dict[builtins.str, typing.Any]]]] = None,
+        match_labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+    ) -> None:
+        '''A label selector is a label query over a set of resources.
+
+        The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+        :param match_expressions: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+        :param match_labels: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__385d6e39815cb32272bda30489d64561dda13ec9946858d27fc65a0802694108)
+            check_type(argname=\\"argument match_expressions\\", value=match_expressions, expected_type=type_hints[\\"match_expressions\\"])
+            check_type(argname=\\"argument match_labels\\", value=match_labels, expected_type=type_hints[\\"match_labels\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if match_expressions is not None:
+            self._values[\\"match_expressions\\"] = match_expressions
+        if match_labels is not None:
+            self._values[\\"match_labels\\"] = match_labels
+
+    @builtins.property
+    def match_expressions(
+        self,
+    ) -> typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions\\"]]:
+        '''matchExpressions is a list of label selector requirements.
+
+        The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchExpressions
+        '''
+        result = self._values.get(\\"match_expressions\\")
+        return typing.cast(typing.Optional[typing.List[\\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions\\"]], result)
+
+    @builtins.property
+    def match_labels(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, builtins.str]]:
+        '''matchLabels is a map of {key,value} pairs.
+
+        A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchLabels
+        '''
+        result = self._values.get(\\"match_labels\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"key\\": \\"key\\", \\"operator\\": \\"operator\\", \\"values\\": \\"values\\"},
+)
+class IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions:
+    def __init__(
+        self,
+        *,
+        key: typing.Optional[builtins.str] = None,
+        operator: typing.Optional[builtins.str] = None,
+        values: typing.Optional[typing.Sequence[builtins.str]] = None,
+    ) -> None:
+        '''A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+        :param key: key is the label key that the selector applies to.
+        :param operator: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+        :param values: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__9fdfe8df35f946a45e968b4b38d69b1382d866a3449f1eda5f75ff5a6ac17808)
+            check_type(argname=\\"argument key\\", value=key, expected_type=type_hints[\\"key\\"])
+            check_type(argname=\\"argument operator\\", value=operator, expected_type=type_hints[\\"operator\\"])
+            check_type(argname=\\"argument values\\", value=values, expected_type=type_hints[\\"values\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if key is not None:
+            self._values[\\"key\\"] = key
+        if operator is not None:
+            self._values[\\"operator\\"] = operator
+        if values is not None:
+            self._values[\\"values\\"] = values
+
+    @builtins.property
+    def key(self) -> typing.Optional[builtins.str]:
+        '''key is the label key that the selector applies to.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#key
+        '''
+        result = self._values.get(\\"key\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def operator(self) -> typing.Optional[builtins.str]:
+        '''operator represents a key's relationship to a set of values.
+
+        Valid operators are In, NotIn, Exists and DoesNotExist.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#operator
+        '''
+        result = self._values.get(\\"operator\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def values(self) -> typing.Optional[typing.List[builtins.str]]:
+        '''values is an array of string values.
+
+        If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+        :schema: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#values
+        '''
+        result = self._values.get(\\"values\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategy\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"rolling_update\\": \\"rollingUpdate\\", \\"type\\": \\"type\\"},
+)
+class IoK8SApiCoreV1DaemonSetUpdateStrategy:
+    def __init__(
+        self,
+        *,
+        rolling_update: typing.Optional[typing.Union[\\"IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        type: typing.Optional[\\"IoK8SApiCoreV1DaemonSetUpdateStrategyType\\"] = None,
+    ) -> None:
+        '''DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.
+
+        :param rolling_update: Spec to control the desired behavior of daemon set rolling update.
+        :param type: Type of daemon set update. Can be \\"RollingUpdate\\" or \\"OnDelete\\". Default is RollingUpdate. Possible enum values: - \`\`\\"OnDelete\\"\`\` Replace the old daemons only when it's killed - \`\`\\"RollingUpdate\\"\`\` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other. Default: RollingUpdate.
+
+        :schema: io.k8s.api.core.v1.DaemonSetUpdateStrategy
+        '''
+        if isinstance(rolling_update, dict):
+            rolling_update = IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate(**rolling_update)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__691cf1c6250365dd9cb33a494eefd1c10935548095a168d5ef395a7441862256)
+            check_type(argname=\\"argument rolling_update\\", value=rolling_update, expected_type=type_hints[\\"rolling_update\\"])
+            check_type(argname=\\"argument type\\", value=type, expected_type=type_hints[\\"type\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if rolling_update is not None:
+            self._values[\\"rolling_update\\"] = rolling_update
+        if type is not None:
+            self._values[\\"type\\"] = type
+
+    @builtins.property
+    def rolling_update(
+        self,
+    ) -> typing.Optional[\\"IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate\\"]:
+        '''Spec to control the desired behavior of daemon set rolling update.
+
+        :schema: io.k8s.api.core.v1.DaemonSetUpdateStrategy#rollingUpdate
+        '''
+        result = self._values.get(\\"rolling_update\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate\\"], result)
+
+    @builtins.property
+    def type(self) -> typing.Optional[\\"IoK8SApiCoreV1DaemonSetUpdateStrategyType\\"]:
+        '''Type of daemon set update. Can be \\"RollingUpdate\\" or \\"OnDelete\\". Default is RollingUpdate.
+
+        Possible enum values:
+
+        - \`\`\\"OnDelete\\"\`\` Replace the old daemons only when it's killed
+        - \`\`\\"RollingUpdate\\"\`\` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.
+
+        :default: RollingUpdate.
+
+        :schema: io.k8s.api.core.v1.DaemonSetUpdateStrategy#type
+        '''
+        result = self._values.get(\\"type\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1DaemonSetUpdateStrategyType\\"], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1DaemonSetUpdateStrategy(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"max_surge\\": \\"maxSurge\\", \\"max_unavailable\\": \\"maxUnavailable\\"},
+)
+class IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate:
+    def __init__(
+        self,
+        *,
+        max_surge: typing.Any = None,
+        max_unavailable: typing.Any = None,
+    ) -> None:
+        '''Spec to control the desired behavior of daemon set rolling update.
+
+        :param max_surge: 
+        :param max_unavailable: 
+
+        :schema: IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__bcbe1e4525c8ae8dac04633b9fd41a3cdc32975e54777d9b5669373b2f18141c)
+            check_type(argname=\\"argument max_surge\\", value=max_surge, expected_type=type_hints[\\"max_surge\\"])
+            check_type(argname=\\"argument max_unavailable\\", value=max_unavailable, expected_type=type_hints[\\"max_unavailable\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if max_surge is not None:
+            self._values[\\"max_surge\\"] = max_surge
+        if max_unavailable is not None:
+            self._values[\\"max_unavailable\\"] = max_unavailable
+
+    @builtins.property
+    def max_surge(self) -> typing.Any:
+        '''
+        :schema: IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate#maxSurge
+        '''
+        result = self._values.get(\\"max_surge\\")
+        return typing.cast(typing.Any, result)
+
+    @builtins.property
+    def max_unavailable(self) -> typing.Any:
+        '''
+        :schema: IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate#maxUnavailable
+        '''
+        result = self._values.get(\\"max_unavailable\\")
+        return typing.cast(typing.Any, result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.enum(jsii_type=\\"lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategyType\\")
+class IoK8SApiCoreV1DaemonSetUpdateStrategyType(enum.Enum):
+    '''Type of daemon set update. Can be \\"RollingUpdate\\" or \\"OnDelete\\". Default is RollingUpdate.
+
+    Possible enum values:
+
+    - \`\`\\"OnDelete\\"\`\` Replace the old daemons only when it's killed
+    - \`\`\\"RollingUpdate\\"\`\` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.
+
+    :default: RollingUpdate.
+
+    :schema: IoK8SApiCoreV1DaemonSetUpdateStrategyType
+    '''
+
+    ON_DELETE = \\"ON_DELETE\\"
+    '''OnDelete.'''
+    ROLLING_UPDATE = \\"ROLLING_UPDATE\\"
+    '''RollingUpdate.'''
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1LocalObjectReference\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"name\\": \\"name\\"},
+)
+class IoK8SApiCoreV1LocalObjectReference:
+    def __init__(self, *, name: typing.Optional[builtins.str] = None) -> None:
+        '''LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+        :param name: Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+        :schema: io.k8s.api.core.v1.LocalObjectReference
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__aad31b07aae14ea370a8ca13338d399e64c240651525bbc3a724ea48937a61e8)
+            check_type(argname=\\"argument name\\", value=name, expected_type=type_hints[\\"name\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if name is not None:
+            self._values[\\"name\\"] = name
+
+    @builtins.property
+    def name(self) -> typing.Optional[builtins.str]:
+        '''Name of the referent.
+
+        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+        :schema: io.k8s.api.core.v1.LocalObjectReference#name
+        '''
+        result = self._values.get(\\"name\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1LocalObjectReference(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1ResourceRequirements\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"limits\\": \\"limits\\", \\"requests\\": \\"requests\\"},
+)
+class IoK8SApiCoreV1ResourceRequirements:
+    def __init__(
+        self,
+        *,
+        limits: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        requests: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    ) -> None:
+        '''ResourceRequirements describes the compute resource requirements.
+
+        :param limits: Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        :param requests: Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+        :schema: io.k8s.api.core.v1.ResourceRequirements
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__b0cfae6cb4aad42921bb69bfe68fccfe027731b98cff20327e29d9b23d764e1a)
+            check_type(argname=\\"argument limits\\", value=limits, expected_type=type_hints[\\"limits\\"])
+            check_type(argname=\\"argument requests\\", value=requests, expected_type=type_hints[\\"requests\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if limits is not None:
+            self._values[\\"limits\\"] = limits
+        if requests is not None:
+            self._values[\\"requests\\"] = requests
+
+    @builtins.property
+    def limits(self) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Limits describes the maximum amount of compute resources allowed.
+
+        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+        :schema: io.k8s.api.core.v1.ResourceRequirements#limits
+        '''
+        result = self._values.get(\\"limits\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def requests(self) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Requests describes the minimum amount of compute resources required.
+
+        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+        :schema: io.k8s.api.core.v1.ResourceRequirements#requests
+        '''
+        result = self._values.get(\\"requests\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1ResourceRequirements(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.IoK8SApiCoreV1Toleration\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"effect\\": \\"effect\\",
+        \\"key\\": \\"key\\",
+        \\"operator\\": \\"operator\\",
+        \\"toleration_seconds\\": \\"tolerationSeconds\\",
+        \\"value\\": \\"value\\",
+    },
+)
+class IoK8SApiCoreV1Toleration:
+    def __init__(
+        self,
+        *,
+        effect: typing.Optional[\\"IoK8SApiCoreV1TolerationEffect\\"] = None,
+        key: typing.Optional[builtins.str] = None,
+        operator: typing.Optional[\\"IoK8SApiCoreV1TolerationOperator\\"] = None,
+        toleration_seconds: typing.Optional[jsii.Number] = None,
+        value: typing.Optional[builtins.str] = None,
+    ) -> None:
+        '''The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator .
+
+        :param effect: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute. Possible enum values: - \`\`\\"NoExecute\\"\`\` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController. - \`\`\\"NoSchedule\\"\`\` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler. - \`\`\\"PreferNoSchedule\\"\`\` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+        :param key: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+        :param operator: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category. Possible enum values: - \`\`\\"Equal\\"\`\` - \`\`\\"Exists\\"\`\` Default: Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+        :param toleration_seconds: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+        :param value: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+
+        :schema: io.k8s.api.core.v1.Toleration
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__8961b249a3bd11e4645f57459dc73620f46a774c6a01af2d7b27f6d837bf44ea)
+            check_type(argname=\\"argument effect\\", value=effect, expected_type=type_hints[\\"effect\\"])
+            check_type(argname=\\"argument key\\", value=key, expected_type=type_hints[\\"key\\"])
+            check_type(argname=\\"argument operator\\", value=operator, expected_type=type_hints[\\"operator\\"])
+            check_type(argname=\\"argument toleration_seconds\\", value=toleration_seconds, expected_type=type_hints[\\"toleration_seconds\\"])
+            check_type(argname=\\"argument value\\", value=value, expected_type=type_hints[\\"value\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if effect is not None:
+            self._values[\\"effect\\"] = effect
+        if key is not None:
+            self._values[\\"key\\"] = key
+        if operator is not None:
+            self._values[\\"operator\\"] = operator
+        if toleration_seconds is not None:
+            self._values[\\"toleration_seconds\\"] = toleration_seconds
+        if value is not None:
+            self._values[\\"value\\"] = value
+
+    @builtins.property
+    def effect(self) -> typing.Optional[\\"IoK8SApiCoreV1TolerationEffect\\"]:
+        '''Effect indicates the taint effect to match.
+
+        Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+        Possible enum values:
+
+        - \`\`\\"NoExecute\\"\`\` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+        - \`\`\\"NoSchedule\\"\`\` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+        - \`\`\\"PreferNoSchedule\\"\`\` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+
+        :schema: io.k8s.api.core.v1.Toleration#effect
+        '''
+        result = self._values.get(\\"effect\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1TolerationEffect\\"], result)
+
+    @builtins.property
+    def key(self) -> typing.Optional[builtins.str]:
+        '''Key is the taint key that the toleration applies to.
+
+        Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+
+        :schema: io.k8s.api.core.v1.Toleration#key
+        '''
+        result = self._values.get(\\"key\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def operator(self) -> typing.Optional[\\"IoK8SApiCoreV1TolerationOperator\\"]:
+        '''Operator represents a key's relationship to the value.
+
+        Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+        Possible enum values:
+
+        - \`\`\\"Equal\\"\`\`
+        - \`\`\\"Exists\\"\`\`
+
+        :default: Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+        :schema: io.k8s.api.core.v1.Toleration#operator
+        '''
+        result = self._values.get(\\"operator\\")
+        return typing.cast(typing.Optional[\\"IoK8SApiCoreV1TolerationOperator\\"], result)
+
+    @builtins.property
+    def toleration_seconds(self) -> typing.Optional[jsii.Number]:
+        '''TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint.
+
+        By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+
+        :schema: io.k8s.api.core.v1.Toleration#tolerationSeconds
+        '''
+        result = self._values.get(\\"toleration_seconds\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    @builtins.property
+    def value(self) -> typing.Optional[builtins.str]:
+        '''Value is the taint value the toleration matches to.
+
+        If the operator is Exists, the value should be empty, otherwise just a regular string.
+
+        :schema: io.k8s.api.core.v1.Toleration#value
+        '''
+        result = self._values.get(\\"value\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"IoK8SApiCoreV1Toleration(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.enum(jsii_type=\\"lacework-agent.IoK8SApiCoreV1TolerationEffect\\")
+class IoK8SApiCoreV1TolerationEffect(enum.Enum):
+    '''Effect indicates the taint effect to match.
+
+    Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+    Possible enum values:
+
+    - \`\`\\"NoExecute\\"\`\` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+    - \`\`\\"NoSchedule\\"\`\` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+    - \`\`\\"PreferNoSchedule\\"\`\` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+
+    :schema: IoK8SApiCoreV1TolerationEffect
+    '''
+
+    NO_EXECUTE = \\"NO_EXECUTE\\"
+    '''NoExecute.'''
+    NO_SCHEDULE = \\"NO_SCHEDULE\\"
+    '''NoSchedule.'''
+    PREFER_NO_SCHEDULE = \\"PREFER_NO_SCHEDULE\\"
+    '''PreferNoSchedule.'''
+
+
+@jsii.enum(jsii_type=\\"lacework-agent.IoK8SApiCoreV1TolerationOperator\\")
+class IoK8SApiCoreV1TolerationOperator(enum.Enum):
+    '''Operator represents a key's relationship to the value.
+
+    Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+    Possible enum values:
+
+    - \`\`\\"Equal\\"\`\`
+    - \`\`\\"Exists\\"\`\`
+
+    :default: Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+    :schema: IoK8SApiCoreV1TolerationOperator
+    '''
+
+    EQUAL = \\"EQUAL\\"
+    '''Equal.'''
+    EXISTS = \\"EXISTS\\"
+    '''Exists.'''
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkAgentCloudservice\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"gke\\": \\"gke\\"},
+)
+class LaceworkAgentCloudservice:
+    def __init__(
+        self,
+        *,
+        gke: typing.Optional[typing.Union[\\"LaceworkAgentCloudserviceGke\\", typing.Dict[builtins.str, typing.Any]]] = None,
+    ) -> None:
+        '''
+        :param gke: 
+
+        :schema: LaceworkAgentCloudservice
+        '''
+        if isinstance(gke, dict):
+            gke = LaceworkAgentCloudserviceGke(**gke)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__a00c30cb766c4ce3670ed7fa040a7194f0cc005e50f492fee71a1d7221fdbc73)
+            check_type(argname=\\"argument gke\\", value=gke, expected_type=type_hints[\\"gke\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if gke is not None:
+            self._values[\\"gke\\"] = gke
+
+    @builtins.property
+    def gke(self) -> typing.Optional[\\"LaceworkAgentCloudserviceGke\\"]:
+        '''
+        :schema: LaceworkAgentCloudservice#gke
+        '''
+        result = self._values.get(\\"gke\\")
+        return typing.cast(typing.Optional[\\"LaceworkAgentCloudserviceGke\\"], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkAgentCloudservice(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkAgentCloudserviceGke\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"autopilot\\": \\"autopilot\\"},
+)
+class LaceworkAgentCloudserviceGke:
+    def __init__(self, *, autopilot: typing.Optional[builtins.bool] = None) -> None:
+        '''
+        :param autopilot: 
+
+        :schema: LaceworkAgentCloudserviceGke
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__a4d2ea86626ffffc816a5d7ea7ea672b7cbcee10de8e26d93325b202baa6294c)
+            check_type(argname=\\"argument autopilot\\", value=autopilot, expected_type=type_hints[\\"autopilot\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if autopilot is not None:
+            self._values[\\"autopilot\\"] = autopilot
+
+    @builtins.property
+    def autopilot(self) -> typing.Optional[builtins.bool]:
+        '''
+        :schema: LaceworkAgentCloudserviceGke#autopilot
+        '''
+        result = self._values.get(\\"autopilot\\")
+        return typing.cast(typing.Optional[builtins.bool], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkAgentCloudserviceGke(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkAgentClusterAgent\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"enable\\": \\"enable\\",
+        \\"image\\": \\"image\\",
+        \\"additional_values\\": \\"additionalValues\\",
+        \\"cluster_region\\": \\"clusterRegion\\",
+        \\"cluster_type\\": \\"clusterType\\",
+        \\"scrape_initial_delay_mins\\": \\"scrapeInitialDelayMins\\",
+        \\"scrape_interval_mins\\": \\"scrapeIntervalMins\\",
+    },
+)
+class LaceworkAgentClusterAgent:
+    def __init__(
+        self,
+        *,
+        enable: builtins.bool,
+        image: typing.Union[\\"LaceworkAgentClusterAgentImage\\", typing.Dict[builtins.str, typing.Any]],
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        cluster_region: typing.Optional[builtins.str] = None,
+        cluster_type: typing.Optional[builtins.str] = None,
+        scrape_initial_delay_mins: typing.Optional[jsii.Number] = None,
+        scrape_interval_mins: typing.Optional[jsii.Number] = None,
+    ) -> None:
+        '''
+        :param enable: Enable cluster agent.
+        :param image: 
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param cluster_region: Kubernetes cluster cloud region.
+        :param cluster_type: Kubernetes cluster type.
+        :param scrape_initial_delay_mins: Cluster mode agent's initial delay of cluster scraping after startup in minutes.
+        :param scrape_interval_mins: Cluster mode agent's scrape interval in minutes.
+
+        :schema: LaceworkAgentClusterAgent
+        '''
+        if isinstance(image, dict):
+            image = LaceworkAgentClusterAgentImage(**image)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__427477360d777d212ced442a6c1a4283eae0d78b2a8c760ed72582ef9fe4964a)
+            check_type(argname=\\"argument enable\\", value=enable, expected_type=type_hints[\\"enable\\"])
+            check_type(argname=\\"argument image\\", value=image, expected_type=type_hints[\\"image\\"])
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument cluster_region\\", value=cluster_region, expected_type=type_hints[\\"cluster_region\\"])
+            check_type(argname=\\"argument cluster_type\\", value=cluster_type, expected_type=type_hints[\\"cluster_type\\"])
+            check_type(argname=\\"argument scrape_initial_delay_mins\\", value=scrape_initial_delay_mins, expected_type=type_hints[\\"scrape_initial_delay_mins\\"])
+            check_type(argname=\\"argument scrape_interval_mins\\", value=scrape_interval_mins, expected_type=type_hints[\\"scrape_interval_mins\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {
+            \\"enable\\": enable,
+            \\"image\\": image,
+        }
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if cluster_region is not None:
+            self._values[\\"cluster_region\\"] = cluster_region
+        if cluster_type is not None:
+            self._values[\\"cluster_type\\"] = cluster_type
+        if scrape_initial_delay_mins is not None:
+            self._values[\\"scrape_initial_delay_mins\\"] = scrape_initial_delay_mins
+        if scrape_interval_mins is not None:
+            self._values[\\"scrape_interval_mins\\"] = scrape_interval_mins
+
+    @builtins.property
+    def enable(self) -> builtins.bool:
+        '''Enable cluster agent.
+
+        :schema: LaceworkAgentClusterAgent#enable
+        '''
+        result = self._values.get(\\"enable\\")
+        assert result is not None, \\"Required property 'enable' is missing\\"
+        return typing.cast(builtins.bool, result)
+
+    @builtins.property
+    def image(self) -> \\"LaceworkAgentClusterAgentImage\\":
+        '''
+        :schema: LaceworkAgentClusterAgent#image
+        '''
+        result = self._values.get(\\"image\\")
+        assert result is not None, \\"Required property 'image' is missing\\"
+        return typing.cast(\\"LaceworkAgentClusterAgentImage\\", result)
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: LaceworkAgentClusterAgent#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def cluster_region(self) -> typing.Optional[builtins.str]:
+        '''Kubernetes cluster cloud region.
+
+        :schema: LaceworkAgentClusterAgent#clusterRegion
+        '''
+        result = self._values.get(\\"cluster_region\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def cluster_type(self) -> typing.Optional[builtins.str]:
+        '''Kubernetes cluster type.
+
+        :schema: LaceworkAgentClusterAgent#clusterType
+        '''
+        result = self._values.get(\\"cluster_type\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def scrape_initial_delay_mins(self) -> typing.Optional[jsii.Number]:
+        '''Cluster mode agent's initial delay of cluster scraping after startup in minutes.
+
+        :schema: LaceworkAgentClusterAgent#scrapeInitialDelayMins
+        '''
+        result = self._values.get(\\"scrape_initial_delay_mins\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    @builtins.property
+    def scrape_interval_mins(self) -> typing.Optional[jsii.Number]:
+        '''Cluster mode agent's scrape interval in minutes.
+
+        :schema: LaceworkAgentClusterAgent#scrapeIntervalMins
+        '''
+        result = self._values.get(\\"scrape_interval_mins\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkAgentClusterAgent(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkAgentClusterAgentImage\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"pull_policy\\": \\"pullPolicy\\",
+        \\"registry\\": \\"registry\\",
+        \\"repository\\": \\"repository\\",
+        \\"tag\\": \\"tag\\",
+        \\"additional_values\\": \\"additionalValues\\",
+        \\"image_pull_secrets\\": \\"imagePullSecrets\\",
+    },
+)
+class LaceworkAgentClusterAgentImage:
+    def __init__(
+        self,
+        *,
+        pull_policy: \\"LaceworkAgentClusterAgentImagePullPolicy\\",
+        registry: builtins.str,
+        repository: builtins.str,
+        tag: builtins.str,
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        image_pull_secrets: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1LocalObjectReference, typing.Dict[builtins.str, typing.Any]]]] = None,
+    ) -> None:
+        '''
+        :param pull_policy: Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images Possible enum values: - \`\`\\"Always\\"\`\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails. - \`\`\\"IfNotPresent\\"\`\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails. - \`\`\\"Never\\"\`\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present Default: Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+        :param registry: 
+        :param repository: 
+        :param tag: 
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param image_pull_secrets: ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+
+        :schema: LaceworkAgentClusterAgentImage
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__1b0c01541508b3b32c7ca4979253b8778a14c281b271f717c8b3cfd5cc199c6e)
+            check_type(argname=\\"argument pull_policy\\", value=pull_policy, expected_type=type_hints[\\"pull_policy\\"])
+            check_type(argname=\\"argument registry\\", value=registry, expected_type=type_hints[\\"registry\\"])
+            check_type(argname=\\"argument repository\\", value=repository, expected_type=type_hints[\\"repository\\"])
+            check_type(argname=\\"argument tag\\", value=tag, expected_type=type_hints[\\"tag\\"])
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument image_pull_secrets\\", value=image_pull_secrets, expected_type=type_hints[\\"image_pull_secrets\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {
+            \\"pull_policy\\": pull_policy,
+            \\"registry\\": registry,
+            \\"repository\\": repository,
+            \\"tag\\": tag,
+        }
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if image_pull_secrets is not None:
+            self._values[\\"image_pull_secrets\\"] = image_pull_secrets
+
+    @builtins.property
+    def pull_policy(self) -> \\"LaceworkAgentClusterAgentImagePullPolicy\\":
+        '''Image pull policy.
+
+        One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+        Possible enum values:
+
+        - \`\`\\"Always\\"\`\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+        - \`\`\\"IfNotPresent\\"\`\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+        - \`\`\\"Never\\"\`\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+
+        :default: Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+        :schema: LaceworkAgentClusterAgentImage#pullPolicy
+        '''
+        result = self._values.get(\\"pull_policy\\")
+        assert result is not None, \\"Required property 'pull_policy' is missing\\"
+        return typing.cast(\\"LaceworkAgentClusterAgentImagePullPolicy\\", result)
+
+    @builtins.property
+    def registry(self) -> builtins.str:
+        '''
+        :schema: LaceworkAgentClusterAgentImage#registry
+        '''
+        result = self._values.get(\\"registry\\")
+        assert result is not None, \\"Required property 'registry' is missing\\"
+        return typing.cast(builtins.str, result)
+
+    @builtins.property
+    def repository(self) -> builtins.str:
+        '''
+        :schema: LaceworkAgentClusterAgentImage#repository
+        '''
+        result = self._values.get(\\"repository\\")
+        assert result is not None, \\"Required property 'repository' is missing\\"
+        return typing.cast(builtins.str, result)
+
+    @builtins.property
+    def tag(self) -> builtins.str:
+        '''
+        :schema: LaceworkAgentClusterAgentImage#tag
+        '''
+        result = self._values.get(\\"tag\\")
+        assert result is not None, \\"Required property 'tag' is missing\\"
+        return typing.cast(builtins.str, result)
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: LaceworkAgentClusterAgentImage#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def image_pull_secrets(
+        self,
+    ) -> typing.Optional[typing.List[IoK8SApiCoreV1LocalObjectReference]]:
+        '''ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+
+        If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+
+        :schema: LaceworkAgentClusterAgentImage#imagePullSecrets
+        '''
+        result = self._values.get(\\"image_pull_secrets\\")
+        return typing.cast(typing.Optional[typing.List[IoK8SApiCoreV1LocalObjectReference]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkAgentClusterAgentImage(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.enum(jsii_type=\\"lacework-agent.LaceworkAgentClusterAgentImagePullPolicy\\")
+class LaceworkAgentClusterAgentImagePullPolicy(enum.Enum):
+    '''Image pull policy.
+
+    One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+    Possible enum values:
+
+    - \`\`\\"Always\\"\`\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+    - \`\`\\"IfNotPresent\\"\`\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+    - \`\`\\"Never\\"\`\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+
+    :default: Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+    :schema: LaceworkAgentClusterAgentImagePullPolicy
+    '''
+
+    ALWAYS = \\"ALWAYS\\"
+    '''Always.'''
+    IF_NOT_PRESENT = \\"IF_NOT_PRESENT\\"
+    '''IfNotPresent.'''
+    NEVER = \\"NEVER\\"
+    '''Never.'''
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkAgentDaemonset\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"affinity\\": \\"affinity\\", \\"update_strategy\\": \\"updateStrategy\\"},
+)
+class LaceworkAgentDaemonset:
+    def __init__(
+        self,
+        *,
+        affinity: typing.Union[IoK8SApiCoreV1Affinity, typing.Dict[builtins.str, typing.Any]],
+        update_strategy: typing.Union[IoK8SApiCoreV1DaemonSetUpdateStrategy, typing.Dict[builtins.str, typing.Any]],
+    ) -> None:
+        '''
+        :param affinity: If specified, the pod's scheduling constraints.
+        :param update_strategy: An update strategy to replace existing DaemonSet pods with new pods.
+
+        :schema: LaceworkAgentDaemonset
+        '''
+        if isinstance(affinity, dict):
+            affinity = IoK8SApiCoreV1Affinity(**affinity)
+        if isinstance(update_strategy, dict):
+            update_strategy = IoK8SApiCoreV1DaemonSetUpdateStrategy(**update_strategy)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__8865f58784f4c0cc708c5b4fff21b85d0aa02c8830ebe0c003e678386afd20c6)
+            check_type(argname=\\"argument affinity\\", value=affinity, expected_type=type_hints[\\"affinity\\"])
+            check_type(argname=\\"argument update_strategy\\", value=update_strategy, expected_type=type_hints[\\"update_strategy\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {
+            \\"affinity\\": affinity,
+            \\"update_strategy\\": update_strategy,
+        }
+
+    @builtins.property
+    def affinity(self) -> IoK8SApiCoreV1Affinity:
+        '''If specified, the pod's scheduling constraints.
+
+        :schema: LaceworkAgentDaemonset#affinity
+        '''
+        result = self._values.get(\\"affinity\\")
+        assert result is not None, \\"Required property 'affinity' is missing\\"
+        return typing.cast(IoK8SApiCoreV1Affinity, result)
+
+    @builtins.property
+    def update_strategy(self) -> IoK8SApiCoreV1DaemonSetUpdateStrategy:
+        '''An update strategy to replace existing DaemonSet pods with new pods.
+
+        :schema: LaceworkAgentDaemonset#updateStrategy
+        '''
+        result = self._values.get(\\"update_strategy\\")
+        assert result is not None, \\"Required property 'update_strategy' is missing\\"
+        return typing.cast(IoK8SApiCoreV1DaemonSetUpdateStrategy, result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkAgentDaemonset(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkAgentDatacollector\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"additional_values\\": \\"additionalValues\\", \\"enable\\": \\"enable\\"},
+)
+class LaceworkAgentDatacollector:
+    def __init__(
+        self,
+        *,
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        enable: typing.Optional[builtins.bool] = None,
+    ) -> None:
+        '''
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param enable: Enable lacework datacollector.
+
+        :schema: LaceworkAgentDatacollector
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__f6147c05aec3384656fc31bffde0dfd4f7b09aec7c5989879df33bfa5a918a27)
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument enable\\", value=enable, expected_type=type_hints[\\"enable\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if enable is not None:
+            self._values[\\"enable\\"] = enable
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: LaceworkAgentDatacollector#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def enable(self) -> typing.Optional[builtins.bool]:
+        '''Enable lacework datacollector.
+
+        :schema: LaceworkAgentDatacollector#enable
+        '''
+        result = self._values.get(\\"enable\\")
+        return typing.cast(typing.Optional[builtins.bool], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkAgentDatacollector(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkAgentDeployment\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"affinity\\": \\"affinity\\",
+        \\"update_strategy\\": \\"updateStrategy\\",
+        \\"priority_class_create\\": \\"priorityClassCreate\\",
+        \\"priority_class_name\\": \\"priorityClassName\\",
+        \\"priority_class_preemption_policy\\": \\"priorityClassPreemptionPolicy\\",
+        \\"priority_class_value\\": \\"priorityClassValue\\",
+        \\"resources\\": \\"resources\\",
+        \\"tolerations\\": \\"tolerations\\",
+    },
+)
+class LaceworkAgentDeployment:
+    def __init__(
+        self,
+        *,
+        affinity: typing.Union[IoK8SApiCoreV1Affinity, typing.Dict[builtins.str, typing.Any]],
+        update_strategy: typing.Union[IoK8SApiCoreV1DaemonSetUpdateStrategy, typing.Dict[builtins.str, typing.Any]],
+        priority_class_create: typing.Optional[builtins.bool] = None,
+        priority_class_name: typing.Optional[builtins.str] = None,
+        priority_class_preemption_policy: typing.Optional[builtins.str] = None,
+        priority_class_value: typing.Optional[jsii.Number] = None,
+        resources: typing.Optional[typing.Union[IoK8SApiCoreV1ResourceRequirements, typing.Dict[builtins.str, typing.Any]]] = None,
+        tolerations: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1Toleration, typing.Dict[builtins.str, typing.Any]]]] = None,
+    ) -> None:
+        '''
+        :param affinity: If specified, the pod's scheduling constraints.
+        :param update_strategy: An update strategy to replace existing DaemonSet pods with new pods.
+        :param priority_class_create: If specified, a priority class is created and used to deploy agent.
+        :param priority_class_name: If specified, indicates the pod's priority. \\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+        :param priority_class_preemption_policy: If specified, it determines if agent pod can preempt a pod with a lower a priority.
+        :param priority_class_value: If specified, it represents the priority class value to use.
+        :param resources: Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        :param tolerations: If specified, the pod's tolerations.
+
+        :schema: LaceworkAgentDeployment
+        '''
+        if isinstance(affinity, dict):
+            affinity = IoK8SApiCoreV1Affinity(**affinity)
+        if isinstance(update_strategy, dict):
+            update_strategy = IoK8SApiCoreV1DaemonSetUpdateStrategy(**update_strategy)
+        if isinstance(resources, dict):
+            resources = IoK8SApiCoreV1ResourceRequirements(**resources)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__787d1f6f42b54e0d6cad91b099f0e65026246f3e2b10b3a1f8add1f3ea9b4637)
+            check_type(argname=\\"argument affinity\\", value=affinity, expected_type=type_hints[\\"affinity\\"])
+            check_type(argname=\\"argument update_strategy\\", value=update_strategy, expected_type=type_hints[\\"update_strategy\\"])
+            check_type(argname=\\"argument priority_class_create\\", value=priority_class_create, expected_type=type_hints[\\"priority_class_create\\"])
+            check_type(argname=\\"argument priority_class_name\\", value=priority_class_name, expected_type=type_hints[\\"priority_class_name\\"])
+            check_type(argname=\\"argument priority_class_preemption_policy\\", value=priority_class_preemption_policy, expected_type=type_hints[\\"priority_class_preemption_policy\\"])
+            check_type(argname=\\"argument priority_class_value\\", value=priority_class_value, expected_type=type_hints[\\"priority_class_value\\"])
+            check_type(argname=\\"argument resources\\", value=resources, expected_type=type_hints[\\"resources\\"])
+            check_type(argname=\\"argument tolerations\\", value=tolerations, expected_type=type_hints[\\"tolerations\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {
+            \\"affinity\\": affinity,
+            \\"update_strategy\\": update_strategy,
+        }
+        if priority_class_create is not None:
+            self._values[\\"priority_class_create\\"] = priority_class_create
+        if priority_class_name is not None:
+            self._values[\\"priority_class_name\\"] = priority_class_name
+        if priority_class_preemption_policy is not None:
+            self._values[\\"priority_class_preemption_policy\\"] = priority_class_preemption_policy
+        if priority_class_value is not None:
+            self._values[\\"priority_class_value\\"] = priority_class_value
+        if resources is not None:
+            self._values[\\"resources\\"] = resources
+        if tolerations is not None:
+            self._values[\\"tolerations\\"] = tolerations
+
+    @builtins.property
+    def affinity(self) -> IoK8SApiCoreV1Affinity:
+        '''If specified, the pod's scheduling constraints.
+
+        :schema: LaceworkAgentDeployment#affinity
+        '''
+        result = self._values.get(\\"affinity\\")
+        assert result is not None, \\"Required property 'affinity' is missing\\"
+        return typing.cast(IoK8SApiCoreV1Affinity, result)
+
+    @builtins.property
+    def update_strategy(self) -> IoK8SApiCoreV1DaemonSetUpdateStrategy:
+        '''An update strategy to replace existing DaemonSet pods with new pods.
+
+        :schema: LaceworkAgentDeployment#updateStrategy
+        '''
+        result = self._values.get(\\"update_strategy\\")
+        assert result is not None, \\"Required property 'update_strategy' is missing\\"
+        return typing.cast(IoK8SApiCoreV1DaemonSetUpdateStrategy, result)
+
+    @builtins.property
+    def priority_class_create(self) -> typing.Optional[builtins.bool]:
+        '''If specified, a priority class is created and used to deploy agent.
+
+        :schema: LaceworkAgentDeployment#priorityClassCreate
+        '''
+        result = self._values.get(\\"priority_class_create\\")
+        return typing.cast(typing.Optional[builtins.bool], result)
+
+    @builtins.property
+    def priority_class_name(self) -> typing.Optional[builtins.str]:
+        '''If specified, indicates the pod's priority.
+
+        \\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+
+        :schema: LaceworkAgentDeployment#priorityClassName
+        '''
+        result = self._values.get(\\"priority_class_name\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def priority_class_preemption_policy(self) -> typing.Optional[builtins.str]:
+        '''If specified, it determines if agent pod can preempt a pod with a lower a priority.
+
+        :schema: LaceworkAgentDeployment#priorityClassPreemptionPolicy
+        '''
+        result = self._values.get(\\"priority_class_preemption_policy\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def priority_class_value(self) -> typing.Optional[jsii.Number]:
+        '''If specified, it represents the priority class value to use.
+
+        :schema: LaceworkAgentDeployment#priorityClassValue
+        '''
+        result = self._values.get(\\"priority_class_value\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    @builtins.property
+    def resources(self) -> typing.Optional[IoK8SApiCoreV1ResourceRequirements]:
+        '''Compute Resources required by this container.
+
+        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+        :schema: LaceworkAgentDeployment#resources
+        '''
+        result = self._values.get(\\"resources\\")
+        return typing.cast(typing.Optional[IoK8SApiCoreV1ResourceRequirements], result)
+
+    @builtins.property
+    def tolerations(self) -> typing.Optional[typing.List[IoK8SApiCoreV1Toleration]]:
+        '''If specified, the pod's tolerations.
+
+        :schema: LaceworkAgentDeployment#tolerations
+        '''
+        result = self._values.get(\\"tolerations\\")
+        return typing.cast(typing.Optional[typing.List[IoK8SApiCoreV1Toleration]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkAgentDeployment(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkAgentImage\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"pull_policy\\": \\"pullPolicy\\",
+        \\"registry\\": \\"registry\\",
+        \\"repository\\": \\"repository\\",
+        \\"tag\\": \\"tag\\",
+        \\"additional_values\\": \\"additionalValues\\",
+        \\"image_pull_secrets\\": \\"imagePullSecrets\\",
+        \\"override_value\\": \\"overrideValue\\",
+    },
+)
+class LaceworkAgentImage:
+    def __init__(
+        self,
+        *,
+        pull_policy: \\"LaceworkAgentImagePullPolicy\\",
+        registry: builtins.str,
+        repository: builtins.str,
+        tag: builtins.str,
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        image_pull_secrets: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1LocalObjectReference, typing.Dict[builtins.str, typing.Any]]]] = None,
+        override_value: typing.Optional[builtins.str] = None,
+    ) -> None:
+        '''
+        :param pull_policy: Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images Possible enum values: - \`\`\\"Always\\"\`\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails. - \`\`\\"IfNotPresent\\"\`\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails. - \`\`\\"Never\\"\`\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present Default: Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+        :param registry: 
+        :param repository: 
+        :param tag: 
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param image_pull_secrets: ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+        :param override_value: 
+
+        :schema: LaceworkAgentImage
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__4c0a83a494e348ea80a80280a82eb843acacd28d70ef2adf7d118c45b12ca124)
+            check_type(argname=\\"argument pull_policy\\", value=pull_policy, expected_type=type_hints[\\"pull_policy\\"])
+            check_type(argname=\\"argument registry\\", value=registry, expected_type=type_hints[\\"registry\\"])
+            check_type(argname=\\"argument repository\\", value=repository, expected_type=type_hints[\\"repository\\"])
+            check_type(argname=\\"argument tag\\", value=tag, expected_type=type_hints[\\"tag\\"])
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument image_pull_secrets\\", value=image_pull_secrets, expected_type=type_hints[\\"image_pull_secrets\\"])
+            check_type(argname=\\"argument override_value\\", value=override_value, expected_type=type_hints[\\"override_value\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {
+            \\"pull_policy\\": pull_policy,
+            \\"registry\\": registry,
+            \\"repository\\": repository,
+            \\"tag\\": tag,
+        }
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if image_pull_secrets is not None:
+            self._values[\\"image_pull_secrets\\"] = image_pull_secrets
+        if override_value is not None:
+            self._values[\\"override_value\\"] = override_value
+
+    @builtins.property
+    def pull_policy(self) -> \\"LaceworkAgentImagePullPolicy\\":
+        '''Image pull policy.
+
+        One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+        Possible enum values:
+
+        - \`\`\\"Always\\"\`\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+        - \`\`\\"IfNotPresent\\"\`\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+        - \`\`\\"Never\\"\`\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+
+        :default: Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+        :schema: LaceworkAgentImage#pullPolicy
+        '''
+        result = self._values.get(\\"pull_policy\\")
+        assert result is not None, \\"Required property 'pull_policy' is missing\\"
+        return typing.cast(\\"LaceworkAgentImagePullPolicy\\", result)
+
+    @builtins.property
+    def registry(self) -> builtins.str:
+        '''
+        :schema: LaceworkAgentImage#registry
+        '''
+        result = self._values.get(\\"registry\\")
+        assert result is not None, \\"Required property 'registry' is missing\\"
+        return typing.cast(builtins.str, result)
+
+    @builtins.property
+    def repository(self) -> builtins.str:
+        '''
+        :schema: LaceworkAgentImage#repository
+        '''
+        result = self._values.get(\\"repository\\")
+        assert result is not None, \\"Required property 'repository' is missing\\"
+        return typing.cast(builtins.str, result)
+
+    @builtins.property
+    def tag(self) -> builtins.str:
+        '''
+        :schema: LaceworkAgentImage#tag
+        '''
+        result = self._values.get(\\"tag\\")
+        assert result is not None, \\"Required property 'tag' is missing\\"
+        return typing.cast(builtins.str, result)
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: LaceworkAgentImage#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def image_pull_secrets(
+        self,
+    ) -> typing.Optional[typing.List[IoK8SApiCoreV1LocalObjectReference]]:
+        '''ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+
+        If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+
+        :schema: LaceworkAgentImage#imagePullSecrets
+        '''
+        result = self._values.get(\\"image_pull_secrets\\")
+        return typing.cast(typing.Optional[typing.List[IoK8SApiCoreV1LocalObjectReference]], result)
+
+    @builtins.property
+    def override_value(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: LaceworkAgentImage#overrideValue
+        '''
+        result = self._values.get(\\"override_value\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkAgentImage(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.enum(jsii_type=\\"lacework-agent.LaceworkAgentImagePullPolicy\\")
+class LaceworkAgentImagePullPolicy(enum.Enum):
+    '''Image pull policy.
+
+    One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+    Possible enum values:
+
+    - \`\`\\"Always\\"\`\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+    - \`\`\\"IfNotPresent\\"\`\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+    - \`\`\\"Never\\"\`\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+
+    :default: Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+    :schema: LaceworkAgentImagePullPolicy
+    '''
+
+    ALWAYS = \\"ALWAYS\\"
+    '''Always.'''
+    IF_NOT_PRESENT = \\"IF_NOT_PRESENT\\"
+    '''IfNotPresent.'''
+    NEVER = \\"NEVER\\"
+    '''Never.'''
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkAgentLaceworkConfig\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"access_token\\": \\"accessToken\\",
+        \\"additional_values\\": \\"additionalValues\\",
+        \\"annotations\\": \\"annotations\\",
+        \\"anonymize_incoming\\": \\"anonymizeIncoming\\",
+        \\"auto_upgrade\\": \\"autoUpgrade\\",
+        \\"cmdlinefilter\\": \\"cmdlinefilter\\",
+        \\"codeaware\\": \\"codeaware\\",
+        \\"container_engine_endpoint\\": \\"containerEngineEndpoint\\",
+        \\"container_runtime\\": \\"containerRuntime\\",
+        \\"datacollector\\": \\"datacollector\\",
+        \\"env\\": \\"env\\",
+        \\"fim\\": \\"fim\\",
+        \\"k8_s_node_scrape_interval_mins\\": \\"k8SNodeScrapeIntervalMins\\",
+        \\"kubernetes_cluster\\": \\"kubernetesCluster\\",
+        \\"labels\\": \\"labels\\",
+        \\"metadata_request_interval\\": \\"metadataRequestInterval\\",
+        \\"packagescan\\": \\"packagescan\\",
+        \\"perfmode\\": \\"perfmode\\",
+        \\"procscan\\": \\"procscan\\",
+        \\"proxy_url\\": \\"proxyUrl\\",
+        \\"server_url\\": \\"serverUrl\\",
+        \\"service_account_name\\": \\"serviceAccountName\\",
+        \\"stdout_logging\\": \\"stdoutLogging\\",
+        \\"tags\\": \\"tags\\",
+    },
+)
+class LaceworkAgentLaceworkConfig:
+    def __init__(
+        self,
+        *,
+        access_token: typing.Any,
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        annotations: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+        anonymize_incoming: typing.Optional[typing.Union[\\"LaceworkAgentLaceworkConfigAnonymizeIncoming\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        auto_upgrade: typing.Optional[\\"LaceworkAgentLaceworkConfigAutoUpgrade\\"] = None,
+        cmdlinefilter: typing.Optional[typing.Union[\\"LaceworkAgentLaceworkConfigCmdlinefilter\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        codeaware: typing.Optional[typing.Union[\\"LaceworkAgentLaceworkConfigCodeaware\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        container_engine_endpoint: typing.Optional[builtins.str] = None,
+        container_runtime: typing.Optional[builtins.str] = None,
+        datacollector: typing.Optional[\\"LaceworkAgentLaceworkConfigDatacollector\\"] = None,
+        env: typing.Optional[builtins.str] = None,
+        fim: typing.Optional[typing.Union[\\"LaceworkAgentLaceworkConfigFim\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        k8_s_node_scrape_interval_mins: typing.Optional[jsii.Number] = None,
+        kubernetes_cluster: typing.Optional[builtins.str] = None,
+        labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+        metadata_request_interval: typing.Optional[builtins.str] = None,
+        packagescan: typing.Optional[typing.Union[\\"LaceworkAgentLaceworkConfigPackagescan\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        perfmode: typing.Optional[builtins.str] = None,
+        procscan: typing.Optional[typing.Union[\\"LaceworkAgentLaceworkConfigProcscan\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        proxy_url: typing.Optional[builtins.str] = None,
+        server_url: typing.Optional[builtins.str] = None,
+        service_account_name: typing.Optional[builtins.str] = None,
+        stdout_logging: typing.Optional[builtins.bool] = None,
+        tags: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+    ) -> None:
+        '''
+        :param access_token: 
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param annotations: Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations
+        :param anonymize_incoming: 
+        :param auto_upgrade: 
+        :param cmdlinefilter: 
+        :param codeaware: 
+        :param container_engine_endpoint: 
+        :param container_runtime: 
+        :param datacollector: 
+        :param env: 
+        :param fim: 
+        :param k8_s_node_scrape_interval_mins: Kubernetes node's scrape interval in minutes.
+        :param kubernetes_cluster: 
+        :param labels: Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
+        :param metadata_request_interval: 
+        :param packagescan: 
+        :param perfmode: 
+        :param procscan: 
+        :param proxy_url: 
+        :param server_url: 
+        :param service_account_name: 
+        :param stdout_logging: 
+        :param tags: 
+
+        :schema: LaceworkAgentLaceworkConfig
+        '''
+        if isinstance(anonymize_incoming, dict):
+            anonymize_incoming = LaceworkAgentLaceworkConfigAnonymizeIncoming(**anonymize_incoming)
+        if isinstance(cmdlinefilter, dict):
+            cmdlinefilter = LaceworkAgentLaceworkConfigCmdlinefilter(**cmdlinefilter)
+        if isinstance(codeaware, dict):
+            codeaware = LaceworkAgentLaceworkConfigCodeaware(**codeaware)
+        if isinstance(fim, dict):
+            fim = LaceworkAgentLaceworkConfigFim(**fim)
+        if isinstance(packagescan, dict):
+            packagescan = LaceworkAgentLaceworkConfigPackagescan(**packagescan)
+        if isinstance(procscan, dict):
+            procscan = LaceworkAgentLaceworkConfigProcscan(**procscan)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__137ccaec2780b925802b147c3602013773aba0adcc89e414986c5d5a31ac1a52)
+            check_type(argname=\\"argument access_token\\", value=access_token, expected_type=type_hints[\\"access_token\\"])
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument annotations\\", value=annotations, expected_type=type_hints[\\"annotations\\"])
+            check_type(argname=\\"argument anonymize_incoming\\", value=anonymize_incoming, expected_type=type_hints[\\"anonymize_incoming\\"])
+            check_type(argname=\\"argument auto_upgrade\\", value=auto_upgrade, expected_type=type_hints[\\"auto_upgrade\\"])
+            check_type(argname=\\"argument cmdlinefilter\\", value=cmdlinefilter, expected_type=type_hints[\\"cmdlinefilter\\"])
+            check_type(argname=\\"argument codeaware\\", value=codeaware, expected_type=type_hints[\\"codeaware\\"])
+            check_type(argname=\\"argument container_engine_endpoint\\", value=container_engine_endpoint, expected_type=type_hints[\\"container_engine_endpoint\\"])
+            check_type(argname=\\"argument container_runtime\\", value=container_runtime, expected_type=type_hints[\\"container_runtime\\"])
+            check_type(argname=\\"argument datacollector\\", value=datacollector, expected_type=type_hints[\\"datacollector\\"])
+            check_type(argname=\\"argument env\\", value=env, expected_type=type_hints[\\"env\\"])
+            check_type(argname=\\"argument fim\\", value=fim, expected_type=type_hints[\\"fim\\"])
+            check_type(argname=\\"argument k8_s_node_scrape_interval_mins\\", value=k8_s_node_scrape_interval_mins, expected_type=type_hints[\\"k8_s_node_scrape_interval_mins\\"])
+            check_type(argname=\\"argument kubernetes_cluster\\", value=kubernetes_cluster, expected_type=type_hints[\\"kubernetes_cluster\\"])
+            check_type(argname=\\"argument labels\\", value=labels, expected_type=type_hints[\\"labels\\"])
+            check_type(argname=\\"argument metadata_request_interval\\", value=metadata_request_interval, expected_type=type_hints[\\"metadata_request_interval\\"])
+            check_type(argname=\\"argument packagescan\\", value=packagescan, expected_type=type_hints[\\"packagescan\\"])
+            check_type(argname=\\"argument perfmode\\", value=perfmode, expected_type=type_hints[\\"perfmode\\"])
+            check_type(argname=\\"argument procscan\\", value=procscan, expected_type=type_hints[\\"procscan\\"])
+            check_type(argname=\\"argument proxy_url\\", value=proxy_url, expected_type=type_hints[\\"proxy_url\\"])
+            check_type(argname=\\"argument server_url\\", value=server_url, expected_type=type_hints[\\"server_url\\"])
+            check_type(argname=\\"argument service_account_name\\", value=service_account_name, expected_type=type_hints[\\"service_account_name\\"])
+            check_type(argname=\\"argument stdout_logging\\", value=stdout_logging, expected_type=type_hints[\\"stdout_logging\\"])
+            check_type(argname=\\"argument tags\\", value=tags, expected_type=type_hints[\\"tags\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {
+            \\"access_token\\": access_token,
+        }
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if annotations is not None:
+            self._values[\\"annotations\\"] = annotations
+        if anonymize_incoming is not None:
+            self._values[\\"anonymize_incoming\\"] = anonymize_incoming
+        if auto_upgrade is not None:
+            self._values[\\"auto_upgrade\\"] = auto_upgrade
+        if cmdlinefilter is not None:
+            self._values[\\"cmdlinefilter\\"] = cmdlinefilter
+        if codeaware is not None:
+            self._values[\\"codeaware\\"] = codeaware
+        if container_engine_endpoint is not None:
+            self._values[\\"container_engine_endpoint\\"] = container_engine_endpoint
+        if container_runtime is not None:
+            self._values[\\"container_runtime\\"] = container_runtime
+        if datacollector is not None:
+            self._values[\\"datacollector\\"] = datacollector
+        if env is not None:
+            self._values[\\"env\\"] = env
+        if fim is not None:
+            self._values[\\"fim\\"] = fim
+        if k8_s_node_scrape_interval_mins is not None:
+            self._values[\\"k8_s_node_scrape_interval_mins\\"] = k8_s_node_scrape_interval_mins
+        if kubernetes_cluster is not None:
+            self._values[\\"kubernetes_cluster\\"] = kubernetes_cluster
+        if labels is not None:
+            self._values[\\"labels\\"] = labels
+        if metadata_request_interval is not None:
+            self._values[\\"metadata_request_interval\\"] = metadata_request_interval
+        if packagescan is not None:
+            self._values[\\"packagescan\\"] = packagescan
+        if perfmode is not None:
+            self._values[\\"perfmode\\"] = perfmode
+        if procscan is not None:
+            self._values[\\"procscan\\"] = procscan
+        if proxy_url is not None:
+            self._values[\\"proxy_url\\"] = proxy_url
+        if server_url is not None:
+            self._values[\\"server_url\\"] = server_url
+        if service_account_name is not None:
+            self._values[\\"service_account_name\\"] = service_account_name
+        if stdout_logging is not None:
+            self._values[\\"stdout_logging\\"] = stdout_logging
+        if tags is not None:
+            self._values[\\"tags\\"] = tags
+
+    @builtins.property
+    def access_token(self) -> typing.Any:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#accessToken
+        '''
+        result = self._values.get(\\"access_token\\")
+        assert result is not None, \\"Required property 'access_token' is missing\\"
+        return typing.cast(typing.Any, result)
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: LaceworkAgentLaceworkConfig#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def annotations(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, builtins.str]]:
+        '''Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata.
+
+        They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations
+
+        :schema: LaceworkAgentLaceworkConfig#annotations
+        '''
+        result = self._values.get(\\"annotations\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, builtins.str]], result)
+
+    @builtins.property
+    def anonymize_incoming(
+        self,
+    ) -> typing.Optional[\\"LaceworkAgentLaceworkConfigAnonymizeIncoming\\"]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#anonymizeIncoming
+        '''
+        result = self._values.get(\\"anonymize_incoming\\")
+        return typing.cast(typing.Optional[\\"LaceworkAgentLaceworkConfigAnonymizeIncoming\\"], result)
+
+    @builtins.property
+    def auto_upgrade(self) -> typing.Optional[\\"LaceworkAgentLaceworkConfigAutoUpgrade\\"]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#autoUpgrade
+        '''
+        result = self._values.get(\\"auto_upgrade\\")
+        return typing.cast(typing.Optional[\\"LaceworkAgentLaceworkConfigAutoUpgrade\\"], result)
+
+    @builtins.property
+    def cmdlinefilter(
+        self,
+    ) -> typing.Optional[\\"LaceworkAgentLaceworkConfigCmdlinefilter\\"]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#cmdlinefilter
+        '''
+        result = self._values.get(\\"cmdlinefilter\\")
+        return typing.cast(typing.Optional[\\"LaceworkAgentLaceworkConfigCmdlinefilter\\"], result)
+
+    @builtins.property
+    def codeaware(self) -> typing.Optional[\\"LaceworkAgentLaceworkConfigCodeaware\\"]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#codeaware
+        '''
+        result = self._values.get(\\"codeaware\\")
+        return typing.cast(typing.Optional[\\"LaceworkAgentLaceworkConfigCodeaware\\"], result)
+
+    @builtins.property
+    def container_engine_endpoint(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#containerEngineEndpoint
+        '''
+        result = self._values.get(\\"container_engine_endpoint\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def container_runtime(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#containerRuntime
+        '''
+        result = self._values.get(\\"container_runtime\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def datacollector(
+        self,
+    ) -> typing.Optional[\\"LaceworkAgentLaceworkConfigDatacollector\\"]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#datacollector
+        '''
+        result = self._values.get(\\"datacollector\\")
+        return typing.cast(typing.Optional[\\"LaceworkAgentLaceworkConfigDatacollector\\"], result)
+
+    @builtins.property
+    def env(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#env
+        '''
+        result = self._values.get(\\"env\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def fim(self) -> typing.Optional[\\"LaceworkAgentLaceworkConfigFim\\"]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#fim
+        '''
+        result = self._values.get(\\"fim\\")
+        return typing.cast(typing.Optional[\\"LaceworkAgentLaceworkConfigFim\\"], result)
+
+    @builtins.property
+    def k8_s_node_scrape_interval_mins(self) -> typing.Optional[jsii.Number]:
+        '''Kubernetes node's scrape interval in minutes.
+
+        :schema: LaceworkAgentLaceworkConfig#k8sNodeScrapeIntervalMins
+        '''
+        result = self._values.get(\\"k8_s_node_scrape_interval_mins\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    @builtins.property
+    def kubernetes_cluster(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#kubernetesCluster
+        '''
+        result = self._values.get(\\"kubernetes_cluster\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def labels(self) -> typing.Optional[typing.Mapping[builtins.str, builtins.str]]:
+        '''Map of string keys and values that can be used to organize and categorize (scope and select) objects.
+
+        May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
+
+        :schema: LaceworkAgentLaceworkConfig#labels
+        '''
+        result = self._values.get(\\"labels\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, builtins.str]], result)
+
+    @builtins.property
+    def metadata_request_interval(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#metadataRequestInterval
+        '''
+        result = self._values.get(\\"metadata_request_interval\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def packagescan(self) -> typing.Optional[\\"LaceworkAgentLaceworkConfigPackagescan\\"]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#packagescan
+        '''
+        result = self._values.get(\\"packagescan\\")
+        return typing.cast(typing.Optional[\\"LaceworkAgentLaceworkConfigPackagescan\\"], result)
+
+    @builtins.property
+    def perfmode(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#perfmode
+        '''
+        result = self._values.get(\\"perfmode\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def procscan(self) -> typing.Optional[\\"LaceworkAgentLaceworkConfigProcscan\\"]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#procscan
+        '''
+        result = self._values.get(\\"procscan\\")
+        return typing.cast(typing.Optional[\\"LaceworkAgentLaceworkConfigProcscan\\"], result)
+
+    @builtins.property
+    def proxy_url(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#proxyUrl
+        '''
+        result = self._values.get(\\"proxy_url\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def server_url(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#serverUrl
+        '''
+        result = self._values.get(\\"server_url\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def service_account_name(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#serviceAccountName
+        '''
+        result = self._values.get(\\"service_account_name\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def stdout_logging(self) -> typing.Optional[builtins.bool]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#stdoutLogging
+        '''
+        result = self._values.get(\\"stdout_logging\\")
+        return typing.cast(typing.Optional[builtins.bool], result)
+
+    @builtins.property
+    def tags(self) -> typing.Optional[typing.Mapping[builtins.str, builtins.str]]:
+        '''
+        :schema: LaceworkAgentLaceworkConfig#tags
+        '''
+        result = self._values.get(\\"tags\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, builtins.str]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkAgentLaceworkConfig(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkAgentLaceworkConfigAnonymizeIncoming\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"additional_values\\": \\"additionalValues\\", \\"netmask\\": \\"netmask\\"},
+)
+class LaceworkAgentLaceworkConfigAnonymizeIncoming:
+    def __init__(
+        self,
+        *,
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        netmask: typing.Optional[builtins.str] = None,
+    ) -> None:
+        '''
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param netmask: 
+
+        :schema: LaceworkAgentLaceworkConfigAnonymizeIncoming
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__cae19ba49ffeb3756e422ae55a616d552a7b1a48e805ed6342cdcedeb898252d)
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument netmask\\", value=netmask, expected_type=type_hints[\\"netmask\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if netmask is not None:
+            self._values[\\"netmask\\"] = netmask
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: LaceworkAgentLaceworkConfigAnonymizeIncoming#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def netmask(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: LaceworkAgentLaceworkConfigAnonymizeIncoming#netmask
+        '''
+        result = self._values.get(\\"netmask\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkAgentLaceworkConfigAnonymizeIncoming(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.enum(jsii_type=\\"lacework-agent.LaceworkAgentLaceworkConfigAutoUpgrade\\")
+class LaceworkAgentLaceworkConfigAutoUpgrade(enum.Enum):
+    '''
+    :schema: LaceworkAgentLaceworkConfigAutoUpgrade
+    '''
+
+    DISABLE = \\"DISABLE\\"
+    '''disable.'''
+    ENABLE = \\"ENABLE\\"
+    '''enable.'''
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkAgentLaceworkConfigCmdlinefilter\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"allow\\": \\"allow\\", \\"disallow\\": \\"disallow\\"},
+)
+class LaceworkAgentLaceworkConfigCmdlinefilter:
+    def __init__(
+        self,
+        *,
+        allow: typing.Optional[builtins.str] = None,
+        disallow: typing.Optional[builtins.str] = None,
+    ) -> None:
+        '''
+        :param allow: 
+        :param disallow: 
+
+        :schema: LaceworkAgentLaceworkConfigCmdlinefilter
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__d49626aa144236418ebd376e1f10ea94398ba5fc8167c20717e1b2e7d5629eb9)
+            check_type(argname=\\"argument allow\\", value=allow, expected_type=type_hints[\\"allow\\"])
+            check_type(argname=\\"argument disallow\\", value=disallow, expected_type=type_hints[\\"disallow\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if allow is not None:
+            self._values[\\"allow\\"] = allow
+        if disallow is not None:
+            self._values[\\"disallow\\"] = disallow
+
+    @builtins.property
+    def allow(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: LaceworkAgentLaceworkConfigCmdlinefilter#allow
+        '''
+        result = self._values.get(\\"allow\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def disallow(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: LaceworkAgentLaceworkConfigCmdlinefilter#disallow
+        '''
+        result = self._values.get(\\"disallow\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkAgentLaceworkConfigCmdlinefilter(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkAgentLaceworkConfigCodeaware\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"enable\\": \\"enable\\"},
+)
+class LaceworkAgentLaceworkConfigCodeaware:
+    def __init__(self, *, enable: typing.Optional[builtins.bool] = None) -> None:
+        '''
+        :param enable: 
+
+        :schema: LaceworkAgentLaceworkConfigCodeaware
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__5882a8edec8095b7334e91a883a0e95f3d4d4a8f83a44c6e4483316a2267bf63)
+            check_type(argname=\\"argument enable\\", value=enable, expected_type=type_hints[\\"enable\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if enable is not None:
+            self._values[\\"enable\\"] = enable
+
+    @builtins.property
+    def enable(self) -> typing.Optional[builtins.bool]:
+        '''
+        :schema: LaceworkAgentLaceworkConfigCodeaware#enable
+        '''
+        result = self._values.get(\\"enable\\")
+        return typing.cast(typing.Optional[builtins.bool], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkAgentLaceworkConfigCodeaware(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.enum(jsii_type=\\"lacework-agent.LaceworkAgentLaceworkConfigDatacollector\\")
+class LaceworkAgentLaceworkConfigDatacollector(enum.Enum):
+    '''
+    :schema: LaceworkAgentLaceworkConfigDatacollector
+    '''
+
+    DISABLE = \\"DISABLE\\"
+    '''disable.'''
+    ENABLE = \\"ENABLE\\"
+    '''enable.'''
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkAgentLaceworkConfigFim\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"enable\\": \\"enable\\",
+        \\"file_ignore\\": \\"fileIgnore\\",
+        \\"file_path\\": \\"filePath\\",
+        \\"additional_values\\": \\"additionalValues\\",
+        \\"cooling_period\\": \\"coolingPeriod\\",
+        \\"crawl_interval\\": \\"crawlInterval\\",
+        \\"no_atime\\": \\"noAtime\\",
+        \\"run_at\\": \\"runAt\\",
+    },
+)
+class LaceworkAgentLaceworkConfigFim:
+    def __init__(
+        self,
+        *,
+        enable: builtins.bool,
+        file_ignore: typing.Sequence[builtins.str],
+        file_path: typing.Sequence[builtins.str],
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        cooling_period: typing.Optional[jsii.Number] = None,
+        crawl_interval: typing.Optional[jsii.Number] = None,
+        no_atime: typing.Optional[builtins.bool] = None,
+        run_at: typing.Any = None,
+    ) -> None:
+        '''
+        :param enable: 
+        :param file_ignore: 
+        :param file_path: 
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param cooling_period: 
+        :param crawl_interval: 
+        :param no_atime: 
+        :param run_at: 
+
+        :schema: LaceworkAgentLaceworkConfigFim
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__3a82613c3b10f84fd3c85552b1bf3d3eb0de5e479e129b12fa8986455f413ed2)
+            check_type(argname=\\"argument enable\\", value=enable, expected_type=type_hints[\\"enable\\"])
+            check_type(argname=\\"argument file_ignore\\", value=file_ignore, expected_type=type_hints[\\"file_ignore\\"])
+            check_type(argname=\\"argument file_path\\", value=file_path, expected_type=type_hints[\\"file_path\\"])
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument cooling_period\\", value=cooling_period, expected_type=type_hints[\\"cooling_period\\"])
+            check_type(argname=\\"argument crawl_interval\\", value=crawl_interval, expected_type=type_hints[\\"crawl_interval\\"])
+            check_type(argname=\\"argument no_atime\\", value=no_atime, expected_type=type_hints[\\"no_atime\\"])
+            check_type(argname=\\"argument run_at\\", value=run_at, expected_type=type_hints[\\"run_at\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {
+            \\"enable\\": enable,
+            \\"file_ignore\\": file_ignore,
+            \\"file_path\\": file_path,
+        }
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if cooling_period is not None:
+            self._values[\\"cooling_period\\"] = cooling_period
+        if crawl_interval is not None:
+            self._values[\\"crawl_interval\\"] = crawl_interval
+        if no_atime is not None:
+            self._values[\\"no_atime\\"] = no_atime
+        if run_at is not None:
+            self._values[\\"run_at\\"] = run_at
+
+    @builtins.property
+    def enable(self) -> builtins.bool:
+        '''
+        :schema: LaceworkAgentLaceworkConfigFim#enable
+        '''
+        result = self._values.get(\\"enable\\")
+        assert result is not None, \\"Required property 'enable' is missing\\"
+        return typing.cast(builtins.bool, result)
+
+    @builtins.property
+    def file_ignore(self) -> typing.List[builtins.str]:
+        '''
+        :schema: LaceworkAgentLaceworkConfigFim#fileIgnore
+        '''
+        result = self._values.get(\\"file_ignore\\")
+        assert result is not None, \\"Required property 'file_ignore' is missing\\"
+        return typing.cast(typing.List[builtins.str], result)
+
+    @builtins.property
+    def file_path(self) -> typing.List[builtins.str]:
+        '''
+        :schema: LaceworkAgentLaceworkConfigFim#filePath
+        '''
+        result = self._values.get(\\"file_path\\")
+        assert result is not None, \\"Required property 'file_path' is missing\\"
+        return typing.cast(typing.List[builtins.str], result)
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: LaceworkAgentLaceworkConfigFim#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def cooling_period(self) -> typing.Optional[jsii.Number]:
+        '''
+        :schema: LaceworkAgentLaceworkConfigFim#coolingPeriod
+        '''
+        result = self._values.get(\\"cooling_period\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    @builtins.property
+    def crawl_interval(self) -> typing.Optional[jsii.Number]:
+        '''
+        :schema: LaceworkAgentLaceworkConfigFim#crawlInterval
+        '''
+        result = self._values.get(\\"crawl_interval\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    @builtins.property
+    def no_atime(self) -> typing.Optional[builtins.bool]:
+        '''
+        :schema: LaceworkAgentLaceworkConfigFim#noAtime
+        '''
+        result = self._values.get(\\"no_atime\\")
+        return typing.cast(typing.Optional[builtins.bool], result)
+
+    @builtins.property
+    def run_at(self) -> typing.Any:
+        '''
+        :schema: LaceworkAgentLaceworkConfigFim#runAt
+        '''
+        result = self._values.get(\\"run_at\\")
+        return typing.cast(typing.Any, result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkAgentLaceworkConfigFim(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkAgentLaceworkConfigPackagescan\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"enable\\": \\"enable\\", \\"interval\\": \\"interval\\"},
+)
+class LaceworkAgentLaceworkConfigPackagescan:
+    def __init__(
+        self,
+        *,
+        enable: typing.Optional[builtins.bool] = None,
+        interval: typing.Optional[jsii.Number] = None,
+    ) -> None:
+        '''
+        :param enable: 
+        :param interval: 
+
+        :schema: LaceworkAgentLaceworkConfigPackagescan
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__7a28ae402580638d4ca326df3f41bd0b2997d028ee2ad046ae4834bceb9580ee)
+            check_type(argname=\\"argument enable\\", value=enable, expected_type=type_hints[\\"enable\\"])
+            check_type(argname=\\"argument interval\\", value=interval, expected_type=type_hints[\\"interval\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if enable is not None:
+            self._values[\\"enable\\"] = enable
+        if interval is not None:
+            self._values[\\"interval\\"] = interval
+
+    @builtins.property
+    def enable(self) -> typing.Optional[builtins.bool]:
+        '''
+        :schema: LaceworkAgentLaceworkConfigPackagescan#enable
+        '''
+        result = self._values.get(\\"enable\\")
+        return typing.cast(typing.Optional[builtins.bool], result)
+
+    @builtins.property
+    def interval(self) -> typing.Optional[jsii.Number]:
+        '''
+        :schema: LaceworkAgentLaceworkConfigPackagescan#interval
+        '''
+        result = self._values.get(\\"interval\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkAgentLaceworkConfigPackagescan(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkAgentLaceworkConfigProcscan\\",
+    jsii_struct_bases=[],
+    name_mapping={\\"enable\\": \\"enable\\", \\"interval\\": \\"interval\\"},
+)
+class LaceworkAgentLaceworkConfigProcscan:
+    def __init__(
+        self,
+        *,
+        enable: typing.Optional[builtins.bool] = None,
+        interval: typing.Optional[jsii.Number] = None,
+    ) -> None:
+        '''
+        :param enable: 
+        :param interval: 
+
+        :schema: LaceworkAgentLaceworkConfigProcscan
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__574fdc26e474c6dcbd22d3b5de880518aa899c6e4ac43317fce728e591c17e31)
+            check_type(argname=\\"argument enable\\", value=enable, expected_type=type_hints[\\"enable\\"])
+            check_type(argname=\\"argument interval\\", value=interval, expected_type=type_hints[\\"interval\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if enable is not None:
+            self._values[\\"enable\\"] = enable
+        if interval is not None:
+            self._values[\\"interval\\"] = interval
+
+    @builtins.property
+    def enable(self) -> typing.Optional[builtins.bool]:
+        '''
+        :schema: LaceworkAgentLaceworkConfigProcscan#enable
+        '''
+        result = self._values.get(\\"enable\\")
+        return typing.cast(typing.Optional[builtins.bool], result)
+
+    @builtins.property
+    def interval(self) -> typing.Optional[jsii.Number]:
+        '''
+        :schema: LaceworkAgentLaceworkConfigProcscan#interval
+        '''
+        result = self._values.get(\\"interval\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkAgentLaceworkConfigProcscan(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+class Laceworkagent(
+    _constructs_77d1e7e8.Construct,
+    metaclass=jsii.JSIIMeta,
+    jsii_type=\\"lacework-agent.Laceworkagent\\",
+):
+    def __init__(
+        self,
+        scope: _constructs_77d1e7e8.Construct,
+        id: builtins.str,
+        *,
+        values: typing.Union[\\"LaceworkagentValues\\", typing.Dict[builtins.str, typing.Any]],
+        helm_executable: typing.Optional[builtins.str] = None,
+        helm_flags: typing.Optional[typing.Sequence[builtins.str]] = None,
+        namespace: typing.Optional[builtins.str] = None,
+        release_name: typing.Optional[builtins.str] = None,
+    ) -> None:
+        '''
+        :param scope: -
+        :param id: -
+        :param values: -
+        :param helm_executable: -
+        :param helm_flags: -
+        :param namespace: -
+        :param release_name: -
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__114ea5fe7e7841a5303933808db33ffb935e37c0ef8577589791a696f226951d)
+            check_type(argname=\\"argument scope\\", value=scope, expected_type=type_hints[\\"scope\\"])
+            check_type(argname=\\"argument id\\", value=id, expected_type=type_hints[\\"id\\"])
+        props = LaceworkagentProps(
+            values=values,
+            helm_executable=helm_executable,
+            helm_flags=helm_flags,
+            namespace=namespace,
+            release_name=release_name,
+        )
+
+        jsii.create(self.__class__, self, [scope, id, props])
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkagentProps\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"values\\": \\"values\\",
+        \\"helm_executable\\": \\"helmExecutable\\",
+        \\"helm_flags\\": \\"helmFlags\\",
+        \\"namespace\\": \\"namespace\\",
+        \\"release_name\\": \\"releaseName\\",
+    },
+)
+class LaceworkagentProps:
+    def __init__(
+        self,
+        *,
+        values: typing.Union[\\"LaceworkagentValues\\", typing.Dict[builtins.str, typing.Any]],
+        helm_executable: typing.Optional[builtins.str] = None,
+        helm_flags: typing.Optional[typing.Sequence[builtins.str]] = None,
+        namespace: typing.Optional[builtins.str] = None,
+        release_name: typing.Optional[builtins.str] = None,
+    ) -> None:
+        '''
+        :param values: -
+        :param helm_executable: -
+        :param helm_flags: -
+        :param namespace: -
+        :param release_name: -
+        '''
+        if isinstance(values, dict):
+            values = LaceworkagentValues(**values)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__42b286772f6a0399931871ddfc86cb3edc039392ac6d0608f2b4d7f1d1dc28fb)
+            check_type(argname=\\"argument values\\", value=values, expected_type=type_hints[\\"values\\"])
+            check_type(argname=\\"argument helm_executable\\", value=helm_executable, expected_type=type_hints[\\"helm_executable\\"])
+            check_type(argname=\\"argument helm_flags\\", value=helm_flags, expected_type=type_hints[\\"helm_flags\\"])
+            check_type(argname=\\"argument namespace\\", value=namespace, expected_type=type_hints[\\"namespace\\"])
+            check_type(argname=\\"argument release_name\\", value=release_name, expected_type=type_hints[\\"release_name\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {
+            \\"values\\": values,
+        }
+        if helm_executable is not None:
+            self._values[\\"helm_executable\\"] = helm_executable
+        if helm_flags is not None:
+            self._values[\\"helm_flags\\"] = helm_flags
+        if namespace is not None:
+            self._values[\\"namespace\\"] = namespace
+        if release_name is not None:
+            self._values[\\"release_name\\"] = release_name
+
+    @builtins.property
+    def values(self) -> \\"LaceworkagentValues\\":
+        result = self._values.get(\\"values\\")
+        assert result is not None, \\"Required property 'values' is missing\\"
+        return typing.cast(\\"LaceworkagentValues\\", result)
+
+    @builtins.property
+    def helm_executable(self) -> typing.Optional[builtins.str]:
+        result = self._values.get(\\"helm_executable\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def helm_flags(self) -> typing.Optional[typing.List[builtins.str]]:
+        result = self._values.get(\\"helm_flags\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    @builtins.property
+    def namespace(self) -> typing.Optional[builtins.str]:
+        result = self._values.get(\\"namespace\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def release_name(self) -> typing.Optional[builtins.str]:
+        result = self._values.get(\\"release_name\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkagentProps(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"lacework-agent.LaceworkagentValues\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"lacework_config\\": \\"laceworkConfig\\",
+        \\"additional_values\\": \\"additionalValues\\",
+        \\"cloudservice\\": \\"cloudservice\\",
+        \\"cluster_agent\\": \\"clusterAgent\\",
+        \\"daemonset\\": \\"daemonset\\",
+        \\"datacollector\\": \\"datacollector\\",
+        \\"deployment\\": \\"deployment\\",
+        \\"global_\\": \\"global\\",
+        \\"image\\": \\"image\\",
+        \\"priority_class_create\\": \\"priorityClassCreate\\",
+        \\"priority_class_name\\": \\"priorityClassName\\",
+        \\"priority_class_preemption_policy\\": \\"priorityClassPreemptionPolicy\\",
+        \\"priority_class_value\\": \\"priorityClassValue\\",
+        \\"resources\\": \\"resources\\",
+        \\"tolerations\\": \\"tolerations\\",
+    },
+)
+class LaceworkagentValues:
+    def __init__(
+        self,
+        *,
+        lacework_config: typing.Union[LaceworkAgentLaceworkConfig, typing.Dict[builtins.str, typing.Any]],
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        cloudservice: typing.Optional[typing.Union[LaceworkAgentCloudservice, typing.Dict[builtins.str, typing.Any]]] = None,
+        cluster_agent: typing.Optional[typing.Union[LaceworkAgentClusterAgent, typing.Dict[builtins.str, typing.Any]]] = None,
+        daemonset: typing.Optional[typing.Union[LaceworkAgentDaemonset, typing.Dict[builtins.str, typing.Any]]] = None,
+        datacollector: typing.Optional[typing.Union[LaceworkAgentDatacollector, typing.Dict[builtins.str, typing.Any]]] = None,
+        deployment: typing.Optional[typing.Union[LaceworkAgentDeployment, typing.Dict[builtins.str, typing.Any]]] = None,
+        global_: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        image: typing.Optional[typing.Union[LaceworkAgentImage, typing.Dict[builtins.str, typing.Any]]] = None,
+        priority_class_create: typing.Optional[builtins.bool] = None,
+        priority_class_name: typing.Optional[builtins.str] = None,
+        priority_class_preemption_policy: typing.Optional[builtins.str] = None,
+        priority_class_value: typing.Optional[jsii.Number] = None,
+        resources: typing.Optional[typing.Union[IoK8SApiCoreV1ResourceRequirements, typing.Dict[builtins.str, typing.Any]]] = None,
+        tolerations: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1Toleration, typing.Dict[builtins.str, typing.Any]]]] = None,
+    ) -> None:
+        '''
+        :param lacework_config: 
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param cloudservice: 
+        :param cluster_agent: 
+        :param daemonset: 
+        :param datacollector: 
+        :param deployment: 
+        :param global_: 
+        :param image: 
+        :param priority_class_create: If specified, a priority class is created and used to deploy agent.
+        :param priority_class_name: If specified, indicates the pod's priority. \\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+        :param priority_class_preemption_policy: If specified, it determines if agent pod can preempt a pod with a lower a priority.
+        :param priority_class_value: If specified, it represents the priority class value to use.
+        :param resources: Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        :param tolerations: If specified, the pod's tolerations.
+
+        :schema: lacework-agent
+        '''
+        if isinstance(lacework_config, dict):
+            lacework_config = LaceworkAgentLaceworkConfig(**lacework_config)
+        if isinstance(cloudservice, dict):
+            cloudservice = LaceworkAgentCloudservice(**cloudservice)
+        if isinstance(cluster_agent, dict):
+            cluster_agent = LaceworkAgentClusterAgent(**cluster_agent)
+        if isinstance(daemonset, dict):
+            daemonset = LaceworkAgentDaemonset(**daemonset)
+        if isinstance(datacollector, dict):
+            datacollector = LaceworkAgentDatacollector(**datacollector)
+        if isinstance(deployment, dict):
+            deployment = LaceworkAgentDeployment(**deployment)
+        if isinstance(image, dict):
+            image = LaceworkAgentImage(**image)
+        if isinstance(resources, dict):
+            resources = IoK8SApiCoreV1ResourceRequirements(**resources)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__75de6b5286dea4b274a90e031e8b30635c9eeb0419b57e7aeb0962ead8d548b7)
+            check_type(argname=\\"argument lacework_config\\", value=lacework_config, expected_type=type_hints[\\"lacework_config\\"])
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument cloudservice\\", value=cloudservice, expected_type=type_hints[\\"cloudservice\\"])
+            check_type(argname=\\"argument cluster_agent\\", value=cluster_agent, expected_type=type_hints[\\"cluster_agent\\"])
+            check_type(argname=\\"argument daemonset\\", value=daemonset, expected_type=type_hints[\\"daemonset\\"])
+            check_type(argname=\\"argument datacollector\\", value=datacollector, expected_type=type_hints[\\"datacollector\\"])
+            check_type(argname=\\"argument deployment\\", value=deployment, expected_type=type_hints[\\"deployment\\"])
+            check_type(argname=\\"argument global_\\", value=global_, expected_type=type_hints[\\"global_\\"])
+            check_type(argname=\\"argument image\\", value=image, expected_type=type_hints[\\"image\\"])
+            check_type(argname=\\"argument priority_class_create\\", value=priority_class_create, expected_type=type_hints[\\"priority_class_create\\"])
+            check_type(argname=\\"argument priority_class_name\\", value=priority_class_name, expected_type=type_hints[\\"priority_class_name\\"])
+            check_type(argname=\\"argument priority_class_preemption_policy\\", value=priority_class_preemption_policy, expected_type=type_hints[\\"priority_class_preemption_policy\\"])
+            check_type(argname=\\"argument priority_class_value\\", value=priority_class_value, expected_type=type_hints[\\"priority_class_value\\"])
+            check_type(argname=\\"argument resources\\", value=resources, expected_type=type_hints[\\"resources\\"])
+            check_type(argname=\\"argument tolerations\\", value=tolerations, expected_type=type_hints[\\"tolerations\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {
+            \\"lacework_config\\": lacework_config,
+        }
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if cloudservice is not None:
+            self._values[\\"cloudservice\\"] = cloudservice
+        if cluster_agent is not None:
+            self._values[\\"cluster_agent\\"] = cluster_agent
+        if daemonset is not None:
+            self._values[\\"daemonset\\"] = daemonset
+        if datacollector is not None:
+            self._values[\\"datacollector\\"] = datacollector
+        if deployment is not None:
+            self._values[\\"deployment\\"] = deployment
+        if global_ is not None:
+            self._values[\\"global_\\"] = global_
+        if image is not None:
+            self._values[\\"image\\"] = image
+        if priority_class_create is not None:
+            self._values[\\"priority_class_create\\"] = priority_class_create
+        if priority_class_name is not None:
+            self._values[\\"priority_class_name\\"] = priority_class_name
+        if priority_class_preemption_policy is not None:
+            self._values[\\"priority_class_preemption_policy\\"] = priority_class_preemption_policy
+        if priority_class_value is not None:
+            self._values[\\"priority_class_value\\"] = priority_class_value
+        if resources is not None:
+            self._values[\\"resources\\"] = resources
+        if tolerations is not None:
+            self._values[\\"tolerations\\"] = tolerations
+
+    @builtins.property
+    def lacework_config(self) -> LaceworkAgentLaceworkConfig:
+        '''
+        :schema: lacework-agent#laceworkConfig
+        '''
+        result = self._values.get(\\"lacework_config\\")
+        assert result is not None, \\"Required property 'lacework_config' is missing\\"
+        return typing.cast(LaceworkAgentLaceworkConfig, result)
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: lacework-agent#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def cloudservice(self) -> typing.Optional[LaceworkAgentCloudservice]:
+        '''
+        :schema: lacework-agent#cloudservice
+        '''
+        result = self._values.get(\\"cloudservice\\")
+        return typing.cast(typing.Optional[LaceworkAgentCloudservice], result)
+
+    @builtins.property
+    def cluster_agent(self) -> typing.Optional[LaceworkAgentClusterAgent]:
+        '''
+        :schema: lacework-agent#clusterAgent
+        '''
+        result = self._values.get(\\"cluster_agent\\")
+        return typing.cast(typing.Optional[LaceworkAgentClusterAgent], result)
+
+    @builtins.property
+    def daemonset(self) -> typing.Optional[LaceworkAgentDaemonset]:
+        '''
+        :schema: lacework-agent#daemonset
+        '''
+        result = self._values.get(\\"daemonset\\")
+        return typing.cast(typing.Optional[LaceworkAgentDaemonset], result)
+
+    @builtins.property
+    def datacollector(self) -> typing.Optional[LaceworkAgentDatacollector]:
+        '''
+        :schema: lacework-agent#datacollector
+        '''
+        result = self._values.get(\\"datacollector\\")
+        return typing.cast(typing.Optional[LaceworkAgentDatacollector], result)
+
+    @builtins.property
+    def deployment(self) -> typing.Optional[LaceworkAgentDeployment]:
+        '''
+        :schema: lacework-agent#deployment
+        '''
+        result = self._values.get(\\"deployment\\")
+        return typing.cast(typing.Optional[LaceworkAgentDeployment], result)
+
+    @builtins.property
+    def global_(self) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''
+        :schema: lacework-agent#global
+        '''
+        result = self._values.get(\\"global_\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def image(self) -> typing.Optional[LaceworkAgentImage]:
+        '''
+        :schema: lacework-agent#image
+        '''
+        result = self._values.get(\\"image\\")
+        return typing.cast(typing.Optional[LaceworkAgentImage], result)
+
+    @builtins.property
+    def priority_class_create(self) -> typing.Optional[builtins.bool]:
+        '''If specified, a priority class is created and used to deploy agent.
+
+        :schema: lacework-agent#priorityClassCreate
+        '''
+        result = self._values.get(\\"priority_class_create\\")
+        return typing.cast(typing.Optional[builtins.bool], result)
+
+    @builtins.property
+    def priority_class_name(self) -> typing.Optional[builtins.str]:
+        '''If specified, indicates the pod's priority.
+
+        \\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+
+        :schema: lacework-agent#priorityClassName
+        '''
+        result = self._values.get(\\"priority_class_name\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def priority_class_preemption_policy(self) -> typing.Optional[builtins.str]:
+        '''If specified, it determines if agent pod can preempt a pod with a lower a priority.
+
+        :schema: lacework-agent#priorityClassPreemptionPolicy
+        '''
+        result = self._values.get(\\"priority_class_preemption_policy\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def priority_class_value(self) -> typing.Optional[jsii.Number]:
+        '''If specified, it represents the priority class value to use.
+
+        :schema: lacework-agent#priorityClassValue
+        '''
+        result = self._values.get(\\"priority_class_value\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    @builtins.property
+    def resources(self) -> typing.Optional[IoK8SApiCoreV1ResourceRequirements]:
+        '''Compute Resources required by this container.
+
+        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+        :schema: lacework-agent#resources
+        '''
+        result = self._values.get(\\"resources\\")
+        return typing.cast(typing.Optional[IoK8SApiCoreV1ResourceRequirements], result)
+
+    @builtins.property
+    def tolerations(self) -> typing.Optional[typing.List[IoK8SApiCoreV1Toleration]]:
+        '''If specified, the pod's tolerations.
+
+        :schema: lacework-agent#tolerations
+        '''
+        result = self._values.get(\\"tolerations\\")
+        return typing.cast(typing.Optional[typing.List[IoK8SApiCoreV1Toleration]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LaceworkagentValues(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+__all__ = [
+    \\"IoK8SApiCoreV1Affinity\\",
+    \\"IoK8SApiCoreV1AffinityNodeAffinity\\",
+    \\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution\\",
+    \\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference\\",
+    \\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions\\",
+    \\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator\\",
+    \\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields\\",
+    \\"IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator\\",
+    \\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution\\",
+    \\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms\\",
+    \\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions\\",
+    \\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator\\",
+    \\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields\\",
+    \\"IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator\\",
+    \\"IoK8SApiCoreV1AffinityPodAffinity\\",
+    \\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution\\",
+    \\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm\\",
+    \\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector\\",
+    \\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions\\",
+    \\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector\\",
+    \\"IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions\\",
+    \\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution\\",
+    \\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector\\",
+    \\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions\\",
+    \\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector\\",
+    \\"IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions\\",
+    \\"IoK8SApiCoreV1AffinityPodAntiAffinity\\",
+    \\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution\\",
+    \\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm\\",
+    \\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector\\",
+    \\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions\\",
+    \\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector\\",
+    \\"IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions\\",
+    \\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution\\",
+    \\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector\\",
+    \\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions\\",
+    \\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector\\",
+    \\"IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions\\",
+    \\"IoK8SApiCoreV1DaemonSetUpdateStrategy\\",
+    \\"IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate\\",
+    \\"IoK8SApiCoreV1DaemonSetUpdateStrategyType\\",
+    \\"IoK8SApiCoreV1LocalObjectReference\\",
+    \\"IoK8SApiCoreV1ResourceRequirements\\",
+    \\"IoK8SApiCoreV1Toleration\\",
+    \\"IoK8SApiCoreV1TolerationEffect\\",
+    \\"IoK8SApiCoreV1TolerationOperator\\",
+    \\"LaceworkAgentCloudservice\\",
+    \\"LaceworkAgentCloudserviceGke\\",
+    \\"LaceworkAgentClusterAgent\\",
+    \\"LaceworkAgentClusterAgentImage\\",
+    \\"LaceworkAgentClusterAgentImagePullPolicy\\",
+    \\"LaceworkAgentDaemonset\\",
+    \\"LaceworkAgentDatacollector\\",
+    \\"LaceworkAgentDeployment\\",
+    \\"LaceworkAgentImage\\",
+    \\"LaceworkAgentImagePullPolicy\\",
+    \\"LaceworkAgentLaceworkConfig\\",
+    \\"LaceworkAgentLaceworkConfigAnonymizeIncoming\\",
+    \\"LaceworkAgentLaceworkConfigAutoUpgrade\\",
+    \\"LaceworkAgentLaceworkConfigCmdlinefilter\\",
+    \\"LaceworkAgentLaceworkConfigCodeaware\\",
+    \\"LaceworkAgentLaceworkConfigDatacollector\\",
+    \\"LaceworkAgentLaceworkConfigFim\\",
+    \\"LaceworkAgentLaceworkConfigPackagescan\\",
+    \\"LaceworkAgentLaceworkConfigProcscan\\",
+    \\"Laceworkagent\\",
+    \\"LaceworkagentProps\\",
+    \\"LaceworkagentValues\\",
+]
+
+publication.publish()
+
+def _typecheckingstub__dcbd3c1d64c57915cdfe4d3e9c252dc593c38b7af2c271606308ad2dd0688fca(
+    *,
+    node_affinity: typing.Optional[typing.Union[IoK8SApiCoreV1AffinityNodeAffinity, typing.Dict[builtins.str, typing.Any]]] = None,
+    pod_affinity: typing.Optional[typing.Union[IoK8SApiCoreV1AffinityPodAffinity, typing.Dict[builtins.str, typing.Any]]] = None,
+    pod_anti_affinity: typing.Optional[typing.Union[IoK8SApiCoreV1AffinityPodAntiAffinity, typing.Dict[builtins.str, typing.Any]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__83fb7082ba953b5b9e787cc0ee59a9bef2197db6a48b11240fdf117606315a5a(
+    *,
+    preferred_during_scheduling_ignored_during_execution: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution, typing.Dict[builtins.str, typing.Any]]]] = None,
+    required_during_scheduling_ignored_during_execution: typing.Optional[typing.Union[IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution, typing.Dict[builtins.str, typing.Any]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__3bc3a7ad7604790369045dfb4698addef29a8a8a6153811d9f7dd8f99e3ee359(
+    *,
+    preference: typing.Optional[typing.Union[IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference, typing.Dict[builtins.str, typing.Any]]] = None,
+    weight: typing.Optional[jsii.Number] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__41dee617dee988ead026c7bad2ebb4fae531007cc7f48f0db25cfa20dca41762(
+    *,
+    match_expressions: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions, typing.Dict[builtins.str, typing.Any]]]] = None,
+    match_fields: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields, typing.Dict[builtins.str, typing.Any]]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__3730cdd540fb8e7d48cf1be08570870a521033bbdb76cecc74c8fb287aebc010(
+    *,
+    key: typing.Optional[builtins.str] = None,
+    operator: typing.Optional[IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator] = None,
+    values: typing.Optional[typing.Sequence[builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__7b9dade3151f99e1afdce33c41e3c8dd8d3c83a16e10b28ddaf5ea28a3e22ada(
+    *,
+    key: typing.Optional[builtins.str] = None,
+    operator: typing.Optional[IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator] = None,
+    values: typing.Optional[typing.Sequence[builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__9acfa843b7229c0e9ad74630682849efa291d2c9468e4afb8a72503609d4a5d6(
+    *,
+    node_selector_terms: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms, typing.Dict[builtins.str, typing.Any]]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__2985f1fb46d7d123a1304f37a4bdd1cb669f518ddebf14def78cd809166f7135(
+    *,
+    match_expressions: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions, typing.Dict[builtins.str, typing.Any]]]] = None,
+    match_fields: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields, typing.Dict[builtins.str, typing.Any]]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__2eef7443ccd6b5aaac15c30182a3aaae735d74ec9a15de2a348964115b0f1bad(
+    *,
+    key: typing.Optional[builtins.str] = None,
+    operator: typing.Optional[IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator] = None,
+    values: typing.Optional[typing.Sequence[builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__9ec67c499846b6a293071ecb3ec3a0f941758830e6820225b2170274524e6b3a(
+    *,
+    key: typing.Optional[builtins.str] = None,
+    operator: typing.Optional[IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator] = None,
+    values: typing.Optional[typing.Sequence[builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__ecd2363c495f3d762f767f20f3b220c8eb4d1138684a8c2cf0ffa57e67d7aeeb(
+    *,
+    preferred_during_scheduling_ignored_during_execution: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution, typing.Dict[builtins.str, typing.Any]]]] = None,
+    required_during_scheduling_ignored_during_execution: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution, typing.Dict[builtins.str, typing.Any]]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__73fb8396890742e720d837189aebf4ac5e0bc16c2f01edcaf5364c545a74c0a1(
+    *,
+    pod_affinity_term: typing.Optional[typing.Union[IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm, typing.Dict[builtins.str, typing.Any]]] = None,
+    weight: typing.Optional[jsii.Number] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__b8dcc9ff575d6ba789f0a4bf1a9431102f18c195a13405596170979aca3a6cb2(
+    *,
+    topology_key: builtins.str,
+    label_selector: typing.Optional[typing.Union[IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector, typing.Dict[builtins.str, typing.Any]]] = None,
+    namespaces: typing.Optional[typing.Sequence[builtins.str]] = None,
+    namespace_selector: typing.Optional[typing.Union[IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector, typing.Dict[builtins.str, typing.Any]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__40cfaac301cd989c2a2863d9bcefa06dbd6fbab7916f86ca78ccf892347ffafb(
+    *,
+    match_expressions: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions, typing.Dict[builtins.str, typing.Any]]]] = None,
+    match_labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__2b198777efafa2bcf798a86663d42e7d69dea513909618f4a7ba62c47966529f(
+    *,
+    key: typing.Optional[builtins.str] = None,
+    operator: typing.Optional[builtins.str] = None,
+    values: typing.Optional[typing.Sequence[builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__1d7a88051a5ab512c4e0d9b5fbed96bb1f36fd6ae3201420ace8e2be23a019b2(
+    *,
+    match_expressions: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions, typing.Dict[builtins.str, typing.Any]]]] = None,
+    match_labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__bbd3a72a8cffc689f71da929f6797f32d6f852fa2e1e9d97277ed0eddeaad132(
+    *,
+    key: typing.Optional[builtins.str] = None,
+    operator: typing.Optional[builtins.str] = None,
+    values: typing.Optional[typing.Sequence[builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__2a6d00d95d2d04eea9613de1c7903d2e66e53fac220751130ed1b8dc64a5e972(
+    *,
+    label_selector: typing.Optional[typing.Union[IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector, typing.Dict[builtins.str, typing.Any]]] = None,
+    namespaces: typing.Optional[typing.Sequence[builtins.str]] = None,
+    namespace_selector: typing.Optional[typing.Union[IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector, typing.Dict[builtins.str, typing.Any]]] = None,
+    topology_key: typing.Optional[builtins.str] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__94286539963b88ed2abd60f58ddf76d754b62bbca1e65881e343f4dc1a75ecae(
+    *,
+    match_expressions: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions, typing.Dict[builtins.str, typing.Any]]]] = None,
+    match_labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__de7b755055a8d366bf9836a2f930f13b4b5936266e2bf73587ed60ba8b4b2a8c(
+    *,
+    key: typing.Optional[builtins.str] = None,
+    operator: typing.Optional[builtins.str] = None,
+    values: typing.Optional[typing.Sequence[builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__216dabe6923643276c2131b29326ded426ee439ab42adc975360c3f53dea4682(
+    *,
+    match_expressions: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions, typing.Dict[builtins.str, typing.Any]]]] = None,
+    match_labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__3ea0d99f7344162148befe0c73dc109ce6af186931d8630c3aab4a07df5a590a(
+    *,
+    key: typing.Optional[builtins.str] = None,
+    operator: typing.Optional[builtins.str] = None,
+    values: typing.Optional[typing.Sequence[builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__b88eace380f44c65d21d90d3a959666edb3c888eb5a8b0fe785c3aaa22d86421(
+    *,
+    preferred_during_scheduling_ignored_during_execution: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution, typing.Dict[builtins.str, typing.Any]]]] = None,
+    required_during_scheduling_ignored_during_execution: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution, typing.Dict[builtins.str, typing.Any]]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__3b5279544107027f249afe15ae53a3f9fc003336039ae784915c7894311253c0(
+    *,
+    pod_affinity_term: typing.Optional[typing.Union[IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm, typing.Dict[builtins.str, typing.Any]]] = None,
+    weight: typing.Optional[jsii.Number] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__d6879ad10b0b3bf32416b947889ea0fafb9697033bd98f9280aa3d9dac126887(
+    *,
+    topology_key: builtins.str,
+    label_selector: typing.Optional[typing.Union[IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector, typing.Dict[builtins.str, typing.Any]]] = None,
+    namespaces: typing.Optional[typing.Sequence[builtins.str]] = None,
+    namespace_selector: typing.Optional[typing.Union[IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector, typing.Dict[builtins.str, typing.Any]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__779e9109822ded6fb329c314168503867d9f0a2da63eb380b58847710fc7c54c(
+    *,
+    match_expressions: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions, typing.Dict[builtins.str, typing.Any]]]] = None,
+    match_labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__fbe1868dfaa4ea324e7b51741dc160ac660e7aead3d6ad63309f8527b880a9ee(
+    *,
+    key: typing.Optional[builtins.str] = None,
+    operator: typing.Optional[builtins.str] = None,
+    values: typing.Optional[typing.Sequence[builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__68e47b2143b4877a3368c835d90e670218ba9b3c952ba8824d9a815404577149(
+    *,
+    match_expressions: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions, typing.Dict[builtins.str, typing.Any]]]] = None,
+    match_labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__22b27419d7799ad450b94ff5f87bc58d4744c4e0c666e3767b396de0204de11a(
+    *,
+    key: typing.Optional[builtins.str] = None,
+    operator: typing.Optional[builtins.str] = None,
+    values: typing.Optional[typing.Sequence[builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__63f8c333243eb40563cc7d45ef1b7e6e5b9d38ad721d1418adf58e94b7bf4acb(
+    *,
+    label_selector: typing.Optional[typing.Union[IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector, typing.Dict[builtins.str, typing.Any]]] = None,
+    namespaces: typing.Optional[typing.Sequence[builtins.str]] = None,
+    namespace_selector: typing.Optional[typing.Union[IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector, typing.Dict[builtins.str, typing.Any]]] = None,
+    topology_key: typing.Optional[builtins.str] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__0fc9c7df6b2de294ab5354d9cf7c44bbfcc94265b47418f00cafe7ecdf36144c(
+    *,
+    match_expressions: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions, typing.Dict[builtins.str, typing.Any]]]] = None,
+    match_labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__ed3918916c6e7886791cf2a5252525faa2413def1916ebb4df746a8a27cbb1e7(
+    *,
+    key: typing.Optional[builtins.str] = None,
+    operator: typing.Optional[builtins.str] = None,
+    values: typing.Optional[typing.Sequence[builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__385d6e39815cb32272bda30489d64561dda13ec9946858d27fc65a0802694108(
+    *,
+    match_expressions: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions, typing.Dict[builtins.str, typing.Any]]]] = None,
+    match_labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__9fdfe8df35f946a45e968b4b38d69b1382d866a3449f1eda5f75ff5a6ac17808(
+    *,
+    key: typing.Optional[builtins.str] = None,
+    operator: typing.Optional[builtins.str] = None,
+    values: typing.Optional[typing.Sequence[builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__691cf1c6250365dd9cb33a494eefd1c10935548095a168d5ef395a7441862256(
+    *,
+    rolling_update: typing.Optional[typing.Union[IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate, typing.Dict[builtins.str, typing.Any]]] = None,
+    type: typing.Optional[IoK8SApiCoreV1DaemonSetUpdateStrategyType] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__bcbe1e4525c8ae8dac04633b9fd41a3cdc32975e54777d9b5669373b2f18141c(
+    *,
+    max_surge: typing.Any = None,
+    max_unavailable: typing.Any = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__aad31b07aae14ea370a8ca13338d399e64c240651525bbc3a724ea48937a61e8(
+    *,
+    name: typing.Optional[builtins.str] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__b0cfae6cb4aad42921bb69bfe68fccfe027731b98cff20327e29d9b23d764e1a(
+    *,
+    limits: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    requests: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__8961b249a3bd11e4645f57459dc73620f46a774c6a01af2d7b27f6d837bf44ea(
+    *,
+    effect: typing.Optional[IoK8SApiCoreV1TolerationEffect] = None,
+    key: typing.Optional[builtins.str] = None,
+    operator: typing.Optional[IoK8SApiCoreV1TolerationOperator] = None,
+    toleration_seconds: typing.Optional[jsii.Number] = None,
+    value: typing.Optional[builtins.str] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__a00c30cb766c4ce3670ed7fa040a7194f0cc005e50f492fee71a1d7221fdbc73(
+    *,
+    gke: typing.Optional[typing.Union[LaceworkAgentCloudserviceGke, typing.Dict[builtins.str, typing.Any]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__a4d2ea86626ffffc816a5d7ea7ea672b7cbcee10de8e26d93325b202baa6294c(
+    *,
+    autopilot: typing.Optional[builtins.bool] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__427477360d777d212ced442a6c1a4283eae0d78b2a8c760ed72582ef9fe4964a(
+    *,
+    enable: builtins.bool,
+    image: typing.Union[LaceworkAgentClusterAgentImage, typing.Dict[builtins.str, typing.Any]],
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    cluster_region: typing.Optional[builtins.str] = None,
+    cluster_type: typing.Optional[builtins.str] = None,
+    scrape_initial_delay_mins: typing.Optional[jsii.Number] = None,
+    scrape_interval_mins: typing.Optional[jsii.Number] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__1b0c01541508b3b32c7ca4979253b8778a14c281b271f717c8b3cfd5cc199c6e(
+    *,
+    pull_policy: LaceworkAgentClusterAgentImagePullPolicy,
+    registry: builtins.str,
+    repository: builtins.str,
+    tag: builtins.str,
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    image_pull_secrets: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1LocalObjectReference, typing.Dict[builtins.str, typing.Any]]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__8865f58784f4c0cc708c5b4fff21b85d0aa02c8830ebe0c003e678386afd20c6(
+    *,
+    affinity: typing.Union[IoK8SApiCoreV1Affinity, typing.Dict[builtins.str, typing.Any]],
+    update_strategy: typing.Union[IoK8SApiCoreV1DaemonSetUpdateStrategy, typing.Dict[builtins.str, typing.Any]],
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__f6147c05aec3384656fc31bffde0dfd4f7b09aec7c5989879df33bfa5a918a27(
+    *,
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    enable: typing.Optional[builtins.bool] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__787d1f6f42b54e0d6cad91b099f0e65026246f3e2b10b3a1f8add1f3ea9b4637(
+    *,
+    affinity: typing.Union[IoK8SApiCoreV1Affinity, typing.Dict[builtins.str, typing.Any]],
+    update_strategy: typing.Union[IoK8SApiCoreV1DaemonSetUpdateStrategy, typing.Dict[builtins.str, typing.Any]],
+    priority_class_create: typing.Optional[builtins.bool] = None,
+    priority_class_name: typing.Optional[builtins.str] = None,
+    priority_class_preemption_policy: typing.Optional[builtins.str] = None,
+    priority_class_value: typing.Optional[jsii.Number] = None,
+    resources: typing.Optional[typing.Union[IoK8SApiCoreV1ResourceRequirements, typing.Dict[builtins.str, typing.Any]]] = None,
+    tolerations: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1Toleration, typing.Dict[builtins.str, typing.Any]]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__4c0a83a494e348ea80a80280a82eb843acacd28d70ef2adf7d118c45b12ca124(
+    *,
+    pull_policy: LaceworkAgentImagePullPolicy,
+    registry: builtins.str,
+    repository: builtins.str,
+    tag: builtins.str,
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    image_pull_secrets: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1LocalObjectReference, typing.Dict[builtins.str, typing.Any]]]] = None,
+    override_value: typing.Optional[builtins.str] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__137ccaec2780b925802b147c3602013773aba0adcc89e414986c5d5a31ac1a52(
+    *,
+    access_token: typing.Any,
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    annotations: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+    anonymize_incoming: typing.Optional[typing.Union[LaceworkAgentLaceworkConfigAnonymizeIncoming, typing.Dict[builtins.str, typing.Any]]] = None,
+    auto_upgrade: typing.Optional[LaceworkAgentLaceworkConfigAutoUpgrade] = None,
+    cmdlinefilter: typing.Optional[typing.Union[LaceworkAgentLaceworkConfigCmdlinefilter, typing.Dict[builtins.str, typing.Any]]] = None,
+    codeaware: typing.Optional[typing.Union[LaceworkAgentLaceworkConfigCodeaware, typing.Dict[builtins.str, typing.Any]]] = None,
+    container_engine_endpoint: typing.Optional[builtins.str] = None,
+    container_runtime: typing.Optional[builtins.str] = None,
+    datacollector: typing.Optional[LaceworkAgentLaceworkConfigDatacollector] = None,
+    env: typing.Optional[builtins.str] = None,
+    fim: typing.Optional[typing.Union[LaceworkAgentLaceworkConfigFim, typing.Dict[builtins.str, typing.Any]]] = None,
+    k8_s_node_scrape_interval_mins: typing.Optional[jsii.Number] = None,
+    kubernetes_cluster: typing.Optional[builtins.str] = None,
+    labels: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+    metadata_request_interval: typing.Optional[builtins.str] = None,
+    packagescan: typing.Optional[typing.Union[LaceworkAgentLaceworkConfigPackagescan, typing.Dict[builtins.str, typing.Any]]] = None,
+    perfmode: typing.Optional[builtins.str] = None,
+    procscan: typing.Optional[typing.Union[LaceworkAgentLaceworkConfigProcscan, typing.Dict[builtins.str, typing.Any]]] = None,
+    proxy_url: typing.Optional[builtins.str] = None,
+    server_url: typing.Optional[builtins.str] = None,
+    service_account_name: typing.Optional[builtins.str] = None,
+    stdout_logging: typing.Optional[builtins.bool] = None,
+    tags: typing.Optional[typing.Mapping[builtins.str, builtins.str]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__cae19ba49ffeb3756e422ae55a616d552a7b1a48e805ed6342cdcedeb898252d(
+    *,
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    netmask: typing.Optional[builtins.str] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__d49626aa144236418ebd376e1f10ea94398ba5fc8167c20717e1b2e7d5629eb9(
+    *,
+    allow: typing.Optional[builtins.str] = None,
+    disallow: typing.Optional[builtins.str] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__5882a8edec8095b7334e91a883a0e95f3d4d4a8f83a44c6e4483316a2267bf63(
+    *,
+    enable: typing.Optional[builtins.bool] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__3a82613c3b10f84fd3c85552b1bf3d3eb0de5e479e129b12fa8986455f413ed2(
+    *,
+    enable: builtins.bool,
+    file_ignore: typing.Sequence[builtins.str],
+    file_path: typing.Sequence[builtins.str],
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    cooling_period: typing.Optional[jsii.Number] = None,
+    crawl_interval: typing.Optional[jsii.Number] = None,
+    no_atime: typing.Optional[builtins.bool] = None,
+    run_at: typing.Any = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__7a28ae402580638d4ca326df3f41bd0b2997d028ee2ad046ae4834bceb9580ee(
+    *,
+    enable: typing.Optional[builtins.bool] = None,
+    interval: typing.Optional[jsii.Number] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__574fdc26e474c6dcbd22d3b5de880518aa899c6e4ac43317fce728e591c17e31(
+    *,
+    enable: typing.Optional[builtins.bool] = None,
+    interval: typing.Optional[jsii.Number] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__114ea5fe7e7841a5303933808db33ffb935e37c0ef8577589791a696f226951d(
+    scope: _constructs_77d1e7e8.Construct,
+    id: builtins.str,
+    *,
+    values: typing.Union[LaceworkagentValues, typing.Dict[builtins.str, typing.Any]],
+    helm_executable: typing.Optional[builtins.str] = None,
+    helm_flags: typing.Optional[typing.Sequence[builtins.str]] = None,
+    namespace: typing.Optional[builtins.str] = None,
+    release_name: typing.Optional[builtins.str] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__42b286772f6a0399931871ddfc86cb3edc039392ac6d0608f2b4d7f1d1dc28fb(
+    *,
+    values: typing.Union[LaceworkagentValues, typing.Dict[builtins.str, typing.Any]],
+    helm_executable: typing.Optional[builtins.str] = None,
+    helm_flags: typing.Optional[typing.Sequence[builtins.str]] = None,
+    namespace: typing.Optional[builtins.str] = None,
+    release_name: typing.Optional[builtins.str] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__75de6b5286dea4b274a90e031e8b30635c9eeb0419b57e7aeb0962ead8d548b7(
+    *,
+    lacework_config: typing.Union[LaceworkAgentLaceworkConfig, typing.Dict[builtins.str, typing.Any]],
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    cloudservice: typing.Optional[typing.Union[LaceworkAgentCloudservice, typing.Dict[builtins.str, typing.Any]]] = None,
+    cluster_agent: typing.Optional[typing.Union[LaceworkAgentClusterAgent, typing.Dict[builtins.str, typing.Any]]] = None,
+    daemonset: typing.Optional[typing.Union[LaceworkAgentDaemonset, typing.Dict[builtins.str, typing.Any]]] = None,
+    datacollector: typing.Optional[typing.Union[LaceworkAgentDatacollector, typing.Dict[builtins.str, typing.Any]]] = None,
+    deployment: typing.Optional[typing.Union[LaceworkAgentDeployment, typing.Dict[builtins.str, typing.Any]]] = None,
+    global_: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    image: typing.Optional[typing.Union[LaceworkAgentImage, typing.Dict[builtins.str, typing.Any]]] = None,
+    priority_class_create: typing.Optional[builtins.bool] = None,
+    priority_class_name: typing.Optional[builtins.str] = None,
+    priority_class_preemption_policy: typing.Optional[builtins.str] = None,
+    priority_class_value: typing.Optional[jsii.Number] = None,
+    resources: typing.Optional[typing.Union[IoK8SApiCoreV1ResourceRequirements, typing.Dict[builtins.str, typing.Any]]] = None,
+    tolerations: typing.Optional[typing.Sequence[typing.Union[IoK8SApiCoreV1Toleration, typing.Dict[builtins.str, typing.Any]]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+",
+  "lacework_agent/_jsii/__init__.py": "import abc
+import builtins
+import datetime
+import enum
+import typing
+
+import jsii
+import publication
+import typing_extensions
+
+from typeguard import check_type
+
+import cdk8s._jsii
+import constructs._jsii
+
+__jsii_assembly__ = jsii.JSIIAssembly.load(
+    \\"lacework-agent\\", \\"0.0.0\\", __name__[0:-6], \\"lacework-agent@0.0.0.jsii.tgz\\"
+)
+
+__all__ = [
+    \\"__jsii_assembly__\\",
+]
+
+publication.publish()
+",
+  "lacework_agent/py.typed": "
+",
+}
+`;
+
+exports[`importing helm chart helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0 with typescript lanugage 1`] = `
+Object {
+  "author": Object {
+    "name": "generated@generated.com",
+    "roles": Array [
+      "author",
+    ],
+  },
+  "dependencies": "__omitted__",
+  "dependencyClosure": Object {
+    "cdk8s": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Org.Cdk8s",
+          "packageId": "Org.Cdk8s",
+        },
+        "go": Object {
+          "moduleName": "github.com/cdk8s-team/cdk8s-core-go",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "cdk8s",
+            "groupId": "org.cdk8s",
+          },
+          "package": "org.cdk8s",
+        },
+        "js": Object {
+          "npm": "cdk8s",
+        },
+        "python": Object {
+          "distName": "cdk8s",
+          "module": "cdk8s",
+        },
+      },
+    },
+    "constructs": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Constructs",
+          "packageId": "Constructs",
+        },
+        "go": Object {
+          "moduleName": "github.com/aws/constructs-go",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "constructs",
+            "groupId": "software.constructs",
+          },
+          "package": "software.constructs",
+        },
+        "js": Object {
+          "npm": "constructs",
+        },
+        "python": Object {
+          "distName": "constructs",
+          "module": "constructs",
+        },
+      },
+    },
+  },
+  "description": "lacework-agent",
+  "fingerprint": "<fingerprint>",
+  "homepage": "http://generated",
+  "jsiiVersion": "__omitted__",
+  "license": "UNLICENSED",
+  "metadata": Object {
+    "jsii": Object {
+      "pacmak": Object {
+        "hasDefaultInterfaces": true,
+      },
+    },
+  },
+  "name": "lacework-agent",
+  "repository": Object {
+    "type": "git",
+    "url": "http://generated",
+  },
+  "schema": "jsii/0.10.0",
+  "targets": Object {
+    "js": Object {
+      "npm": "lacework-agent",
+    },
+  },
+  "types": Object {
+    "lacework-agent.IoK8SApiCoreV1Affinity": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "io.k8s.api.core.v1.Affinity",
+        },
+        "summary": "Affinity is a group of affinity scheduling rules.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1Affinity",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 583,
+      },
+      "name": "IoK8SApiCoreV1Affinity",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.Affinity#nodeAffinity",
+            },
+            "summary": "Node affinity is a group of node affinity scheduling rules.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 589,
+          },
+          "name": "nodeAffinity",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinity",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.Affinity#podAffinity",
+            },
+            "summary": "Pod affinity is a group of inter pod affinity scheduling rules.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 596,
+          },
+          "name": "podAffinity",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinity",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.Affinity#podAntiAffinity",
+            },
+            "summary": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 603,
+          },
+          "name": "podAntiAffinity",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinity",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1Affinity",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinity": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinity",
+        },
+        "summary": "Node affinity is a group of node affinity scheduling rules.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinity",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 914,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinity",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinity#preferredDuringSchedulingIgnoredDuringExecution",
+            },
+            "remarks": "The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+            "summary": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 920,
+          },
+          "name": "preferredDuringSchedulingIgnoredDuringExecution",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinity#requiredDuringSchedulingIgnoredDuringExecution",
+            },
+            "remarks": "that is, it represents the OR of the selectors represented by the node selector terms.",
+            "summary": "A node selector represents the union of the results of one or more label queries over a set of nodes;",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 927,
+          },
+          "name": "requiredDuringSchedulingIgnoredDuringExecution",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinity",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+        },
+        "summary": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1035,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution#preference",
+            },
+            "remarks": "The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+            "summary": "A null or empty node selector term matches no objects.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1041,
+          },
+          "name": "preference",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight",
+            },
+            "summary": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1048,
+          },
+          "name": "weight",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
+        },
+        "remarks": "The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+        "summary": "A null or empty node selector term matches no objects.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1188,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference#matchExpressions",
+            },
+            "summary": "A list of node selector requirements by node's labels.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1194,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference#matchFields",
+            },
+            "summary": "A list of node selector requirements by node's fields.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1201,
+          },
+          "name": "matchFields",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
+        },
+        "summary": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1392,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#key",
+            },
+            "summary": "The label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1398,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#operator",
+            },
+            "remarks": "Possible enum values:
+- \`\\"DoesNotExist\\"\`
+- \`\\"Exists\\"\`
+- \`\\"Gt\\"\`
+- \`\\"In\\"\`
+- \`\\"Lt\\"\`
+- \`\\"NotIn\\"\`",
+            "summary": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1413,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+            "summary": "An array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1420,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator",
+        },
+        "remarks": "Possible enum values:
+- \`\\"DoesNotExist\\"\`
+- \`\\"Exists\\"\`
+- \`\\"Gt\\"\`
+- \`\\"In\\"\`
+- \`\\"Lt\\"\`
+- \`\\"NotIn\\"\`",
+        "summary": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1752,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "DoesNotExist.",
+          },
+          "name": "DOES_NOT_EXIST",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Exists.",
+          },
+          "name": "EXISTS",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Gt.",
+          },
+          "name": "GT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "In.",
+          },
+          "name": "IN",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Lt.",
+          },
+          "name": "LT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "NotIn.",
+          },
+          "name": "NOT_IN",
+        },
+      ],
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator",
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
+        },
+        "summary": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1429,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#key",
+            },
+            "summary": "The label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1435,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#operator",
+            },
+            "remarks": "Possible enum values:
+- \`\\"DoesNotExist\\"\`
+- \`\\"Exists\\"\`
+- \`\\"Gt\\"\`
+- \`\\"In\\"\`
+- \`\\"Lt\\"\`
+- \`\\"NotIn\\"\`",
+            "summary": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1450,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+            "summary": "An array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1457,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator",
+        },
+        "remarks": "Possible enum values:
+- \`\\"DoesNotExist\\"\`
+- \`\\"Exists\\"\`
+- \`\\"Gt\\"\`
+- \`\\"In\\"\`
+- \`\\"Lt\\"\`
+- \`\\"NotIn\\"\`",
+        "summary": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1780,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "DoesNotExist.",
+          },
+          "name": "DOES_NOT_EXIST",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Exists.",
+          },
+          "name": "EXISTS",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Gt.",
+          },
+          "name": "GT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "In.",
+          },
+          "name": "IN",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Lt.",
+          },
+          "name": "LT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "NotIn.",
+          },
+          "name": "NOT_IN",
+        },
+      ],
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator",
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+        },
+        "remarks": "that is, it represents the OR of the selectors represented by the node selector terms.",
+        "summary": "A node selector represents the union of the results of one or more label queries over a set of nodes;",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1057,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution#nodeSelectorTerms",
+            },
+            "remarks": "A list of node selector terms. The terms are ORed.",
+            "summary": "Required.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1063,
+          },
+          "name": "nodeSelectorTerms",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
+        },
+        "remarks": "The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+        "summary": "A null or empty node selector term matches no objects.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1210,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms#matchExpressions",
+            },
+            "summary": "A list of node selector requirements by node's labels.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1216,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms#matchFields",
+            },
+            "summary": "A list of node selector requirements by node's fields.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1223,
+          },
+          "name": "matchFields",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
+        },
+        "summary": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1466,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#key",
+            },
+            "summary": "The label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1472,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#operator",
+            },
+            "remarks": "Possible enum values:
+- \`\\"DoesNotExist\\"\`
+- \`\\"Exists\\"\`
+- \`\\"Gt\\"\`
+- \`\\"In\\"\`
+- \`\\"Lt\\"\`
+- \`\\"NotIn\\"\`",
+            "summary": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1487,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+            "summary": "An array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1494,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator",
+        },
+        "remarks": "Possible enum values:
+- \`\\"DoesNotExist\\"\`
+- \`\\"Exists\\"\`
+- \`\\"Gt\\"\`
+- \`\\"In\\"\`
+- \`\\"Lt\\"\`
+- \`\\"NotIn\\"\`",
+        "summary": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1808,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "DoesNotExist.",
+          },
+          "name": "DOES_NOT_EXIST",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Exists.",
+          },
+          "name": "EXISTS",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Gt.",
+          },
+          "name": "GT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "In.",
+          },
+          "name": "IN",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Lt.",
+          },
+          "name": "LT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "NotIn.",
+          },
+          "name": "NOT_IN",
+        },
+      ],
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator",
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
+        },
+        "summary": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1503,
+      },
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#key",
+            },
+            "summary": "The label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1509,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#operator",
+            },
+            "remarks": "Possible enum values:
+- \`\\"DoesNotExist\\"\`
+- \`\\"Exists\\"\`
+- \`\\"Gt\\"\`
+- \`\\"In\\"\`
+- \`\\"Lt\\"\`
+- \`\\"NotIn\\"\`",
+            "summary": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1524,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+            "summary": "An array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1531,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator",
+        },
+        "remarks": "Possible enum values:
+- \`\\"DoesNotExist\\"\`
+- \`\\"Exists\\"\`
+- \`\\"Gt\\"\`
+- \`\\"In\\"\`
+- \`\\"Lt\\"\`
+- \`\\"NotIn\\"\`",
+        "summary": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1836,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "DoesNotExist.",
+          },
+          "name": "DOES_NOT_EXIST",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Exists.",
+          },
+          "name": "EXISTS",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Gt.",
+          },
+          "name": "GT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "In.",
+          },
+          "name": "IN",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Lt.",
+          },
+          "name": "LT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "NotIn.",
+          },
+          "name": "NOT_IN",
+        },
+      ],
+      "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator",
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinity": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinity",
+        },
+        "summary": "Pod affinity is a group of inter pod affinity scheduling rules.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinity",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 936,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinity",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinity#preferredDuringSchedulingIgnoredDuringExecution",
+            },
+            "remarks": "The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+            "summary": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 942,
+          },
+          "name": "preferredDuringSchedulingIgnoredDuringExecution",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinity#requiredDuringSchedulingIgnoredDuringExecution",
+            },
+            "remarks": "If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+            "summary": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 949,
+          },
+          "name": "requiredDuringSchedulingIgnoredDuringExecution",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinity",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+        },
+        "summary": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s).",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1072,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution#podAffinityTerm",
+            },
+            "summary": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1078,
+          },
+          "name": "podAffinityTerm",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight",
+            },
+            "summary": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1085,
+          },
+          "name": "weight",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+        },
+        "summary": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1232,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#topologyKey",
+            },
+            "remarks": "Empty topologyKey is not allowed.",
+            "summary": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1259,
+          },
+          "name": "topologyKey",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#labelSelector",
+            },
+            "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "summary": "A label selector is a label query over a set of resources.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1238,
+          },
+          "name": "labelSelector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaces",
+            },
+            "remarks": "The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".",
+            "summary": "namespaces specifies a static list of namespace names that the term applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1252,
+          },
+          "name": "namespaces",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaceSelector",
+            },
+            "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "summary": "A label selector is a label query over a set of resources.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1245,
+          },
+          "name": "namespaceSelector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+        },
+        "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "summary": "A label selector is a label query over a set of resources.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1540,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchExpressions",
+            },
+            "remarks": "The requirements are ANDed.",
+            "summary": "matchExpressions is a list of label selector requirements.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1546,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchLabels",
+            },
+            "remarks": "A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.",
+            "summary": "matchLabels is a map of {key,value} pairs.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1553,
+          },
+          "name": "matchLabels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+        },
+        "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1856,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#key",
+            },
+            "summary": "key is the label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1862,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#operator",
+            },
+            "remarks": "Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "summary": "operator represents a key's relationship to a set of values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1869,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "summary": "values is an array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1876,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+        },
+        "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "summary": "A label selector is a label query over a set of resources.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1562,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchExpressions",
+            },
+            "remarks": "The requirements are ANDed.",
+            "summary": "matchExpressions is a list of label selector requirements.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1568,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchLabels",
+            },
+            "remarks": "A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.",
+            "summary": "matchLabels is a map of {key,value} pairs.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1575,
+          },
+          "name": "matchLabels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+        },
+        "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1885,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#key",
+            },
+            "summary": "key is the label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1891,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#operator",
+            },
+            "remarks": "Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "summary": "operator represents a key's relationship to a set of values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1898,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "summary": "values is an array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1905,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+        },
+        "summary": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1094,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#labelSelector",
+            },
+            "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "summary": "A label selector is a label query over a set of resources.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1100,
+          },
+          "name": "labelSelector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaces",
+            },
+            "remarks": "The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".",
+            "summary": "namespaces specifies a static list of namespace names that the term applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1114,
+          },
+          "name": "namespaces",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaceSelector",
+            },
+            "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "summary": "A label selector is a label query over a set of resources.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1107,
+          },
+          "name": "namespaceSelector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#topologyKey",
+            },
+            "remarks": "Empty topologyKey is not allowed.",
+            "summary": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1121,
+          },
+          "name": "topologyKey",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+        },
+        "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "summary": "A label selector is a label query over a set of resources.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1268,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchExpressions",
+            },
+            "remarks": "The requirements are ANDed.",
+            "summary": "matchExpressions is a list of label selector requirements.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1274,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchLabels",
+            },
+            "remarks": "A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.",
+            "summary": "matchLabels is a map of {key,value} pairs.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1281,
+          },
+          "name": "matchLabels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+        },
+        "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1584,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#key",
+            },
+            "summary": "key is the label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1590,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#operator",
+            },
+            "remarks": "Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "summary": "operator represents a key's relationship to a set of values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1597,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "summary": "values is an array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1604,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+        },
+        "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "summary": "A label selector is a label query over a set of resources.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1290,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchExpressions",
+            },
+            "remarks": "The requirements are ANDed.",
+            "summary": "matchExpressions is a list of label selector requirements.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1296,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchLabels",
+            },
+            "remarks": "A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.",
+            "summary": "matchLabels is a map of {key,value} pairs.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1303,
+          },
+          "name": "matchLabels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+        },
+        "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1613,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#key",
+            },
+            "summary": "key is the label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1619,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#operator",
+            },
+            "remarks": "Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "summary": "operator represents a key's relationship to a set of values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1626,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "summary": "values is an array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1633,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinity": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinity",
+        },
+        "summary": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinity",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 958,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinity",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinity#preferredDuringSchedulingIgnoredDuringExecution",
+            },
+            "remarks": "The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+            "summary": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 964,
+          },
+          "name": "preferredDuringSchedulingIgnoredDuringExecution",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinity#requiredDuringSchedulingIgnoredDuringExecution",
+            },
+            "remarks": "If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+            "summary": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 971,
+          },
+          "name": "requiredDuringSchedulingIgnoredDuringExecution",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinity",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+        },
+        "summary": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s).",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1130,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution#podAffinityTerm",
+            },
+            "summary": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1136,
+          },
+          "name": "podAffinityTerm",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight",
+            },
+            "summary": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1143,
+          },
+          "name": "weight",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+        },
+        "summary": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1312,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#topologyKey",
+            },
+            "remarks": "Empty topologyKey is not allowed.",
+            "summary": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1339,
+          },
+          "name": "topologyKey",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#labelSelector",
+            },
+            "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "summary": "A label selector is a label query over a set of resources.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1318,
+          },
+          "name": "labelSelector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaces",
+            },
+            "remarks": "The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".",
+            "summary": "namespaces specifies a static list of namespace names that the term applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1332,
+          },
+          "name": "namespaces",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaceSelector",
+            },
+            "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "summary": "A label selector is a label query over a set of resources.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1325,
+          },
+          "name": "namespaceSelector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+        },
+        "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "summary": "A label selector is a label query over a set of resources.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1642,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchExpressions",
+            },
+            "remarks": "The requirements are ANDed.",
+            "summary": "matchExpressions is a list of label selector requirements.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1648,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchLabels",
+            },
+            "remarks": "A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.",
+            "summary": "matchLabels is a map of {key,value} pairs.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1655,
+          },
+          "name": "matchLabels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+        },
+        "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1914,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#key",
+            },
+            "summary": "key is the label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1920,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#operator",
+            },
+            "remarks": "Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "summary": "operator represents a key's relationship to a set of values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1927,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "summary": "values is an array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1934,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+        },
+        "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "summary": "A label selector is a label query over a set of resources.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1664,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchExpressions",
+            },
+            "remarks": "The requirements are ANDed.",
+            "summary": "matchExpressions is a list of label selector requirements.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1670,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchLabels",
+            },
+            "remarks": "A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.",
+            "summary": "matchLabels is a map of {key,value} pairs.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1677,
+          },
+          "name": "matchLabels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+        },
+        "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1943,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#key",
+            },
+            "summary": "key is the label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1949,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#operator",
+            },
+            "remarks": "Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "summary": "operator represents a key's relationship to a set of values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1956,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "summary": "values is an array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1963,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+        },
+        "summary": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1152,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#labelSelector",
+            },
+            "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "summary": "A label selector is a label query over a set of resources.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1158,
+          },
+          "name": "labelSelector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaces",
+            },
+            "remarks": "The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".",
+            "summary": "namespaces specifies a static list of namespace names that the term applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1172,
+          },
+          "name": "namespaces",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaceSelector",
+            },
+            "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "summary": "A label selector is a label query over a set of resources.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1165,
+          },
+          "name": "namespaceSelector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#topologyKey",
+            },
+            "remarks": "Empty topologyKey is not allowed.",
+            "summary": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1179,
+          },
+          "name": "topologyKey",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+        },
+        "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "summary": "A label selector is a label query over a set of resources.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1348,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchExpressions",
+            },
+            "remarks": "The requirements are ANDed.",
+            "summary": "matchExpressions is a list of label selector requirements.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1354,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchLabels",
+            },
+            "remarks": "A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.",
+            "summary": "matchLabels is a map of {key,value} pairs.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1361,
+          },
+          "name": "matchLabels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+        },
+        "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1686,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#key",
+            },
+            "summary": "key is the label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1692,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#operator",
+            },
+            "remarks": "Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "summary": "operator represents a key's relationship to a set of values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1699,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "summary": "values is an array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1706,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+        },
+        "remarks": "The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+        "summary": "A label selector is a label query over a set of resources.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1370,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchExpressions",
+            },
+            "remarks": "The requirements are ANDed.",
+            "summary": "matchExpressions is a list of label selector requirements.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1376,
+          },
+          "name": "matchExpressions",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchLabels",
+            },
+            "remarks": "A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.",
+            "summary": "matchLabels is a map of {key,value} pairs.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1383,
+          },
+          "name": "matchLabels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
+    },
+    "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+        },
+        "summary": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1715,
+      },
+      "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#key",
+            },
+            "summary": "key is the label key that the selector applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1721,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#operator",
+            },
+            "remarks": "Valid operators are In, NotIn, Exists and DoesNotExist.",
+            "summary": "operator represents a key's relationship to a set of values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1728,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#values",
+            },
+            "remarks": "If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+            "summary": "values is an array of string values.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 1735,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
+    },
+    "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategy": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "io.k8s.api.core.v1.DaemonSetUpdateStrategy",
+        },
+        "summary": "DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategy",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 612,
+      },
+      "name": "IoK8SApiCoreV1DaemonSetUpdateStrategy",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.DaemonSetUpdateStrategy#rollingUpdate",
+            },
+            "summary": "Spec to control the desired behavior of daemon set rolling update.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 618,
+          },
+          "name": "rollingUpdate",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.DaemonSetUpdateStrategy#type",
+            },
+            "default": "RollingUpdate.",
+            "remarks": "Possible enum values:
+- \`\\"OnDelete\\"\` Replace the old daemons only when it's killed
+- \`\\"RollingUpdate\\"\` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.",
+            "summary": "Type of daemon set update. Can be \\"RollingUpdate\\" or \\"OnDelete\\". Default is RollingUpdate.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 630,
+          },
+          "name": "type",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategyType",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1DaemonSetUpdateStrategy",
+    },
+    "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
+        },
+        "summary": "Spec to control the desired behavior of daemon set rolling update.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 980,
+      },
+      "name": "IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate#maxSurge",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 984,
+          },
+          "name": "maxSurge",
+          "optional": true,
+          "type": Object {
+            "primitive": "any",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate#maxUnavailable",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 989,
+          },
+          "name": "maxUnavailable",
+          "optional": true,
+          "type": Object {
+            "primitive": "any",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
+    },
+    "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategyType": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1DaemonSetUpdateStrategyType",
+        },
+        "default": "RollingUpdate.",
+        "remarks": "Possible enum values:
+- \`\\"OnDelete\\"\` Replace the old daemons only when it's killed
+- \`\\"RollingUpdate\\"\` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.",
+        "summary": "Type of daemon set update. Can be \\"RollingUpdate\\" or \\"OnDelete\\". Default is RollingUpdate.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategyType",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1003,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "OnDelete.",
+          },
+          "name": "ON_DELETE",
+        },
+        Object {
+          "docs": Object {
+            "summary": "RollingUpdate.",
+          },
+          "name": "ROLLING_UPDATE",
+        },
+      ],
+      "name": "IoK8SApiCoreV1DaemonSetUpdateStrategyType",
+      "symbolId": "lacework-agent:IoK8SApiCoreV1DaemonSetUpdateStrategyType",
+    },
+    "lacework-agent.IoK8SApiCoreV1LocalObjectReference": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "io.k8s.api.core.v1.LocalObjectReference",
+        },
+        "summary": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1LocalObjectReference",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 650,
+      },
+      "name": "IoK8SApiCoreV1LocalObjectReference",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.LocalObjectReference#name",
+            },
+            "remarks": "More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+            "summary": "Name of the referent.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 656,
+          },
+          "name": "name",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1LocalObjectReference",
+    },
+    "lacework-agent.IoK8SApiCoreV1ResourceRequirements": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "io.k8s.api.core.v1.ResourceRequirements",
+        },
+        "summary": "ResourceRequirements describes the compute resource requirements.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1ResourceRequirements",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 508,
+      },
+      "name": "IoK8SApiCoreV1ResourceRequirements",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.ResourceRequirements#limits",
+            },
+            "remarks": "More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+            "summary": "Limits describes the maximum amount of compute resources allowed.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 514,
+          },
+          "name": "limits",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.ResourceRequirements#requests",
+            },
+            "remarks": "If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+            "summary": "Requests describes the minimum amount of compute resources required.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 521,
+          },
+          "name": "requests",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1ResourceRequirements",
+    },
+    "lacework-agent.IoK8SApiCoreV1Toleration": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "io.k8s.api.core.v1.Toleration",
+        },
+        "summary": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1Toleration",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 530,
+      },
+      "name": "IoK8SApiCoreV1Toleration",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.Toleration#effect",
+            },
+            "remarks": "Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+Possible enum values:
+- \`\\"NoExecute\\"\` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+- \`\\"NoSchedule\\"\` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+- \`\\"PreferNoSchedule\\"\` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.",
+            "summary": "Effect indicates the taint effect to match.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 541,
+          },
+          "name": "effect",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1TolerationEffect",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.Toleration#key",
+            },
+            "remarks": "Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+            "summary": "Key is the taint key that the toleration applies to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 548,
+          },
+          "name": "key",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.Toleration#operator",
+            },
+            "default": "Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+            "remarks": "Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+Possible enum values:
+- \`\\"Equal\\"\`
+- \`\\"Exists\\"\`",
+            "summary": "Operator represents a key's relationship to the value.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 560,
+          },
+          "name": "operator",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1TolerationOperator",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.Toleration#tolerationSeconds",
+            },
+            "remarks": "By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+            "summary": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 567,
+          },
+          "name": "tolerationSeconds",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "io.k8s.api.core.v1.Toleration#value",
+            },
+            "remarks": "If the operator is Exists, the value should be empty, otherwise just a regular string.",
+            "summary": "Value is the taint value the toleration matches to.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 574,
+          },
+          "name": "value",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:IoK8SApiCoreV1Toleration",
+    },
+    "lacework-agent.IoK8SApiCoreV1TolerationEffect": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1TolerationEffect",
+        },
+        "remarks": "Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+Possible enum values:
+- \`\\"NoExecute\\"\` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+- \`\\"NoSchedule\\"\` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+- \`\\"PreferNoSchedule\\"\` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.",
+        "summary": "Effect indicates the taint effect to match.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1TolerationEffect",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 883,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "NoExecute.",
+          },
+          "name": "NO_EXECUTE",
+        },
+        Object {
+          "docs": Object {
+            "summary": "NoSchedule.",
+          },
+          "name": "NO_SCHEDULE",
+        },
+        Object {
+          "docs": Object {
+            "summary": "PreferNoSchedule.",
+          },
+          "name": "PREFER_NO_SCHEDULE",
+        },
+      ],
+      "name": "IoK8SApiCoreV1TolerationEffect",
+      "symbolId": "lacework-agent:IoK8SApiCoreV1TolerationEffect",
+    },
+    "lacework-agent.IoK8SApiCoreV1TolerationOperator": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "IoK8SApiCoreV1TolerationOperator",
+        },
+        "default": "Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+        "remarks": "Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+Possible enum values:
+- \`\\"Equal\\"\`
+- \`\\"Exists\\"\`",
+        "summary": "Operator represents a key's relationship to the value.",
+      },
+      "fqn": "lacework-agent.IoK8SApiCoreV1TolerationOperator",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 902,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "Equal.",
+          },
+          "name": "EQUAL",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Exists.",
+          },
+          "name": "EXISTS",
+        },
+      ],
+      "name": "IoK8SApiCoreV1TolerationOperator",
+      "symbolId": "lacework-agent:IoK8SApiCoreV1TolerationOperator",
+    },
+    "lacework-agent.LaceworkAgentCloudservice": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentCloudservice",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentCloudservice",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 235,
+      },
+      "name": "LaceworkAgentCloudservice",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentCloudservice#gke",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 239,
+          },
+          "name": "gke",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentCloudserviceGke",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentCloudservice",
+    },
+    "lacework-agent.LaceworkAgentCloudserviceGke": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentCloudserviceGke",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentCloudserviceGke",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 637,
+      },
+      "name": "LaceworkAgentCloudserviceGke",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentCloudserviceGke#autopilot",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 641,
+          },
+          "name": "autopilot",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentCloudserviceGke",
+    },
+    "lacework-agent.LaceworkAgentClusterAgent": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentClusterAgent",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentClusterAgent",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 319,
+      },
+      "name": "LaceworkAgentClusterAgent",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgent#enable",
+            },
+            "summary": "Enable cluster agent.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 330,
+          },
+          "name": "enable",
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgent#image",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 323,
+          },
+          "name": "image",
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentClusterAgentImage",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgent#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 365,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgent#clusterRegion",
+            },
+            "summary": "Kubernetes cluster cloud region.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 344,
+          },
+          "name": "clusterRegion",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgent#clusterType",
+            },
+            "summary": "Kubernetes cluster type.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 337,
+          },
+          "name": "clusterType",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgent#scrapeInitialDelayMins",
+            },
+            "summary": "Cluster mode agent's initial delay of cluster scraping after startup in minutes.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 351,
+          },
+          "name": "scrapeInitialDelayMins",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgent#scrapeIntervalMins",
+            },
+            "summary": "Cluster mode agent's scrape interval in minutes.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 358,
+          },
+          "name": "scrapeIntervalMins",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentClusterAgent",
+    },
+    "lacework-agent.LaceworkAgentClusterAgentImage": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentClusterAgentImage",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentClusterAgentImage",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 683,
+      },
+      "name": "LaceworkAgentClusterAgentImage",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgentImage#pullPolicy",
+            },
+            "default": "Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+            "remarks": "One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+Possible enum values:
+- \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+- \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+- \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+            "summary": "Image pull policy.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 702,
+          },
+          "name": "pullPolicy",
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentClusterAgentImagePullPolicy",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgentImage#registry",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 707,
+          },
+          "name": "registry",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgentImage#repository",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 712,
+          },
+          "name": "repository",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgentImage#tag",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 717,
+          },
+          "name": "tag",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgentImage#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 724,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentClusterAgentImage#imagePullSecrets",
+            },
+            "remarks": "If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+            "summary": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 689,
+          },
+          "name": "imagePullSecrets",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1LocalObjectReference",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentClusterAgentImage",
+    },
+    "lacework-agent.LaceworkAgentClusterAgentImagePullPolicy": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentClusterAgentImagePullPolicy",
+        },
+        "default": "Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+        "remarks": "One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+Possible enum values:
+- \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+- \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+- \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+        "summary": "Image pull policy.",
+      },
+      "fqn": "lacework-agent.LaceworkAgentClusterAgentImagePullPolicy",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 1021,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "Always.",
+          },
+          "name": "ALWAYS",
+        },
+        Object {
+          "docs": Object {
+            "summary": "IfNotPresent.",
+          },
+          "name": "IF_NOT_PRESENT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Never.",
+          },
+          "name": "NEVER",
+        },
+      ],
+      "name": "LaceworkAgentClusterAgentImagePullPolicy",
+      "symbolId": "lacework-agent:LaceworkAgentClusterAgentImagePullPolicy",
+    },
+    "lacework-agent.LaceworkAgentDaemonset": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentDaemonset",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentDaemonset",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 153,
+      },
+      "name": "LaceworkAgentDaemonset",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDaemonset#affinity",
+            },
+            "summary": "If specified, the pod's scheduling constraints.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 159,
+          },
+          "name": "affinity",
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1Affinity",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDaemonset#updateStrategy",
+            },
+            "summary": "An update strategy to replace existing DaemonSet pods with new pods.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 166,
+          },
+          "name": "updateStrategy",
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategy",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentDaemonset",
+    },
+    "lacework-agent.LaceworkAgentDatacollector": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentDatacollector",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentDatacollector",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 246,
+      },
+      "name": "LaceworkAgentDatacollector",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDatacollector#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 259,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDatacollector#enable",
+            },
+            "summary": "Enable lacework datacollector.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 252,
+          },
+          "name": "enable",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentDatacollector",
+    },
+    "lacework-agent.LaceworkAgentDeployment": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentDeployment",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentDeployment",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 173,
+      },
+      "name": "LaceworkAgentDeployment",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDeployment#affinity",
+            },
+            "summary": "If specified, the pod's scheduling constraints.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 179,
+          },
+          "name": "affinity",
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1Affinity",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDeployment#updateStrategy",
+            },
+            "summary": "An update strategy to replace existing DaemonSet pods with new pods.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 186,
+          },
+          "name": "updateStrategy",
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1DaemonSetUpdateStrategy",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDeployment#priorityClassCreate",
+            },
+            "summary": "If specified, a priority class is created and used to deploy agent.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 207,
+          },
+          "name": "priorityClassCreate",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDeployment#priorityClassName",
+            },
+            "remarks": "\\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+            "summary": "If specified, indicates the pod's priority.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 200,
+          },
+          "name": "priorityClassName",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDeployment#priorityClassPreemptionPolicy",
+            },
+            "summary": "If specified, it determines if agent pod can preempt a pod with a lower a priority.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 214,
+          },
+          "name": "priorityClassPreemptionPolicy",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDeployment#priorityClassValue",
+            },
+            "summary": "If specified, it represents the priority class value to use.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 221,
+          },
+          "name": "priorityClassValue",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDeployment#resources",
+            },
+            "remarks": "Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+            "summary": "Compute Resources required by this container.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 193,
+          },
+          "name": "resources",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1ResourceRequirements",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentDeployment#tolerations",
+            },
+            "summary": "If specified, the pod's tolerations.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 228,
+          },
+          "name": "tolerations",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1Toleration",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentDeployment",
+    },
+    "lacework-agent.LaceworkAgentImage": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentImage",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentImage",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 266,
+      },
+      "name": "LaceworkAgentImage",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentImage#pullPolicy",
+            },
+            "default": "Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+            "remarks": "One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+Possible enum values:
+- \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+- \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+- \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+            "summary": "Image pull policy.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 285,
+          },
+          "name": "pullPolicy",
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentImagePullPolicy",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentImage#registry",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 290,
+          },
+          "name": "registry",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentImage#repository",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 295,
+          },
+          "name": "repository",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentImage#tag",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 300,
+          },
+          "name": "tag",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentImage#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 312,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentImage#imagePullSecrets",
+            },
+            "remarks": "If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+            "summary": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 272,
+          },
+          "name": "imagePullSecrets",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1LocalObjectReference",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentImage#overrideValue",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 305,
+          },
+          "name": "overrideValue",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentImage",
+    },
+    "lacework-agent.LaceworkAgentImagePullPolicy": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentImagePullPolicy",
+        },
+        "default": "Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+        "remarks": "One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+Possible enum values:
+- \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+- \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+- \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+        "summary": "Image pull policy.",
+      },
+      "fqn": "lacework-agent.LaceworkAgentImagePullPolicy",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 671,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "Always.",
+          },
+          "name": "ALWAYS",
+        },
+        Object {
+          "docs": Object {
+            "summary": "IfNotPresent.",
+          },
+          "name": "IF_NOT_PRESENT",
+        },
+        Object {
+          "docs": Object {
+            "summary": "Never.",
+          },
+          "name": "NEVER",
+        },
+      ],
+      "name": "LaceworkAgentImagePullPolicy",
+      "symbolId": "lacework-agent:LaceworkAgentImagePullPolicy",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfig": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfig",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfig",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 372,
+      },
+      "name": "LaceworkAgentLaceworkConfig",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#accessToken",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 376,
+          },
+          "name": "accessToken",
+          "type": Object {
+            "primitive": "any",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 499,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#annotations",
+            },
+            "remarks": "They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+            "summary": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 388,
+          },
+          "name": "annotations",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#anonymizeIncoming",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 381,
+          },
+          "name": "anonymizeIncoming",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigAnonymizeIncoming",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#autoUpgrade",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 393,
+          },
+          "name": "autoUpgrade",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigAutoUpgrade",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#cmdlinefilter",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 398,
+          },
+          "name": "cmdlinefilter",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigCmdlinefilter",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#codeaware",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 403,
+          },
+          "name": "codeaware",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigCodeaware",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#containerEngineEndpoint",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 408,
+          },
+          "name": "containerEngineEndpoint",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#containerRuntime",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 413,
+          },
+          "name": "containerRuntime",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#datacollector",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 418,
+          },
+          "name": "datacollector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigDatacollector",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#env",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 447,
+          },
+          "name": "env",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#fim",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 452,
+          },
+          "name": "fim",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigFim",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#k8sNodeScrapeIntervalMins",
+            },
+            "summary": "Kubernetes node's scrape interval in minutes.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 425,
+          },
+          "name": "k8SNodeScrapeIntervalMins",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#kubernetesCluster",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 430,
+          },
+          "name": "kubernetesCluster",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#labels",
+            },
+            "remarks": "May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+            "summary": "Map of string keys and values that can be used to organize and categorize (scope and select) objects.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 437,
+          },
+          "name": "labels",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#metadataRequestInterval",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 442,
+          },
+          "name": "metadataRequestInterval",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#packagescan",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 457,
+          },
+          "name": "packagescan",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigPackagescan",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#perfmode",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 492,
+          },
+          "name": "perfmode",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#procscan",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 462,
+          },
+          "name": "procscan",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfigProcscan",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#proxyUrl",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 467,
+          },
+          "name": "proxyUrl",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#serverUrl",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 472,
+          },
+          "name": "serverUrl",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#serviceAccountName",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 477,
+          },
+          "name": "serviceAccountName",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#stdoutLogging",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 482,
+          },
+          "name": "stdoutLogging",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfig#tags",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 487,
+          },
+          "name": "tags",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfig",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigAnonymizeIncoming": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigAnonymizeIncoming",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigAnonymizeIncoming",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 731,
+      },
+      "name": "LaceworkAgentLaceworkConfigAnonymizeIncoming",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigAnonymizeIncoming#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 742,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigAnonymizeIncoming#netmask",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 735,
+          },
+          "name": "netmask",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigAnonymizeIncoming",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigAutoUpgrade": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigAutoUpgrade",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigAutoUpgrade",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 749,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "disable.",
+          },
+          "name": "DISABLE",
+        },
+        Object {
+          "docs": Object {
+            "summary": "enable.",
+          },
+          "name": "ENABLE",
+        },
+      ],
+      "name": "LaceworkAgentLaceworkConfigAutoUpgrade",
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigAutoUpgrade",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigCmdlinefilter": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigCmdlinefilter",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigCmdlinefilter",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 759,
+      },
+      "name": "LaceworkAgentLaceworkConfigCmdlinefilter",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigCmdlinefilter#allow",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 763,
+          },
+          "name": "allow",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigCmdlinefilter#disallow",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 768,
+          },
+          "name": "disallow",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigCmdlinefilter",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigCodeaware": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigCodeaware",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigCodeaware",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 775,
+      },
+      "name": "LaceworkAgentLaceworkConfigCodeaware",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigCodeaware#enable",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 779,
+          },
+          "name": "enable",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigCodeaware",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigDatacollector": Object {
+      "assembly": "lacework-agent",
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigDatacollector",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigDatacollector",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 786,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "disable.",
+          },
+          "name": "DISABLE",
+        },
+        Object {
+          "docs": Object {
+            "summary": "enable.",
+          },
+          "name": "ENABLE",
+        },
+      ],
+      "name": "LaceworkAgentLaceworkConfigDatacollector",
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigDatacollector",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigFim": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigFim",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigFim",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 796,
+      },
+      "name": "LaceworkAgentLaceworkConfigFim",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigFim#enable",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 810,
+          },
+          "name": "enable",
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigFim#fileIgnore",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 815,
+          },
+          "name": "fileIgnore",
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigFim#filePath",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 820,
+          },
+          "name": "filePath",
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigFim#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 837,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigFim#coolingPeriod",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 800,
+          },
+          "name": "coolingPeriod",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigFim#crawlInterval",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 805,
+          },
+          "name": "crawlInterval",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigFim#noAtime",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 825,
+          },
+          "name": "noAtime",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigFim#runAt",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 830,
+          },
+          "name": "runAt",
+          "optional": true,
+          "type": Object {
+            "primitive": "any",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigFim",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigPackagescan": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigPackagescan",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigPackagescan",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 844,
+      },
+      "name": "LaceworkAgentLaceworkConfigPackagescan",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigPackagescan#enable",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 848,
+          },
+          "name": "enable",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigPackagescan#interval",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 853,
+          },
+          "name": "interval",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigPackagescan",
+    },
+    "lacework-agent.LaceworkAgentLaceworkConfigProcscan": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "LaceworkAgentLaceworkConfigProcscan",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkAgentLaceworkConfigProcscan",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 860,
+      },
+      "name": "LaceworkAgentLaceworkConfigProcscan",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigProcscan#enable",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 864,
+          },
+          "name": "enable",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "LaceworkAgentLaceworkConfigProcscan#interval",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 869,
+          },
+          "name": "interval",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkAgentLaceworkConfigProcscan",
+    },
+    "lacework-agent.Laceworkagent": Object {
+      "assembly": "lacework-agent",
+      "base": "constructs.Construct",
+      "fqn": "lacework-agent.Laceworkagent",
+      "initializer": Object {
+        "locationInModule": Object {
+          "filename": "lacework-agent.ts",
+          "line": 14,
+        },
+        "parameters": Array [
+          Object {
+            "name": "scope",
+            "type": Object {
+              "fqn": "constructs.Construct",
+            },
+          },
+          Object {
+            "name": "id",
+            "type": Object {
+              "primitive": "string",
+            },
+          },
+          Object {
+            "name": "props",
+            "type": Object {
+              "fqn": "lacework-agent.LaceworkagentProps",
+            },
+          },
+        ],
+      },
+      "kind": "class",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 13,
+      },
+      "name": "Laceworkagent",
+      "symbolId": "lacework-agent:Laceworkagent",
+    },
+    "lacework-agent.LaceworkagentProps": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "fqn": "lacework-agent.LaceworkagentProps",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 5,
+      },
+      "name": "LaceworkagentProps",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 10,
+          },
+          "name": "values",
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkagentValues",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 8,
+          },
+          "name": "helmExecutable",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 9,
+          },
+          "name": "helmFlags",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 6,
+          },
+          "name": "namespace",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 7,
+          },
+          "name": "releaseName",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkagentProps",
+    },
+    "lacework-agent.LaceworkagentValues": Object {
+      "assembly": "lacework-agent",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "lacework-agent",
+        },
+      },
+      "fqn": "lacework-agent.LaceworkagentValues",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "lacework-agent.ts",
+        "line": 58,
+      },
+      "name": "LaceworkagentValues",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#laceworkConfig",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 97,
+          },
+          "name": "laceworkConfig",
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentLaceworkConfig",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 146,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#cloudservice",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 77,
+          },
+          "name": "cloudservice",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentCloudservice",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#clusterAgent",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 92,
+          },
+          "name": "clusterAgent",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentClusterAgent",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#daemonset",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 67,
+          },
+          "name": "daemonset",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentDaemonset",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#datacollector",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 82,
+          },
+          "name": "datacollector",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentDatacollector",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#deployment",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 72,
+          },
+          "name": "deployment",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentDeployment",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#global",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 62,
+          },
+          "name": "global",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#image",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 87,
+          },
+          "name": "image",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.LaceworkAgentImage",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#priorityClassCreate",
+            },
+            "summary": "If specified, a priority class is created and used to deploy agent.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 118,
+          },
+          "name": "priorityClassCreate",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#priorityClassName",
+            },
+            "remarks": "\\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+            "summary": "If specified, indicates the pod's priority.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 111,
+          },
+          "name": "priorityClassName",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#priorityClassPreemptionPolicy",
+            },
+            "summary": "If specified, it determines if agent pod can preempt a pod with a lower a priority.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 125,
+          },
+          "name": "priorityClassPreemptionPolicy",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#priorityClassValue",
+            },
+            "summary": "If specified, it represents the priority class value to use.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 132,
+          },
+          "name": "priorityClassValue",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#resources",
+            },
+            "remarks": "Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+            "summary": "Compute Resources required by this container.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 104,
+          },
+          "name": "resources",
+          "optional": true,
+          "type": Object {
+            "fqn": "lacework-agent.IoK8SApiCoreV1ResourceRequirements",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "lacework-agent#tolerations",
+            },
+            "summary": "If specified, the pod's tolerations.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 139,
+          },
+          "name": "tolerations",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "fqn": "lacework-agent.IoK8SApiCoreV1Toleration",
+              },
+              "kind": "array",
+            },
+          },
+        },
+      ],
+      "symbolId": "lacework-agent:LaceworkagentValues",
+    },
+  },
+  "version": "0.0.0",
+}
+`;
+
+exports[`importing helm chart helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0 with typescript lanugage 2`] = `
+Object {
+  "lacework-agent.ts": "// generated by cdk8s
+import { Helm, HelmProps } from 'cdk8s';
+import { Construct } from 'constructs';
+
+export interface LaceworkagentProps {
+  readonly namespace?: string;
+  readonly releaseName?: string;
+  readonly helmExecutable?: string;
+  readonly helmFlags?: string[];
+  readonly values: LaceworkagentValues;
+}
+
+export class Laceworkagent extends Construct {
+  public constructor(scope: Construct, id: string, props: LaceworkagentProps) {
+    super(scope, id)
+    let updatedProps = {};
+
+    if (props.values) {
+      const { additionalValues, ...valuesWithoutAdditionalValues } = props.values;
+      updatedProps = {
+        ...props,
+        values: {
+          ...this.flattenAdditionalValues(valuesWithoutAdditionalValues),
+          ...additionalValues,
+        }
+      };
+    }
+
+    const finalProps: HelmProps = {
+      chart: 'lacework-agent',
+      repo: 'https://lacework.github.io/helm-charts',
+      version: '6.9.0',
+      ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
+    };
+
+    new Helm(scope, 'Helm', finalProps)
+  }
+
+  private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
+    for (let prop in props) {
+      if (typeof(props[prop]) === 'object' && prop !== 'additionalValues') {
+        props[prop] = this.flattenAdditionalValues(props[prop]);
+      }
+    }
+
+    const { additionalValues, ...valuesWithoutAdditionalValues } = props;
+
+    return {
+      ...valuesWithoutAdditionalValues,
+      ...additionalValues,
+    };
+  }
+}
+
+/**
+ * @schema lacework-agent
+ */
+export interface LaceworkagentValues {
+  /**
+   * @schema lacework-agent#global
+   */
+  readonly global?: { [key: string]: any };
+
+  /**
+   * @schema lacework-agent#daemonset
+   */
+  readonly daemonset?: LaceworkAgentDaemonset;
+
+  /**
+   * @schema lacework-agent#deployment
+   */
+  readonly deployment?: LaceworkAgentDeployment;
+
+  /**
+   * @schema lacework-agent#cloudservice
+   */
+  readonly cloudservice?: LaceworkAgentCloudservice;
+
+  /**
+   * @schema lacework-agent#datacollector
+   */
+  readonly datacollector?: LaceworkAgentDatacollector;
+
+  /**
+   * @schema lacework-agent#image
+   */
+  readonly image?: LaceworkAgentImage;
+
+  /**
+   * @schema lacework-agent#clusterAgent
+   */
+  readonly clusterAgent?: LaceworkAgentClusterAgent;
+
+  /**
+   * @schema lacework-agent#laceworkConfig
+   */
+  readonly laceworkConfig: LaceworkAgentLaceworkConfig;
+
+  /**
+   * Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+   *
+   * @schema lacework-agent#resources
+   */
+  readonly resources?: IoK8SApiCoreV1ResourceRequirements;
+
+  /**
+   * If specified, indicates the pod's priority. \\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+   *
+   * @schema lacework-agent#priorityClassName
+   */
+  readonly priorityClassName?: string;
+
+  /**
+   * If specified, a priority class is created and used to deploy agent
+   *
+   * @schema lacework-agent#priorityClassCreate
+   */
+  readonly priorityClassCreate?: boolean;
+
+  /**
+   * If specified, it determines if agent pod can preempt a pod with a lower a priority
+   *
+   * @schema lacework-agent#priorityClassPreemptionPolicy
+   */
+  readonly priorityClassPreemptionPolicy?: string;
+
+  /**
+   * If specified, it represents the priority class value to use
+   *
+   * @schema lacework-agent#priorityClassValue
+   */
+  readonly priorityClassValue?: number;
+
+  /**
+   * If specified, the pod's tolerations.
+   *
+   * @schema lacework-agent#tolerations
+   */
+  readonly tolerations?: IoK8SApiCoreV1Toleration[];
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema lacework-agent#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema LaceworkAgentDaemonset
+ */
+export interface LaceworkAgentDaemonset {
+  /**
+   * If specified, the pod's scheduling constraints
+   *
+   * @schema LaceworkAgentDaemonset#affinity
+   */
+  readonly affinity: IoK8SApiCoreV1Affinity;
+
+  /**
+   * An update strategy to replace existing DaemonSet pods with new pods.
+   *
+   * @schema LaceworkAgentDaemonset#updateStrategy
+   */
+  readonly updateStrategy: IoK8SApiCoreV1DaemonSetUpdateStrategy;
+
+}
+
+/**
+ * @schema LaceworkAgentDeployment
+ */
+export interface LaceworkAgentDeployment {
+  /**
+   * If specified, the pod's scheduling constraints
+   *
+   * @schema LaceworkAgentDeployment#affinity
+   */
+  readonly affinity: IoK8SApiCoreV1Affinity;
+
+  /**
+   * An update strategy to replace existing DaemonSet pods with new pods.
+   *
+   * @schema LaceworkAgentDeployment#updateStrategy
+   */
+  readonly updateStrategy: IoK8SApiCoreV1DaemonSetUpdateStrategy;
+
+  /**
+   * Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+   *
+   * @schema LaceworkAgentDeployment#resources
+   */
+  readonly resources?: IoK8SApiCoreV1ResourceRequirements;
+
+  /**
+   * If specified, indicates the pod's priority. \\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+   *
+   * @schema LaceworkAgentDeployment#priorityClassName
+   */
+  readonly priorityClassName?: string;
+
+  /**
+   * If specified, a priority class is created and used to deploy agent
+   *
+   * @schema LaceworkAgentDeployment#priorityClassCreate
+   */
+  readonly priorityClassCreate?: boolean;
+
+  /**
+   * If specified, it determines if agent pod can preempt a pod with a lower a priority
+   *
+   * @schema LaceworkAgentDeployment#priorityClassPreemptionPolicy
+   */
+  readonly priorityClassPreemptionPolicy?: string;
+
+  /**
+   * If specified, it represents the priority class value to use
+   *
+   * @schema LaceworkAgentDeployment#priorityClassValue
+   */
+  readonly priorityClassValue?: number;
+
+  /**
+   * If specified, the pod's tolerations.
+   *
+   * @schema LaceworkAgentDeployment#tolerations
+   */
+  readonly tolerations?: IoK8SApiCoreV1Toleration[];
+
+}
+
+/**
+ * @schema LaceworkAgentCloudservice
+ */
+export interface LaceworkAgentCloudservice {
+  /**
+   * @schema LaceworkAgentCloudservice#gke
+   */
+  readonly gke?: LaceworkAgentCloudserviceGke;
+
+}
+
+/**
+ * @schema LaceworkAgentDatacollector
+ */
+export interface LaceworkAgentDatacollector {
+  /**
+   * Enable lacework datacollector
+   *
+   * @schema LaceworkAgentDatacollector#enable
+   */
+  readonly enable?: boolean;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema LaceworkAgentDatacollector#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema LaceworkAgentImage
+ */
+export interface LaceworkAgentImage {
+  /**
+   * ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+   *
+   * @schema LaceworkAgentImage#imagePullSecrets
+   */
+  readonly imagePullSecrets?: IoK8SApiCoreV1LocalObjectReference[];
+
+  /**
+   * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+   *
+   * Possible enum values:
+   * - \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+   * - \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+   * - \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+   *
+   * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+   * @schema LaceworkAgentImage#pullPolicy
+   */
+  readonly pullPolicy: LaceworkAgentImagePullPolicy;
+
+  /**
+   * @schema LaceworkAgentImage#registry
+   */
+  readonly registry: string;
+
+  /**
+   * @schema LaceworkAgentImage#repository
+   */
+  readonly repository: string;
+
+  /**
+   * @schema LaceworkAgentImage#tag
+   */
+  readonly tag: string;
+
+  /**
+   * @schema LaceworkAgentImage#overrideValue
+   */
+  readonly overrideValue?: string;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema LaceworkAgentImage#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema LaceworkAgentClusterAgent
+ */
+export interface LaceworkAgentClusterAgent {
+  /**
+   * @schema LaceworkAgentClusterAgent#image
+   */
+  readonly image: LaceworkAgentClusterAgentImage;
+
+  /**
+   * Enable cluster agent
+   *
+   * @schema LaceworkAgentClusterAgent#enable
+   */
+  readonly enable: boolean;
+
+  /**
+   * Kubernetes cluster type
+   *
+   * @schema LaceworkAgentClusterAgent#clusterType
+   */
+  readonly clusterType?: string;
+
+  /**
+   * Kubernetes cluster cloud region
+   *
+   * @schema LaceworkAgentClusterAgent#clusterRegion
+   */
+  readonly clusterRegion?: string;
+
+  /**
+   * Cluster mode agent's initial delay of cluster scraping after startup in minutes
+   *
+   * @schema LaceworkAgentClusterAgent#scrapeInitialDelayMins
+   */
+  readonly scrapeInitialDelayMins?: number;
+
+  /**
+   * Cluster mode agent's scrape interval in minutes
+   *
+   * @schema LaceworkAgentClusterAgent#scrapeIntervalMins
+   */
+  readonly scrapeIntervalMins?: number;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema LaceworkAgentClusterAgent#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfig
+ */
+export interface LaceworkAgentLaceworkConfig {
+  /**
+   * @schema LaceworkAgentLaceworkConfig#accessToken
+   */
+  readonly accessToken: any;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#anonymizeIncoming
+   */
+  readonly anonymizeIncoming?: LaceworkAgentLaceworkConfigAnonymizeIncoming;
+
+  /**
+   * Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations
+   *
+   * @schema LaceworkAgentLaceworkConfig#annotations
+   */
+  readonly annotations?: { [key: string]: string };
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#autoUpgrade
+   */
+  readonly autoUpgrade?: LaceworkAgentLaceworkConfigAutoUpgrade;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#cmdlinefilter
+   */
+  readonly cmdlinefilter?: LaceworkAgentLaceworkConfigCmdlinefilter;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#codeaware
+   */
+  readonly codeaware?: LaceworkAgentLaceworkConfigCodeaware;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#containerEngineEndpoint
+   */
+  readonly containerEngineEndpoint?: string;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#containerRuntime
+   */
+  readonly containerRuntime?: string;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#datacollector
+   */
+  readonly datacollector?: LaceworkAgentLaceworkConfigDatacollector;
+
+  /**
+   * Kubernetes node's scrape interval in minutes
+   *
+   * @schema LaceworkAgentLaceworkConfig#k8sNodeScrapeIntervalMins
+   */
+  readonly k8SNodeScrapeIntervalMins?: number;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#kubernetesCluster
+   */
+  readonly kubernetesCluster?: string;
+
+  /**
+   * Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
+   *
+   * @schema LaceworkAgentLaceworkConfig#labels
+   */
+  readonly labels?: { [key: string]: string };
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#metadataRequestInterval
+   */
+  readonly metadataRequestInterval?: string;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#env
+   */
+  readonly env?: string;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#fim
+   */
+  readonly fim?: LaceworkAgentLaceworkConfigFim;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#packagescan
+   */
+  readonly packagescan?: LaceworkAgentLaceworkConfigPackagescan;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#procscan
+   */
+  readonly procscan?: LaceworkAgentLaceworkConfigProcscan;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#proxyUrl
+   */
+  readonly proxyUrl?: string;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#serverUrl
+   */
+  readonly serverUrl?: string;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#serviceAccountName
+   */
+  readonly serviceAccountName?: string;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#stdoutLogging
+   */
+  readonly stdoutLogging?: boolean;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#tags
+   */
+  readonly tags?: { [key: string]: string };
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#perfmode
+   */
+  readonly perfmode?: string;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema LaceworkAgentLaceworkConfig#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * ResourceRequirements describes the compute resource requirements.
+ *
+ * @schema io.k8s.api.core.v1.ResourceRequirements
+ */
+export interface IoK8SApiCoreV1ResourceRequirements {
+  /**
+   * Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+   *
+   * @schema io.k8s.api.core.v1.ResourceRequirements#limits
+   */
+  readonly limits?: { [key: string]: any };
+
+  /**
+   * Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+   *
+   * @schema io.k8s.api.core.v1.ResourceRequirements#requests
+   */
+  readonly requests?: { [key: string]: any };
+
+}
+
+/**
+ * The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+ *
+ * @schema io.k8s.api.core.v1.Toleration
+ */
+export interface IoK8SApiCoreV1Toleration {
+  /**
+   * Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+   *
+   * Possible enum values:
+   * - \`\\"NoExecute\\"\` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+   * - \`\\"NoSchedule\\"\` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+   * - \`\\"PreferNoSchedule\\"\` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+   *
+   * @schema io.k8s.api.core.v1.Toleration#effect
+   */
+  readonly effect?: IoK8SApiCoreV1TolerationEffect;
+
+  /**
+   * Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+   *
+   * @schema io.k8s.api.core.v1.Toleration#key
+   */
+  readonly key?: string;
+
+  /**
+   * Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+   *
+   * Possible enum values:
+   * - \`\\"Equal\\"\`
+   * - \`\\"Exists\\"\`
+   *
+   * @default Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+   * @schema io.k8s.api.core.v1.Toleration#operator
+   */
+  readonly operator?: IoK8SApiCoreV1TolerationOperator;
+
+  /**
+   * TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+   *
+   * @schema io.k8s.api.core.v1.Toleration#tolerationSeconds
+   */
+  readonly tolerationSeconds?: number;
+
+  /**
+   * Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+   *
+   * @schema io.k8s.api.core.v1.Toleration#value
+   */
+  readonly value?: string;
+
+}
+
+/**
+ * Affinity is a group of affinity scheduling rules.
+ *
+ * @schema io.k8s.api.core.v1.Affinity
+ */
+export interface IoK8SApiCoreV1Affinity {
+  /**
+   * Node affinity is a group of node affinity scheduling rules.
+   *
+   * @schema io.k8s.api.core.v1.Affinity#nodeAffinity
+   */
+  readonly nodeAffinity?: IoK8SApiCoreV1AffinityNodeAffinity;
+
+  /**
+   * Pod affinity is a group of inter pod affinity scheduling rules.
+   *
+   * @schema io.k8s.api.core.v1.Affinity#podAffinity
+   */
+  readonly podAffinity?: IoK8SApiCoreV1AffinityPodAffinity;
+
+  /**
+   * Pod anti affinity is a group of inter pod anti affinity scheduling rules.
+   *
+   * @schema io.k8s.api.core.v1.Affinity#podAntiAffinity
+   */
+  readonly podAntiAffinity?: IoK8SApiCoreV1AffinityPodAntiAffinity;
+
+}
+
+/**
+ * DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.
+ *
+ * @schema io.k8s.api.core.v1.DaemonSetUpdateStrategy
+ */
+export interface IoK8SApiCoreV1DaemonSetUpdateStrategy {
+  /**
+   * Spec to control the desired behavior of daemon set rolling update.
+   *
+   * @schema io.k8s.api.core.v1.DaemonSetUpdateStrategy#rollingUpdate
+   */
+  readonly rollingUpdate?: IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate;
+
+  /**
+   * Type of daemon set update. Can be \\"RollingUpdate\\" or \\"OnDelete\\". Default is RollingUpdate.
+   *
+   * Possible enum values:
+   * - \`\\"OnDelete\\"\` Replace the old daemons only when it's killed
+   * - \`\\"RollingUpdate\\"\` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.
+   *
+   * @default RollingUpdate.
+   * @schema io.k8s.api.core.v1.DaemonSetUpdateStrategy#type
+   */
+  readonly type?: IoK8SApiCoreV1DaemonSetUpdateStrategyType;
+
+}
+
+/**
+ * @schema LaceworkAgentCloudserviceGke
+ */
+export interface LaceworkAgentCloudserviceGke {
+  /**
+   * @schema LaceworkAgentCloudserviceGke#autopilot
+   */
+  readonly autopilot?: boolean;
+
+}
+
+/**
+ * LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+ *
+ * @schema io.k8s.api.core.v1.LocalObjectReference
+ */
+export interface IoK8SApiCoreV1LocalObjectReference {
+  /**
+   * Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+   *
+   * @schema io.k8s.api.core.v1.LocalObjectReference#name
+   */
+  readonly name?: string;
+
+}
+
+/**
+ * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+ *
+ * Possible enum values:
+ * - \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+ * - \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+ * - \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+ *
+ * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+ * @schema LaceworkAgentImagePullPolicy
+ */
+export enum LaceworkAgentImagePullPolicy {
+  /** Always */
+  ALWAYS = \\"Always\\",
+  /** IfNotPresent */
+  IF_NOT_PRESENT = \\"IfNotPresent\\",
+  /** Never */
+  NEVER = \\"Never\\",
+}
+
+/**
+ * @schema LaceworkAgentClusterAgentImage
+ */
+export interface LaceworkAgentClusterAgentImage {
+  /**
+   * ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+   *
+   * @schema LaceworkAgentClusterAgentImage#imagePullSecrets
+   */
+  readonly imagePullSecrets?: IoK8SApiCoreV1LocalObjectReference[];
+
+  /**
+   * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+   *
+   * Possible enum values:
+   * - \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+   * - \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+   * - \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+   *
+   * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+   * @schema LaceworkAgentClusterAgentImage#pullPolicy
+   */
+  readonly pullPolicy: LaceworkAgentClusterAgentImagePullPolicy;
+
+  /**
+   * @schema LaceworkAgentClusterAgentImage#registry
+   */
+  readonly registry: string;
+
+  /**
+   * @schema LaceworkAgentClusterAgentImage#repository
+   */
+  readonly repository: string;
+
+  /**
+   * @schema LaceworkAgentClusterAgentImage#tag
+   */
+  readonly tag: string;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema LaceworkAgentClusterAgentImage#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigAnonymizeIncoming
+ */
+export interface LaceworkAgentLaceworkConfigAnonymizeIncoming {
+  /**
+   * @schema LaceworkAgentLaceworkConfigAnonymizeIncoming#netmask
+   */
+  readonly netmask?: string;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema LaceworkAgentLaceworkConfigAnonymizeIncoming#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigAutoUpgrade
+ */
+export enum LaceworkAgentLaceworkConfigAutoUpgrade {
+  /** disable */
+  DISABLE = \\"disable\\",
+  /** enable */
+  ENABLE = \\"enable\\",
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigCmdlinefilter
+ */
+export interface LaceworkAgentLaceworkConfigCmdlinefilter {
+  /**
+   * @schema LaceworkAgentLaceworkConfigCmdlinefilter#allow
+   */
+  readonly allow?: string;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigCmdlinefilter#disallow
+   */
+  readonly disallow?: string;
+
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigCodeaware
+ */
+export interface LaceworkAgentLaceworkConfigCodeaware {
+  /**
+   * @schema LaceworkAgentLaceworkConfigCodeaware#enable
+   */
+  readonly enable?: boolean;
+
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigDatacollector
+ */
+export enum LaceworkAgentLaceworkConfigDatacollector {
+  /** disable */
+  DISABLE = \\"disable\\",
+  /** enable */
+  ENABLE = \\"enable\\",
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigFim
+ */
+export interface LaceworkAgentLaceworkConfigFim {
+  /**
+   * @schema LaceworkAgentLaceworkConfigFim#coolingPeriod
+   */
+  readonly coolingPeriod?: number;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigFim#crawlInterval
+   */
+  readonly crawlInterval?: number;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigFim#enable
+   */
+  readonly enable: boolean;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigFim#fileIgnore
+   */
+  readonly fileIgnore: string[];
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigFim#filePath
+   */
+  readonly filePath: string[];
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigFim#noAtime
+   */
+  readonly noAtime?: boolean;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigFim#runAt
+   */
+  readonly runAt?: any;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema LaceworkAgentLaceworkConfigFim#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigPackagescan
+ */
+export interface LaceworkAgentLaceworkConfigPackagescan {
+  /**
+   * @schema LaceworkAgentLaceworkConfigPackagescan#enable
+   */
+  readonly enable?: boolean;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigPackagescan#interval
+   */
+  readonly interval?: number;
+
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigProcscan
+ */
+export interface LaceworkAgentLaceworkConfigProcscan {
+  /**
+   * @schema LaceworkAgentLaceworkConfigProcscan#enable
+   */
+  readonly enable?: boolean;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigProcscan#interval
+   */
+  readonly interval?: number;
+
+}
+
+/**
+ * Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+ *
+ * Possible enum values:
+ * - \`\\"NoExecute\\"\` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+ * - \`\\"NoSchedule\\"\` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+ * - \`\\"PreferNoSchedule\\"\` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+ *
+ * @schema IoK8SApiCoreV1TolerationEffect
+ */
+export enum IoK8SApiCoreV1TolerationEffect {
+  /** NoExecute */
+  NO_EXECUTE = \\"NoExecute\\",
+  /** NoSchedule */
+  NO_SCHEDULE = \\"NoSchedule\\",
+  /** PreferNoSchedule */
+  PREFER_NO_SCHEDULE = \\"PreferNoSchedule\\",
+}
+
+/**
+ * Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+ *
+ * Possible enum values:
+ * - \`\\"Equal\\"\`
+ * - \`\\"Exists\\"\`
+ *
+ * @default Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+ * @schema IoK8SApiCoreV1TolerationOperator
+ */
+export enum IoK8SApiCoreV1TolerationOperator {
+  /** Equal */
+  EQUAL = \\"Equal\\",
+  /** Exists */
+  EXISTS = \\"Exists\\",
+}
+
+/**
+ * Node affinity is a group of node affinity scheduling rules.
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinity
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinity {
+  /**
+   * The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinity#preferredDuringSchedulingIgnoredDuringExecution
+   */
+  readonly preferredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution[];
+
+  /**
+   * A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinity#requiredDuringSchedulingIgnoredDuringExecution
+   */
+  readonly requiredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution;
+
+}
+
+/**
+ * Pod affinity is a group of inter pod affinity scheduling rules.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinity
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinity {
+  /**
+   * The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinity#preferredDuringSchedulingIgnoredDuringExecution
+   */
+  readonly preferredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution[];
+
+  /**
+   * If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinity#requiredDuringSchedulingIgnoredDuringExecution
+   */
+  readonly requiredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution[];
+
+}
+
+/**
+ * Pod anti affinity is a group of inter pod anti affinity scheduling rules.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinity
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinity {
+  /**
+   * The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinity#preferredDuringSchedulingIgnoredDuringExecution
+   */
+  readonly preferredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution[];
+
+  /**
+   * If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinity#requiredDuringSchedulingIgnoredDuringExecution
+   */
+  readonly requiredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution[];
+
+}
+
+/**
+ * Spec to control the desired behavior of daemon set rolling update.
+ *
+ * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate
+ */
+export interface IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate {
+  /**
+   * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate#maxSurge
+   */
+  readonly maxSurge?: any;
+
+  /**
+   * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate#maxUnavailable
+   */
+  readonly maxUnavailable?: any;
+
+}
+
+/**
+ * Type of daemon set update. Can be \\"RollingUpdate\\" or \\"OnDelete\\". Default is RollingUpdate.
+ *
+ * Possible enum values:
+ * - \`\\"OnDelete\\"\` Replace the old daemons only when it's killed
+ * - \`\\"RollingUpdate\\"\` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.
+ *
+ * @default RollingUpdate.
+ * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyType
+ */
+export enum IoK8SApiCoreV1DaemonSetUpdateStrategyType {
+  /** OnDelete */
+  ON_DELETE = \\"OnDelete\\",
+  /** RollingUpdate */
+  ROLLING_UPDATE = \\"RollingUpdate\\",
+}
+
+/**
+ * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+ *
+ * Possible enum values:
+ * - \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+ * - \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+ * - \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+ *
+ * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+ * @schema LaceworkAgentClusterAgentImagePullPolicy
+ */
+export enum LaceworkAgentClusterAgentImagePullPolicy {
+  /** Always */
+  ALWAYS = \\"Always\\",
+  /** IfNotPresent */
+  IF_NOT_PRESENT = \\"IfNotPresent\\",
+  /** Never */
+  NEVER = \\"Never\\",
+}
+
+/**
+ * An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution {
+  /**
+   * A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution#preference
+   */
+  readonly preference?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference;
+
+  /**
+   * Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
+   */
+  readonly weight?: number;
+
+}
+
+/**
+ * A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution {
+  /**
+   * Required. A list of node selector terms. The terms are ORed.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution#nodeSelectorTerms
+   */
+  readonly nodeSelectorTerms?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms[];
+
+}
+
+/**
+ * The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution {
+  /**
+   * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution#podAffinityTerm
+   */
+  readonly podAffinityTerm?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm;
+
+  /**
+   * weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
+   */
+  readonly weight?: number;
+
+}
+
+/**
+ * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution {
+  /**
+   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#labelSelector
+   */
+  readonly labelSelector?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector;
+
+  /**
+   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaceSelector
+   */
+  readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector;
+
+  /**
+   * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaces
+   */
+  readonly namespaces?: string[];
+
+  /**
+   * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#topologyKey
+   */
+  readonly topologyKey?: string;
+
+}
+
+/**
+ * The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution {
+  /**
+   * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution#podAffinityTerm
+   */
+  readonly podAffinityTerm?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm;
+
+  /**
+   * weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
+   */
+  readonly weight?: number;
+
+}
+
+/**
+ * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution {
+  /**
+   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#labelSelector
+   */
+  readonly labelSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector;
+
+  /**
+   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaceSelector
+   */
+  readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector;
+
+  /**
+   * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaces
+   */
+  readonly namespaces?: string[];
+
+  /**
+   * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#topologyKey
+   */
+  readonly topologyKey?: string;
+
+}
+
+/**
+ * A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference {
+  /**
+   * A list of node selector requirements by node's labels.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions[];
+
+  /**
+   * A list of node selector requirements by node's fields.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference#matchFields
+   */
+  readonly matchFields?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields[];
+
+}
+
+/**
+ * A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms {
+  /**
+   * A list of node selector requirements by node's labels.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions[];
+
+  /**
+   * A list of node selector requirements by node's fields.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms#matchFields
+   */
+  readonly matchFields?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields[];
+
+}
+
+/**
+ * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm {
+  /**
+   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#labelSelector
+   */
+  readonly labelSelector?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector;
+
+  /**
+   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaceSelector
+   */
+  readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector;
+
+  /**
+   * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaces
+   */
+  readonly namespaces?: string[];
+
+  /**
+   * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#topologyKey
+   */
+  readonly topologyKey: string;
+
+}
+
+/**
+ * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector {
+  /**
+   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions[];
+
+  /**
+   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchLabels
+   */
+  readonly matchLabels?: { [key: string]: string };
+
+}
+
+/**
+ * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector {
+  /**
+   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions[];
+
+  /**
+   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchLabels
+   */
+  readonly matchLabels?: { [key: string]: string };
+
+}
+
+/**
+ * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm {
+  /**
+   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#labelSelector
+   */
+  readonly labelSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector;
+
+  /**
+   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaceSelector
+   */
+  readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector;
+
+  /**
+   * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaces
+   */
+  readonly namespaces?: string[];
+
+  /**
+   * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#topologyKey
+   */
+  readonly topologyKey: string;
+
+}
+
+/**
+ * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector {
+  /**
+   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions[];
+
+  /**
+   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchLabels
+   */
+  readonly matchLabels?: { [key: string]: string };
+
+}
+
+/**
+ * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector {
+  /**
+   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions[];
+
+  /**
+   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchLabels
+   */
+  readonly matchLabels?: { [key: string]: string };
+
+}
+
+/**
+ * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions {
+  /**
+   * The label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+   *
+   * Possible enum values:
+   * - \`\\"DoesNotExist\\"\`
+   * - \`\\"Exists\\"\`
+   * - \`\\"Gt\\"\`
+   * - \`\\"In\\"\`
+   * - \`\\"Lt\\"\`
+   * - \`\\"NotIn\\"\`
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#operator
+   */
+  readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator;
+
+  /**
+   * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields {
+  /**
+   * The label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#key
+   */
+  readonly key?: string;
+
+  /**
+   * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+   *
+   * Possible enum values:
+   * - \`\\"DoesNotExist\\"\`
+   * - \`\\"Exists\\"\`
+   * - \`\\"Gt\\"\`
+   * - \`\\"In\\"\`
+   * - \`\\"Lt\\"\`
+   * - \`\\"NotIn\\"\`
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#operator
+   */
+  readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator;
+
+  /**
+   * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions {
+  /**
+   * The label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+   *
+   * Possible enum values:
+   * - \`\\"DoesNotExist\\"\`
+   * - \`\\"Exists\\"\`
+   * - \`\\"Gt\\"\`
+   * - \`\\"In\\"\`
+   * - \`\\"Lt\\"\`
+   * - \`\\"NotIn\\"\`
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#operator
+   */
+  readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator;
+
+  /**
+   * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields {
+  /**
+   * The label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#key
+   */
+  readonly key?: string;
+
+  /**
+   * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+   *
+   * Possible enum values:
+   * - \`\\"DoesNotExist\\"\`
+   * - \`\\"Exists\\"\`
+   * - \`\\"Gt\\"\`
+   * - \`\\"In\\"\`
+   * - \`\\"Lt\\"\`
+   * - \`\\"NotIn\\"\`
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#operator
+   */
+  readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator;
+
+  /**
+   * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector {
+  /**
+   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions[];
+
+  /**
+   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchLabels
+   */
+  readonly matchLabels?: { [key: string]: string };
+
+}
+
+/**
+ * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector {
+  /**
+   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions[];
+
+  /**
+   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchLabels
+   */
+  readonly matchLabels?: { [key: string]: string };
+
+}
+
+/**
+ * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions {
+  /**
+   * key is the label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#operator
+   */
+  readonly operator?: string;
+
+  /**
+   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions {
+  /**
+   * key is the label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#operator
+   */
+  readonly operator?: string;
+
+  /**
+   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector {
+  /**
+   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions[];
+
+  /**
+   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchLabels
+   */
+  readonly matchLabels?: { [key: string]: string };
+
+}
+
+/**
+ * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector {
+  /**
+   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions[];
+
+  /**
+   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchLabels
+   */
+  readonly matchLabels?: { [key: string]: string };
+
+}
+
+/**
+ * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions {
+  /**
+   * key is the label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#operator
+   */
+  readonly operator?: string;
+
+  /**
+   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions {
+  /**
+   * key is the label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#operator
+   */
+  readonly operator?: string;
+
+  /**
+   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+ *
+ * Possible enum values:
+ * - \`\\"DoesNotExist\\"\`
+ * - \`\\"Exists\\"\`
+ * - \`\\"Gt\\"\`
+ * - \`\\"In\\"\`
+ * - \`\\"Lt\\"\`
+ * - \`\\"NotIn\\"\`
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator
+ */
+export enum IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator {
+  /** DoesNotExist */
+  DOES_NOT_EXIST = \\"DoesNotExist\\",
+  /** Exists */
+  EXISTS = \\"Exists\\",
+  /** Gt */
+  GT = \\"Gt\\",
+  /** In */
+  IN = \\"In\\",
+  /** Lt */
+  LT = \\"Lt\\",
+  /** NotIn */
+  NOT_IN = \\"NotIn\\",
+}
+
+/**
+ * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+ *
+ * Possible enum values:
+ * - \`\\"DoesNotExist\\"\`
+ * - \`\\"Exists\\"\`
+ * - \`\\"Gt\\"\`
+ * - \`\\"In\\"\`
+ * - \`\\"Lt\\"\`
+ * - \`\\"NotIn\\"\`
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator
+ */
+export enum IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator {
+  /** DoesNotExist */
+  DOES_NOT_EXIST = \\"DoesNotExist\\",
+  /** Exists */
+  EXISTS = \\"Exists\\",
+  /** Gt */
+  GT = \\"Gt\\",
+  /** In */
+  IN = \\"In\\",
+  /** Lt */
+  LT = \\"Lt\\",
+  /** NotIn */
+  NOT_IN = \\"NotIn\\",
+}
+
+/**
+ * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+ *
+ * Possible enum values:
+ * - \`\\"DoesNotExist\\"\`
+ * - \`\\"Exists\\"\`
+ * - \`\\"Gt\\"\`
+ * - \`\\"In\\"\`
+ * - \`\\"Lt\\"\`
+ * - \`\\"NotIn\\"\`
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator
+ */
+export enum IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator {
+  /** DoesNotExist */
+  DOES_NOT_EXIST = \\"DoesNotExist\\",
+  /** Exists */
+  EXISTS = \\"Exists\\",
+  /** Gt */
+  GT = \\"Gt\\",
+  /** In */
+  IN = \\"In\\",
+  /** Lt */
+  LT = \\"Lt\\",
+  /** NotIn */
+  NOT_IN = \\"NotIn\\",
+}
+
+/**
+ * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+ *
+ * Possible enum values:
+ * - \`\\"DoesNotExist\\"\`
+ * - \`\\"Exists\\"\`
+ * - \`\\"Gt\\"\`
+ * - \`\\"In\\"\`
+ * - \`\\"Lt\\"\`
+ * - \`\\"NotIn\\"\`
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator
+ */
+export enum IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator {
+  /** DoesNotExist */
+  DOES_NOT_EXIST = \\"DoesNotExist\\",
+  /** Exists */
+  EXISTS = \\"Exists\\",
+  /** Gt */
+  GT = \\"Gt\\",
+  /** In */
+  IN = \\"In\\",
+  /** Lt */
+  LT = \\"Lt\\",
+  /** NotIn */
+  NOT_IN = \\"NotIn\\",
+}
+
+/**
+ * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions {
+  /**
+   * key is the label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#operator
+   */
+  readonly operator?: string;
+
+  /**
+   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions {
+  /**
+   * key is the label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#operator
+   */
+  readonly operator?: string;
+
+  /**
+   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions {
+  /**
+   * key is the label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#operator
+   */
+  readonly operator?: string;
+
+  /**
+   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions {
+  /**
+   * key is the label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#operator
+   */
+  readonly operator?: string;
+
+  /**
+   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+",
+}
+`;

--- a/test/import/import-helm.test.ts
+++ b/test/import/import-helm.test.ts
@@ -7,6 +7,7 @@ import { parseImports } from '../../src/util';
 describe.each([
   'helm:https://charts.bitnami.com/bitnami/mysql@9.10.10', // Contains schema and dependencies
   'helm:https://kubernetes.github.io/ingress-nginx/ingress-nginx@4.8.0', // Does not contain schema
+  'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0', //
 ])('importing helm chart %s', (testChartUrl) => {
   const spec = parseImports(testChartUrl);
 


### PR DESCRIPTION
We don't do for anything else because its a breaking change in the generated code. Helm import was [released](https://github.com/cdk8s-team/cdk8s-cli/pull/1202) only a few hours ago so we assume its still ok.