### PR TITLE
fix: helm chart url is considered as crd during helm synthesis

### DIFF
--- a/src/cli/cmds/synth.ts
+++ b/src/cli/cmds/synth.ts
@@ -9,7 +9,7 @@ import { HelmChartApiVersion, SynthesisFormat, ValidationConfig, readConfigSync 
 import { ImportCustomResourceDefinition } from '../../import/crd';
 import { matchImporter } from '../../import/dispatch';
 import { PluginManager } from '../../plugins/_manager';
-import { SynthesizedApp, crdsArePresent, deriveFileName, download, isK8sImport, mkdtemp, parseImports, synthApp, validateApp } from '../../util';
+import { SynthesizedApp, crdsArePresent, deriveFileName, download, isHelmImport, isK8sImport, mkdtemp, parseImports, synthApp, validateApp } from '../../util';
 
 const CHART_YAML_FILE = 'Chart.yaml';
 const README = 'README.md';
@@ -174,7 +174,7 @@ async function createHelmScaffolding(apiVersion: string, chartVersion: string, o
 }
 
 async function addCrdsToHelmChart(chartDir: string) {
-  const crds = (config?.imports ?? []).filter((imprt) => !isK8sImport(imprt));
+  const crds = (config?.imports ?? []).filter((imprt) => (!isK8sImport(imprt) && !isHelmImport(imprt)));
 
   for (const crd of crds) {
     const importSpec = parseImports(crd);

--- a/src/util.ts
+++ b/src/util.ts
@@ -325,6 +325,14 @@ export function isK8sImport(value: string): boolean {
   return true;
 }
 
+export function isHelmImport(value: string): boolean {
+  if (!value.startsWith('helm:')) {
+    return false;
+  }
+
+  return true;
+}
+
 export function crdsArePresent(imprts: string[] | undefined): boolean {
-  return (imprts ?? []).some(imprt => !isK8sImport(imprt));
+  return (imprts ?? []).some(imprt => (!isK8sImport(imprt) && !isHelmImport(imprt)));
 }

--- a/test/synth/synth-stdout.test.ts
+++ b/test/synth/synth-stdout.test.ts
@@ -678,7 +678,11 @@ describe('Helm synthesis', () => {
         chartVersion: '1.1.1',
         chartApiVersion: HelmChartApiVersion.V1,
         config: {
-          imports: ['k8s', 'foo.yaml'],
+          imports: [
+            'k8s',
+            'foo.yaml',
+            'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0',
+          ],
         },
       },
     ],
@@ -691,7 +695,11 @@ describe('Helm synthesis', () => {
             chartVersion: '1.1.1',
             chartApiVersion: HelmChartApiVersion.V1,
           },
-          imports: ['k8s', 'foo.yaml'],
+          imports: [
+            'k8s',
+            'foo.yaml',
+            'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0',
+          ],
         },
       },
     ],
@@ -702,7 +710,11 @@ describe('Helm synthesis', () => {
         chartVersion: '1.1.1',
         chartApiVersion: HelmChartApiVersion.V1,
         config: {
-          imports: ['k8s', 'foo.yaml'],
+          imports: [
+            'k8s',
+            'foo.yaml',
+            'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0',
+          ],
           synthConfig: {
             format: SynthesisFormat.HELM,
             chartVersion: '1.1.1',
@@ -721,7 +733,11 @@ describe('Helm synthesis', () => {
           synthConfig: {
             chartApiVersion: HelmChartApiVersion.V2,
           },
-          imports: ['k8s', 'foo.yaml'],
+          imports: [
+            'k8s',
+            'foo.yaml',
+            'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0',
+          ],
         },
       },
     ],
@@ -741,7 +757,7 @@ describe('Helm synthesis', () => {
         chartVersion: '1.1.1',
         chartApiVersion: HelmChartApiVersion.V1,
         config: {
-          imports: ['k8s'],
+          imports: ['k8s', 'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0'],
         },
         postSynth: matchSynthSnapshot,
       },
@@ -755,7 +771,7 @@ describe('Helm synthesis', () => {
             chartVersion: '1.1.1',
             chartApiVersion: HelmChartApiVersion.V1,
           },
-          imports: ['k8s'],
+          imports: ['k8s', 'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0'],
         },
         postSynth: matchSynthSnapshot,
       },
@@ -772,7 +788,7 @@ describe('Helm synthesis', () => {
             chartVersion: '1.1.1',
             chartApiVersion: HelmChartApiVersion.V1,
           },
-          imports: ['k8s'],
+          imports: ['k8s', 'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0'],
         },
         postSynth: matchSynthSnapshot,
       },
@@ -787,7 +803,7 @@ describe('Helm synthesis', () => {
           synthConfig: {
             chartApiVersion: HelmChartApiVersion.V2,
           },
-          imports: ['k8s'],
+          imports: ['k8s', 'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0'],
         },
         postSynth: matchSynthSnapshot,
       },
@@ -851,6 +867,7 @@ describe('Helm synthesis', () => {
 
   const importsForChartApiv2 = [
     'k8s',
+    'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0',
     path.join(__dirname, './__resources__/crds/foo.yaml'),
     `bar:=${path.join(__dirname, './__resources__/crds/bar.yaml')}`,
     'github:crossplane/crossplane@0.14.0',
@@ -926,6 +943,7 @@ describe('Helm synthesis', () => {
         config: {
           imports: [
             'k8s',
+            'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0',
             filename,
           ],
         },
@@ -942,6 +960,7 @@ describe('Helm synthesis', () => {
           },
           imports: [
             'k8s',
+            'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0',
             filename,
           ],
         },
@@ -960,6 +979,7 @@ describe('Helm synthesis', () => {
           },
           imports: [
             'k8s',
+            'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0',
             filename,
           ],
         },
@@ -978,6 +998,7 @@ describe('Helm synthesis', () => {
           },
           imports: [
             'k8s',
+            'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0',
             filename,
           ],
         },

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,7 +1,7 @@
 import { promises } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
-import { crdsArePresent, deriveFileName, findManifests, hashAndEncode, isK8sImport, parseImports } from '../src/util';
+import { crdsArePresent, deriveFileName, findManifests, hashAndEncode, isHelmImport, isK8sImport, parseImports } from '../src/util';
 
 describe('findManifests', () => {
 
@@ -73,12 +73,22 @@ test('import is k8s', () => {
   expect(isK8sImport('foo')).toBeFalsy();
 });
 
+test('import is helm', () => {
+  expect(isHelmImport('helm:https://charts.bitnami.com/bitnami/mysql@9.10.10')).toBeTruthy();
+  expect(isHelmImport('helm:https://kubernetes.github.io/ingress-nginx/ingress-nginx@4.8.0')).toBeTruthy();
+  expect(isHelmImport('helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0')).toBeTruthy();
+  expect(isK8sImport('foo')).toBeFalsy();
+});
+
 test('are crds presents in imports', () => {
   const imprts = [
     'k8s',
     'k8s@1.22',
     'foo.yaml',
     'github:crossplane/crossplane@0.14.0',
+    'helm:https://charts.bitnami.com/bitnami/mysql@9.10.10',
+    'helm:https://kubernetes.github.io/ingress-nginx/ingress-nginx@4.8.0',
+    'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0',
   ];
 
   expect(crdsArePresent(imprts)).toBeTruthy();

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -77,7 +77,7 @@ test('import is helm', () => {
   expect(isHelmImport('helm:https://charts.bitnami.com/bitnami/mysql@9.10.10')).toBeTruthy();
   expect(isHelmImport('helm:https://kubernetes.github.io/ingress-nginx/ingress-nginx@4.8.0')).toBeTruthy();
   expect(isHelmImport('helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0')).toBeTruthy();
-  expect(isK8sImport('foo')).toBeFalsy();
+  expect(isHelmImport('foo')).toBeFalsy();
 });
 
 test('are crds presents in imports', () => {


### PR DESCRIPTION
Currently we are just ignoring `k8s` in `cdk8s.yaml` config file during synthesizing cdk8s app as a helm chart. This is because helm chart only needs `crds`(Custom Resource Definition) in it.

With the new url structure for importing `helm charts` i.e. prefixed with `helm:`, this also is being added to crds which throws an error when it tries to download it. For instance, 

`'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0'` URL would not lead to a CRD and hence the error. 

This PR is ignoring the `helm:` prefix as well since that is not a CRD. 