### PR TITLE
feat: import helm charts from oci repositories

### DIFF
--- a/src/import/codegen.ts
+++ b/src/import/codegen.ts
@@ -377,8 +377,12 @@ export function generateHelmConstruct(typegen: TypeGenerator, def: HelmObjectDef
       code.line();
 
       code.open('const finalProps: HelmProps = {');
-      code.line(`chart: \'${def.chartName}\',`);
-      code.line(`repo: \'${repoUrl}\',`);
+      if (repoUrl.startsWith('oci://')) {
+        code.line(`chart: \'${repoUrl}\',`);
+      } else {
+        code.line(`chart: \'${def.chartName}\',`);
+        code.line(`repo: \'${repoUrl}\',`);
+      }
       code.line(`version: \'${chartVersion}\',`);
       code.line('...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),');
       code.close('};');

--- a/src/import/helm.ts
+++ b/src/import/helm.ts
@@ -158,8 +158,6 @@ function pullHelmRepo(chartUrl: string, chartName: string, chartVersion: string)
   args.push('--untar');
   args.push('--untardir', workdir);
 
-  args.forEach((item) => console.log(`ITEM: ----> ${item}`));
-
   const command = 'helm';
 
   const helm = spawnSync(command, args, {

--- a/test/import/__snapshots__/import-helm.test.ts.snap
+++ b/test/import/__snapshots__/import-helm.test.ts.snap
@@ -24646,3 +24646,4128 @@ export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingI
 ",
 }
 `;
+
+exports[`importing helm chart helm:oci://registry-1.docker.io/bitnamicharts/mysql@9.12.5 with python lanugage 1`] = `
+Object {
+  "author": Object {
+    "name": "generated@generated.com",
+    "roles": Array [
+      "author",
+    ],
+  },
+  "dependencies": "__omitted__",
+  "dependencyClosure": Object {
+    "cdk8s": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Org.Cdk8s",
+          "packageId": "Org.Cdk8s",
+        },
+        "go": Object {
+          "moduleName": "github.com/cdk8s-team/cdk8s-core-go",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "cdk8s",
+            "groupId": "org.cdk8s",
+          },
+          "package": "org.cdk8s",
+        },
+        "js": Object {
+          "npm": "cdk8s",
+        },
+        "python": Object {
+          "distName": "cdk8s",
+          "module": "cdk8s",
+        },
+      },
+    },
+    "constructs": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Constructs",
+          "packageId": "Constructs",
+        },
+        "go": Object {
+          "moduleName": "github.com/aws/constructs-go",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "constructs",
+            "groupId": "software.constructs",
+          },
+          "package": "software.constructs",
+        },
+        "js": Object {
+          "npm": "constructs",
+        },
+        "python": Object {
+          "distName": "constructs",
+          "module": "constructs",
+        },
+      },
+    },
+  },
+  "description": "mysql",
+  "fingerprint": "<fingerprint>",
+  "homepage": "http://generated",
+  "jsiiVersion": "__omitted__",
+  "license": "UNLICENSED",
+  "metadata": Object {
+    "jsii": Object {
+      "pacmak": Object {
+        "hasDefaultInterfaces": true,
+      },
+    },
+  },
+  "name": "mysql",
+  "repository": Object {
+    "type": "git",
+    "url": "http://generated",
+  },
+  "schema": "jsii/0.10.0",
+  "targets": Object {
+    "js": Object {
+      "npm": "mysql",
+    },
+    "python": Object {
+      "distName": "generated",
+      "module": "mysql",
+    },
+  },
+  "types": Object {
+    "mysql.Mysql": Object {
+      "assembly": "mysql",
+      "base": "constructs.Construct",
+      "fqn": "mysql.Mysql",
+      "initializer": Object {
+        "locationInModule": Object {
+          "filename": "mysql.ts",
+          "line": 14,
+        },
+        "parameters": Array [
+          Object {
+            "name": "scope",
+            "type": Object {
+              "fqn": "constructs.Construct",
+            },
+          },
+          Object {
+            "name": "id",
+            "type": Object {
+              "primitive": "string",
+            },
+          },
+          Object {
+            "name": "props",
+            "optional": true,
+            "type": Object {
+              "fqn": "mysql.MysqlProps",
+            },
+          },
+        ],
+      },
+      "kind": "class",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 13,
+      },
+      "name": "Mysql",
+      "symbolId": "mysql:Mysql",
+    },
+    "mysql.MysqlArchitecture": Object {
+      "assembly": "mysql",
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlArchitecture",
+        },
+        "summary": "Allowed values: \`standalone\` or \`replication\`.",
+      },
+      "fqn": "mysql.MysqlArchitecture",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 104,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "standalone.",
+          },
+          "name": "STANDALONE",
+        },
+        Object {
+          "docs": Object {
+            "summary": "replication.",
+          },
+          "name": "REPLICATION",
+        },
+      ],
+      "name": "MysqlArchitecture",
+      "symbolId": "mysql:MysqlArchitecture",
+    },
+    "mysql.MysqlAuth": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlAuth",
+        },
+      },
+      "fqn": "mysql.MysqlAuth",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 114,
+      },
+      "name": "MysqlAuth",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlAuth#password",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 136,
+          },
+          "name": "password",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlAuth#username",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 131,
+          },
+          "name": "username",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlAuth#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 158,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlAuth#createDatabase",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 151,
+          },
+          "name": "createDatabase",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlAuth#database",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 126,
+          },
+          "name": "database",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlAuth#replicationPassword",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 146,
+          },
+          "name": "replicationPassword",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlAuth#replicationUser",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 141,
+          },
+          "name": "replicationUser",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlAuth#rootPassword",
+            },
+            "default": "a random 10-character alphanumeric string if not set",
+            "summary": "Defaults to a random 10-character alphanumeric string if not set.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 121,
+          },
+          "name": "rootPassword",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlAuth",
+    },
+    "mysql.MysqlPrimary": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlPrimary",
+        },
+      },
+      "fqn": "mysql.MysqlPrimary",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 165,
+      },
+      "name": "MysqlPrimary",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimary#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 186,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimary#containerSecurityContext",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 174,
+          },
+          "name": "containerSecurityContext",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlPrimaryContainerSecurityContext",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimary#persistence",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 179,
+          },
+          "name": "persistence",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlPrimaryPersistence",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimary#podSecurityContext",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 169,
+          },
+          "name": "podSecurityContext",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlPrimaryPodSecurityContext",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlPrimary",
+    },
+    "mysql.MysqlPrimaryContainerSecurityContext": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlPrimaryContainerSecurityContext",
+        },
+      },
+      "fqn": "mysql.MysqlPrimaryContainerSecurityContext",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 244,
+      },
+      "name": "MysqlPrimaryContainerSecurityContext",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryContainerSecurityContext#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 260,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryContainerSecurityContext#enabled",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 248,
+          },
+          "name": "enabled",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryContainerSecurityContext#runAsUser",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 253,
+          },
+          "name": "runAsUser",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlPrimaryContainerSecurityContext",
+    },
+    "mysql.MysqlPrimaryPersistence": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlPrimaryPersistence",
+        },
+      },
+      "fqn": "mysql.MysqlPrimaryPersistence",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 267,
+      },
+      "name": "MysqlPrimaryPersistence",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryPersistence#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 283,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryPersistence#enabled",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 271,
+          },
+          "name": "enabled",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryPersistence#size",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 276,
+          },
+          "name": "size",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlPrimaryPersistence",
+    },
+    "mysql.MysqlPrimaryPodSecurityContext": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlPrimaryPodSecurityContext",
+        },
+      },
+      "fqn": "mysql.MysqlPrimaryPodSecurityContext",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 221,
+      },
+      "name": "MysqlPrimaryPodSecurityContext",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryPodSecurityContext#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 237,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryPodSecurityContext#enabled",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 225,
+          },
+          "name": "enabled",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryPodSecurityContext#fsGroup",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 230,
+          },
+          "name": "fsGroup",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlPrimaryPodSecurityContext",
+    },
+    "mysql.MysqlProps": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "fqn": "mysql.MysqlProps",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 5,
+      },
+      "name": "MysqlProps",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 8,
+          },
+          "name": "helmExecutable",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 9,
+          },
+          "name": "helmFlags",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 6,
+          },
+          "name": "namespace",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 7,
+          },
+          "name": "releaseName",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 10,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlValues",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlProps",
+    },
+    "mysql.MysqlSecondary": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlSecondary",
+        },
+      },
+      "fqn": "mysql.MysqlSecondary",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 193,
+      },
+      "name": "MysqlSecondary",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondary#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 214,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondary#containerSecurityContext",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 202,
+          },
+          "name": "containerSecurityContext",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlSecondaryContainerSecurityContext",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondary#persistence",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 207,
+          },
+          "name": "persistence",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlSecondaryPersistence",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondary#podSecurityContext",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 197,
+          },
+          "name": "podSecurityContext",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlSecondaryPodSecurityContext",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlSecondary",
+    },
+    "mysql.MysqlSecondaryContainerSecurityContext": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlSecondaryContainerSecurityContext",
+        },
+      },
+      "fqn": "mysql.MysqlSecondaryContainerSecurityContext",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 313,
+      },
+      "name": "MysqlSecondaryContainerSecurityContext",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryContainerSecurityContext#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 329,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryContainerSecurityContext#enabled",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 317,
+          },
+          "name": "enabled",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryContainerSecurityContext#runAsUser",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 322,
+          },
+          "name": "runAsUser",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlSecondaryContainerSecurityContext",
+    },
+    "mysql.MysqlSecondaryPersistence": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlSecondaryPersistence",
+        },
+      },
+      "fqn": "mysql.MysqlSecondaryPersistence",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 336,
+      },
+      "name": "MysqlSecondaryPersistence",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryPersistence#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 352,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryPersistence#enabled",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 340,
+          },
+          "name": "enabled",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryPersistence#size",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 345,
+          },
+          "name": "size",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlSecondaryPersistence",
+    },
+    "mysql.MysqlSecondaryPodSecurityContext": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlSecondaryPodSecurityContext",
+        },
+      },
+      "fqn": "mysql.MysqlSecondaryPodSecurityContext",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 290,
+      },
+      "name": "MysqlSecondaryPodSecurityContext",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryPodSecurityContext#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 306,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryPodSecurityContext#enabled",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 294,
+          },
+          "name": "enabled",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryPodSecurityContext#fsGroup",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 299,
+          },
+          "name": "fsGroup",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlSecondaryPodSecurityContext",
+    },
+    "mysql.MysqlValues": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "mysql",
+        },
+      },
+      "fqn": "mysql.MysqlValues",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 57,
+      },
+      "name": "MysqlValues",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "mysql#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 95,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "mysql#architecture",
+            },
+            "summary": "Allowed values: \`standalone\` or \`replication\`.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 63,
+          },
+          "name": "architecture",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlArchitecture",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "mysql#auth",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 68,
+          },
+          "name": "auth",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlAuth",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "mysql#common",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 83,
+          },
+          "name": "common",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "mysql#global",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 88,
+          },
+          "name": "global",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "mysql#primary",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 73,
+          },
+          "name": "primary",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlPrimary",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "mysql#secondary",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 78,
+          },
+          "name": "secondary",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlSecondary",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlValues",
+    },
+  },
+  "version": "0.0.0",
+}
+`;
+
+exports[`importing helm chart helm:oci://registry-1.docker.io/bitnamicharts/mysql@9.12.5 with python lanugage 2`] = `
+Object {
+  "mysql/__init__.py": "import abc
+import builtins
+import datetime
+import enum
+import typing
+
+import jsii
+import publication
+import typing_extensions
+
+from typeguard import check_type
+
+from ._jsii import *
+
+import constructs as _constructs_77d1e7e8
+
+
+class Mysql(
+    _constructs_77d1e7e8.Construct,
+    metaclass=jsii.JSIIMeta,
+    jsii_type=\\"mysql.Mysql\\",
+):
+    def __init__(
+        self,
+        scope: _constructs_77d1e7e8.Construct,
+        id: builtins.str,
+        *,
+        helm_executable: typing.Optional[builtins.str] = None,
+        helm_flags: typing.Optional[typing.Sequence[builtins.str]] = None,
+        namespace: typing.Optional[builtins.str] = None,
+        release_name: typing.Optional[builtins.str] = None,
+        values: typing.Optional[typing.Union[\\"MysqlValues\\", typing.Dict[builtins.str, typing.Any]]] = None,
+    ) -> None:
+        '''
+        :param scope: -
+        :param id: -
+        :param helm_executable: -
+        :param helm_flags: -
+        :param namespace: -
+        :param release_name: -
+        :param values: -
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__95a811b01af67eee2d8e2ae24fcefa9fa2ac995a1f9685f3e921af5330ef82ff)
+            check_type(argname=\\"argument scope\\", value=scope, expected_type=type_hints[\\"scope\\"])
+            check_type(argname=\\"argument id\\", value=id, expected_type=type_hints[\\"id\\"])
+        props = MysqlProps(
+            helm_executable=helm_executable,
+            helm_flags=helm_flags,
+            namespace=namespace,
+            release_name=release_name,
+            values=values,
+        )
+
+        jsii.create(self.__class__, self, [scope, id, props])
+
+
+@jsii.enum(jsii_type=\\"mysql.MysqlArchitecture\\")
+class MysqlArchitecture(enum.Enum):
+    '''Allowed values: \`\`standalone\`\` or \`\`replication\`\`.
+
+    :schema: MysqlArchitecture
+    '''
+
+    STANDALONE = \\"STANDALONE\\"
+    '''standalone.'''
+    REPLICATION = \\"REPLICATION\\"
+    '''replication.'''
+
+
+@jsii.data_type(
+    jsii_type=\\"mysql.MysqlAuth\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"password\\": \\"password\\",
+        \\"username\\": \\"username\\",
+        \\"additional_values\\": \\"additionalValues\\",
+        \\"create_database\\": \\"createDatabase\\",
+        \\"database\\": \\"database\\",
+        \\"replication_password\\": \\"replicationPassword\\",
+        \\"replication_user\\": \\"replicationUser\\",
+        \\"root_password\\": \\"rootPassword\\",
+    },
+)
+class MysqlAuth:
+    def __init__(
+        self,
+        *,
+        password: builtins.str,
+        username: builtins.str,
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        create_database: typing.Optional[builtins.bool] = None,
+        database: typing.Optional[builtins.str] = None,
+        replication_password: typing.Optional[builtins.str] = None,
+        replication_user: typing.Optional[builtins.str] = None,
+        root_password: typing.Optional[builtins.str] = None,
+    ) -> None:
+        '''
+        :param password: 
+        :param username: 
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param create_database: 
+        :param database: 
+        :param replication_password: 
+        :param replication_user: 
+        :param root_password: Defaults to a random 10-character alphanumeric string if not set. Default: a random 10-character alphanumeric string if not set
+
+        :schema: MysqlAuth
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__ee06bc5fa81868398bad26c41946af017c8765bcca5abe66e5d88d360a20e315)
+            check_type(argname=\\"argument password\\", value=password, expected_type=type_hints[\\"password\\"])
+            check_type(argname=\\"argument username\\", value=username, expected_type=type_hints[\\"username\\"])
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument create_database\\", value=create_database, expected_type=type_hints[\\"create_database\\"])
+            check_type(argname=\\"argument database\\", value=database, expected_type=type_hints[\\"database\\"])
+            check_type(argname=\\"argument replication_password\\", value=replication_password, expected_type=type_hints[\\"replication_password\\"])
+            check_type(argname=\\"argument replication_user\\", value=replication_user, expected_type=type_hints[\\"replication_user\\"])
+            check_type(argname=\\"argument root_password\\", value=root_password, expected_type=type_hints[\\"root_password\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {
+            \\"password\\": password,
+            \\"username\\": username,
+        }
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if create_database is not None:
+            self._values[\\"create_database\\"] = create_database
+        if database is not None:
+            self._values[\\"database\\"] = database
+        if replication_password is not None:
+            self._values[\\"replication_password\\"] = replication_password
+        if replication_user is not None:
+            self._values[\\"replication_user\\"] = replication_user
+        if root_password is not None:
+            self._values[\\"root_password\\"] = root_password
+
+    @builtins.property
+    def password(self) -> builtins.str:
+        '''
+        :schema: MysqlAuth#password
+        '''
+        result = self._values.get(\\"password\\")
+        assert result is not None, \\"Required property 'password' is missing\\"
+        return typing.cast(builtins.str, result)
+
+    @builtins.property
+    def username(self) -> builtins.str:
+        '''
+        :schema: MysqlAuth#username
+        '''
+        result = self._values.get(\\"username\\")
+        assert result is not None, \\"Required property 'username' is missing\\"
+        return typing.cast(builtins.str, result)
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: MysqlAuth#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def create_database(self) -> typing.Optional[builtins.bool]:
+        '''
+        :schema: MysqlAuth#createDatabase
+        '''
+        result = self._values.get(\\"create_database\\")
+        return typing.cast(typing.Optional[builtins.bool], result)
+
+    @builtins.property
+    def database(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: MysqlAuth#database
+        '''
+        result = self._values.get(\\"database\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def replication_password(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: MysqlAuth#replicationPassword
+        '''
+        result = self._values.get(\\"replication_password\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def replication_user(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: MysqlAuth#replicationUser
+        '''
+        result = self._values.get(\\"replication_user\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def root_password(self) -> typing.Optional[builtins.str]:
+        '''Defaults to a random 10-character alphanumeric string if not set.
+
+        :default: a random 10-character alphanumeric string if not set
+
+        :schema: MysqlAuth#rootPassword
+        '''
+        result = self._values.get(\\"root_password\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"MysqlAuth(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"mysql.MysqlPrimary\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"additional_values\\": \\"additionalValues\\",
+        \\"container_security_context\\": \\"containerSecurityContext\\",
+        \\"persistence\\": \\"persistence\\",
+        \\"pod_security_context\\": \\"podSecurityContext\\",
+    },
+)
+class MysqlPrimary:
+    def __init__(
+        self,
+        *,
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        container_security_context: typing.Optional[typing.Union[\\"MysqlPrimaryContainerSecurityContext\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        persistence: typing.Optional[typing.Union[\\"MysqlPrimaryPersistence\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        pod_security_context: typing.Optional[typing.Union[\\"MysqlPrimaryPodSecurityContext\\", typing.Dict[builtins.str, typing.Any]]] = None,
+    ) -> None:
+        '''
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param container_security_context: 
+        :param persistence: 
+        :param pod_security_context: 
+
+        :schema: MysqlPrimary
+        '''
+        if isinstance(container_security_context, dict):
+            container_security_context = MysqlPrimaryContainerSecurityContext(**container_security_context)
+        if isinstance(persistence, dict):
+            persistence = MysqlPrimaryPersistence(**persistence)
+        if isinstance(pod_security_context, dict):
+            pod_security_context = MysqlPrimaryPodSecurityContext(**pod_security_context)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__5f80f16db85307f6e2dc2fd18749079a45e96857945ee617d44938b1e1fa49dd)
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument container_security_context\\", value=container_security_context, expected_type=type_hints[\\"container_security_context\\"])
+            check_type(argname=\\"argument persistence\\", value=persistence, expected_type=type_hints[\\"persistence\\"])
+            check_type(argname=\\"argument pod_security_context\\", value=pod_security_context, expected_type=type_hints[\\"pod_security_context\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if container_security_context is not None:
+            self._values[\\"container_security_context\\"] = container_security_context
+        if persistence is not None:
+            self._values[\\"persistence\\"] = persistence
+        if pod_security_context is not None:
+            self._values[\\"pod_security_context\\"] = pod_security_context
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: MysqlPrimary#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def container_security_context(
+        self,
+    ) -> typing.Optional[\\"MysqlPrimaryContainerSecurityContext\\"]:
+        '''
+        :schema: MysqlPrimary#containerSecurityContext
+        '''
+        result = self._values.get(\\"container_security_context\\")
+        return typing.cast(typing.Optional[\\"MysqlPrimaryContainerSecurityContext\\"], result)
+
+    @builtins.property
+    def persistence(self) -> typing.Optional[\\"MysqlPrimaryPersistence\\"]:
+        '''
+        :schema: MysqlPrimary#persistence
+        '''
+        result = self._values.get(\\"persistence\\")
+        return typing.cast(typing.Optional[\\"MysqlPrimaryPersistence\\"], result)
+
+    @builtins.property
+    def pod_security_context(self) -> typing.Optional[\\"MysqlPrimaryPodSecurityContext\\"]:
+        '''
+        :schema: MysqlPrimary#podSecurityContext
+        '''
+        result = self._values.get(\\"pod_security_context\\")
+        return typing.cast(typing.Optional[\\"MysqlPrimaryPodSecurityContext\\"], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"MysqlPrimary(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"mysql.MysqlPrimaryContainerSecurityContext\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"additional_values\\": \\"additionalValues\\",
+        \\"enabled\\": \\"enabled\\",
+        \\"run_as_user\\": \\"runAsUser\\",
+    },
+)
+class MysqlPrimaryContainerSecurityContext:
+    def __init__(
+        self,
+        *,
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        enabled: typing.Optional[builtins.bool] = None,
+        run_as_user: typing.Optional[jsii.Number] = None,
+    ) -> None:
+        '''
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param enabled: 
+        :param run_as_user: 
+
+        :schema: MysqlPrimaryContainerSecurityContext
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__b6c44d7f91b4cf3cb542cb1506165f060a9a15243f09931b735b74af15eaf7ae)
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument enabled\\", value=enabled, expected_type=type_hints[\\"enabled\\"])
+            check_type(argname=\\"argument run_as_user\\", value=run_as_user, expected_type=type_hints[\\"run_as_user\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if enabled is not None:
+            self._values[\\"enabled\\"] = enabled
+        if run_as_user is not None:
+            self._values[\\"run_as_user\\"] = run_as_user
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: MysqlPrimaryContainerSecurityContext#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def enabled(self) -> typing.Optional[builtins.bool]:
+        '''
+        :schema: MysqlPrimaryContainerSecurityContext#enabled
+        '''
+        result = self._values.get(\\"enabled\\")
+        return typing.cast(typing.Optional[builtins.bool], result)
+
+    @builtins.property
+    def run_as_user(self) -> typing.Optional[jsii.Number]:
+        '''
+        :schema: MysqlPrimaryContainerSecurityContext#runAsUser
+        '''
+        result = self._values.get(\\"run_as_user\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"MysqlPrimaryContainerSecurityContext(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"mysql.MysqlPrimaryPersistence\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"additional_values\\": \\"additionalValues\\",
+        \\"enabled\\": \\"enabled\\",
+        \\"size\\": \\"size\\",
+    },
+)
+class MysqlPrimaryPersistence:
+    def __init__(
+        self,
+        *,
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        enabled: typing.Optional[builtins.bool] = None,
+        size: typing.Optional[builtins.str] = None,
+    ) -> None:
+        '''
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param enabled: 
+        :param size: 
+
+        :schema: MysqlPrimaryPersistence
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__da573ccf5d6dca82a8d1cb770a6c85bd0dd98f4b5fe00a7260e815a7140dc9ba)
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument enabled\\", value=enabled, expected_type=type_hints[\\"enabled\\"])
+            check_type(argname=\\"argument size\\", value=size, expected_type=type_hints[\\"size\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if enabled is not None:
+            self._values[\\"enabled\\"] = enabled
+        if size is not None:
+            self._values[\\"size\\"] = size
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: MysqlPrimaryPersistence#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def enabled(self) -> typing.Optional[builtins.bool]:
+        '''
+        :schema: MysqlPrimaryPersistence#enabled
+        '''
+        result = self._values.get(\\"enabled\\")
+        return typing.cast(typing.Optional[builtins.bool], result)
+
+    @builtins.property
+    def size(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: MysqlPrimaryPersistence#size
+        '''
+        result = self._values.get(\\"size\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"MysqlPrimaryPersistence(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"mysql.MysqlPrimaryPodSecurityContext\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"additional_values\\": \\"additionalValues\\",
+        \\"enabled\\": \\"enabled\\",
+        \\"fs_group\\": \\"fsGroup\\",
+    },
+)
+class MysqlPrimaryPodSecurityContext:
+    def __init__(
+        self,
+        *,
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        enabled: typing.Optional[builtins.bool] = None,
+        fs_group: typing.Optional[jsii.Number] = None,
+    ) -> None:
+        '''
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param enabled: 
+        :param fs_group: 
+
+        :schema: MysqlPrimaryPodSecurityContext
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__f093d2c1e555d5d67dfb226a625b4abd2741a6b3333a3f12627a45d66a375c7c)
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument enabled\\", value=enabled, expected_type=type_hints[\\"enabled\\"])
+            check_type(argname=\\"argument fs_group\\", value=fs_group, expected_type=type_hints[\\"fs_group\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if enabled is not None:
+            self._values[\\"enabled\\"] = enabled
+        if fs_group is not None:
+            self._values[\\"fs_group\\"] = fs_group
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: MysqlPrimaryPodSecurityContext#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def enabled(self) -> typing.Optional[builtins.bool]:
+        '''
+        :schema: MysqlPrimaryPodSecurityContext#enabled
+        '''
+        result = self._values.get(\\"enabled\\")
+        return typing.cast(typing.Optional[builtins.bool], result)
+
+    @builtins.property
+    def fs_group(self) -> typing.Optional[jsii.Number]:
+        '''
+        :schema: MysqlPrimaryPodSecurityContext#fsGroup
+        '''
+        result = self._values.get(\\"fs_group\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"MysqlPrimaryPodSecurityContext(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"mysql.MysqlProps\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"helm_executable\\": \\"helmExecutable\\",
+        \\"helm_flags\\": \\"helmFlags\\",
+        \\"namespace\\": \\"namespace\\",
+        \\"release_name\\": \\"releaseName\\",
+        \\"values\\": \\"values\\",
+    },
+)
+class MysqlProps:
+    def __init__(
+        self,
+        *,
+        helm_executable: typing.Optional[builtins.str] = None,
+        helm_flags: typing.Optional[typing.Sequence[builtins.str]] = None,
+        namespace: typing.Optional[builtins.str] = None,
+        release_name: typing.Optional[builtins.str] = None,
+        values: typing.Optional[typing.Union[\\"MysqlValues\\", typing.Dict[builtins.str, typing.Any]]] = None,
+    ) -> None:
+        '''
+        :param helm_executable: -
+        :param helm_flags: -
+        :param namespace: -
+        :param release_name: -
+        :param values: -
+        '''
+        if isinstance(values, dict):
+            values = MysqlValues(**values)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__e0f01c3bcbff3f33dcd5e42ea1dca1754a4ffa560d4ed4393b91bf8167da3e71)
+            check_type(argname=\\"argument helm_executable\\", value=helm_executable, expected_type=type_hints[\\"helm_executable\\"])
+            check_type(argname=\\"argument helm_flags\\", value=helm_flags, expected_type=type_hints[\\"helm_flags\\"])
+            check_type(argname=\\"argument namespace\\", value=namespace, expected_type=type_hints[\\"namespace\\"])
+            check_type(argname=\\"argument release_name\\", value=release_name, expected_type=type_hints[\\"release_name\\"])
+            check_type(argname=\\"argument values\\", value=values, expected_type=type_hints[\\"values\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if helm_executable is not None:
+            self._values[\\"helm_executable\\"] = helm_executable
+        if helm_flags is not None:
+            self._values[\\"helm_flags\\"] = helm_flags
+        if namespace is not None:
+            self._values[\\"namespace\\"] = namespace
+        if release_name is not None:
+            self._values[\\"release_name\\"] = release_name
+        if values is not None:
+            self._values[\\"values\\"] = values
+
+    @builtins.property
+    def helm_executable(self) -> typing.Optional[builtins.str]:
+        result = self._values.get(\\"helm_executable\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def helm_flags(self) -> typing.Optional[typing.List[builtins.str]]:
+        result = self._values.get(\\"helm_flags\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    @builtins.property
+    def namespace(self) -> typing.Optional[builtins.str]:
+        result = self._values.get(\\"namespace\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def release_name(self) -> typing.Optional[builtins.str]:
+        result = self._values.get(\\"release_name\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def values(self) -> typing.Optional[\\"MysqlValues\\"]:
+        result = self._values.get(\\"values\\")
+        return typing.cast(typing.Optional[\\"MysqlValues\\"], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"MysqlProps(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"mysql.MysqlSecondary\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"additional_values\\": \\"additionalValues\\",
+        \\"container_security_context\\": \\"containerSecurityContext\\",
+        \\"persistence\\": \\"persistence\\",
+        \\"pod_security_context\\": \\"podSecurityContext\\",
+    },
+)
+class MysqlSecondary:
+    def __init__(
+        self,
+        *,
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        container_security_context: typing.Optional[typing.Union[\\"MysqlSecondaryContainerSecurityContext\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        persistence: typing.Optional[typing.Union[\\"MysqlSecondaryPersistence\\", typing.Dict[builtins.str, typing.Any]]] = None,
+        pod_security_context: typing.Optional[typing.Union[\\"MysqlSecondaryPodSecurityContext\\", typing.Dict[builtins.str, typing.Any]]] = None,
+    ) -> None:
+        '''
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param container_security_context: 
+        :param persistence: 
+        :param pod_security_context: 
+
+        :schema: MysqlSecondary
+        '''
+        if isinstance(container_security_context, dict):
+            container_security_context = MysqlSecondaryContainerSecurityContext(**container_security_context)
+        if isinstance(persistence, dict):
+            persistence = MysqlSecondaryPersistence(**persistence)
+        if isinstance(pod_security_context, dict):
+            pod_security_context = MysqlSecondaryPodSecurityContext(**pod_security_context)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__9f5e9436f8b23b1168f49948e6f47f206871fa357437067fe13eb80a1e4844f2)
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument container_security_context\\", value=container_security_context, expected_type=type_hints[\\"container_security_context\\"])
+            check_type(argname=\\"argument persistence\\", value=persistence, expected_type=type_hints[\\"persistence\\"])
+            check_type(argname=\\"argument pod_security_context\\", value=pod_security_context, expected_type=type_hints[\\"pod_security_context\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if container_security_context is not None:
+            self._values[\\"container_security_context\\"] = container_security_context
+        if persistence is not None:
+            self._values[\\"persistence\\"] = persistence
+        if pod_security_context is not None:
+            self._values[\\"pod_security_context\\"] = pod_security_context
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: MysqlSecondary#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def container_security_context(
+        self,
+    ) -> typing.Optional[\\"MysqlSecondaryContainerSecurityContext\\"]:
+        '''
+        :schema: MysqlSecondary#containerSecurityContext
+        '''
+        result = self._values.get(\\"container_security_context\\")
+        return typing.cast(typing.Optional[\\"MysqlSecondaryContainerSecurityContext\\"], result)
+
+    @builtins.property
+    def persistence(self) -> typing.Optional[\\"MysqlSecondaryPersistence\\"]:
+        '''
+        :schema: MysqlSecondary#persistence
+        '''
+        result = self._values.get(\\"persistence\\")
+        return typing.cast(typing.Optional[\\"MysqlSecondaryPersistence\\"], result)
+
+    @builtins.property
+    def pod_security_context(
+        self,
+    ) -> typing.Optional[\\"MysqlSecondaryPodSecurityContext\\"]:
+        '''
+        :schema: MysqlSecondary#podSecurityContext
+        '''
+        result = self._values.get(\\"pod_security_context\\")
+        return typing.cast(typing.Optional[\\"MysqlSecondaryPodSecurityContext\\"], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"MysqlSecondary(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"mysql.MysqlSecondaryContainerSecurityContext\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"additional_values\\": \\"additionalValues\\",
+        \\"enabled\\": \\"enabled\\",
+        \\"run_as_user\\": \\"runAsUser\\",
+    },
+)
+class MysqlSecondaryContainerSecurityContext:
+    def __init__(
+        self,
+        *,
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        enabled: typing.Optional[builtins.bool] = None,
+        run_as_user: typing.Optional[jsii.Number] = None,
+    ) -> None:
+        '''
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param enabled: 
+        :param run_as_user: 
+
+        :schema: MysqlSecondaryContainerSecurityContext
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__1ae0b9a8b2ed30dd59da81691df3e07509c48d79c4bae3cf246ab40221c987b1)
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument enabled\\", value=enabled, expected_type=type_hints[\\"enabled\\"])
+            check_type(argname=\\"argument run_as_user\\", value=run_as_user, expected_type=type_hints[\\"run_as_user\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if enabled is not None:
+            self._values[\\"enabled\\"] = enabled
+        if run_as_user is not None:
+            self._values[\\"run_as_user\\"] = run_as_user
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: MysqlSecondaryContainerSecurityContext#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def enabled(self) -> typing.Optional[builtins.bool]:
+        '''
+        :schema: MysqlSecondaryContainerSecurityContext#enabled
+        '''
+        result = self._values.get(\\"enabled\\")
+        return typing.cast(typing.Optional[builtins.bool], result)
+
+    @builtins.property
+    def run_as_user(self) -> typing.Optional[jsii.Number]:
+        '''
+        :schema: MysqlSecondaryContainerSecurityContext#runAsUser
+        '''
+        result = self._values.get(\\"run_as_user\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"MysqlSecondaryContainerSecurityContext(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"mysql.MysqlSecondaryPersistence\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"additional_values\\": \\"additionalValues\\",
+        \\"enabled\\": \\"enabled\\",
+        \\"size\\": \\"size\\",
+    },
+)
+class MysqlSecondaryPersistence:
+    def __init__(
+        self,
+        *,
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        enabled: typing.Optional[builtins.bool] = None,
+        size: typing.Optional[builtins.str] = None,
+    ) -> None:
+        '''
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param enabled: 
+        :param size: 
+
+        :schema: MysqlSecondaryPersistence
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__948c5c8f94b41fa54e53ae6a34ae87281865e016dcca8ad5308b1666738cbd56)
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument enabled\\", value=enabled, expected_type=type_hints[\\"enabled\\"])
+            check_type(argname=\\"argument size\\", value=size, expected_type=type_hints[\\"size\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if enabled is not None:
+            self._values[\\"enabled\\"] = enabled
+        if size is not None:
+            self._values[\\"size\\"] = size
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: MysqlSecondaryPersistence#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def enabled(self) -> typing.Optional[builtins.bool]:
+        '''
+        :schema: MysqlSecondaryPersistence#enabled
+        '''
+        result = self._values.get(\\"enabled\\")
+        return typing.cast(typing.Optional[builtins.bool], result)
+
+    @builtins.property
+    def size(self) -> typing.Optional[builtins.str]:
+        '''
+        :schema: MysqlSecondaryPersistence#size
+        '''
+        result = self._values.get(\\"size\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"MysqlSecondaryPersistence(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"mysql.MysqlSecondaryPodSecurityContext\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"additional_values\\": \\"additionalValues\\",
+        \\"enabled\\": \\"enabled\\",
+        \\"fs_group\\": \\"fsGroup\\",
+    },
+)
+class MysqlSecondaryPodSecurityContext:
+    def __init__(
+        self,
+        *,
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        enabled: typing.Optional[builtins.bool] = None,
+        fs_group: typing.Optional[jsii.Number] = None,
+    ) -> None:
+        '''
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param enabled: 
+        :param fs_group: 
+
+        :schema: MysqlSecondaryPodSecurityContext
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__c3d21a01f61c5c4594bfd80de49afce454aa452afa8cc380cf0792cf29872ce7)
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument enabled\\", value=enabled, expected_type=type_hints[\\"enabled\\"])
+            check_type(argname=\\"argument fs_group\\", value=fs_group, expected_type=type_hints[\\"fs_group\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if enabled is not None:
+            self._values[\\"enabled\\"] = enabled
+        if fs_group is not None:
+            self._values[\\"fs_group\\"] = fs_group
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: MysqlSecondaryPodSecurityContext#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def enabled(self) -> typing.Optional[builtins.bool]:
+        '''
+        :schema: MysqlSecondaryPodSecurityContext#enabled
+        '''
+        result = self._values.get(\\"enabled\\")
+        return typing.cast(typing.Optional[builtins.bool], result)
+
+    @builtins.property
+    def fs_group(self) -> typing.Optional[jsii.Number]:
+        '''
+        :schema: MysqlSecondaryPodSecurityContext#fsGroup
+        '''
+        result = self._values.get(\\"fs_group\\")
+        return typing.cast(typing.Optional[jsii.Number], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"MysqlSecondaryPodSecurityContext(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+@jsii.data_type(
+    jsii_type=\\"mysql.MysqlValues\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"additional_values\\": \\"additionalValues\\",
+        \\"architecture\\": \\"architecture\\",
+        \\"auth\\": \\"auth\\",
+        \\"common\\": \\"common\\",
+        \\"global_\\": \\"global\\",
+        \\"primary\\": \\"primary\\",
+        \\"secondary\\": \\"secondary\\",
+    },
+)
+class MysqlValues:
+    def __init__(
+        self,
+        *,
+        additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        architecture: typing.Optional[MysqlArchitecture] = None,
+        auth: typing.Optional[typing.Union[MysqlAuth, typing.Dict[builtins.str, typing.Any]]] = None,
+        common: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        global_: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+        primary: typing.Optional[typing.Union[MysqlPrimary, typing.Dict[builtins.str, typing.Any]]] = None,
+        secondary: typing.Optional[typing.Union[MysqlSecondary, typing.Dict[builtins.str, typing.Any]]] = None,
+    ) -> None:
+        '''
+        :param additional_values: Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+        :param architecture: Allowed values: \`\`standalone\`\` or \`\`replication\`\`.
+        :param auth: 
+        :param common: 
+        :param global_: 
+        :param primary: 
+        :param secondary: 
+
+        :schema: mysql
+        '''
+        if isinstance(auth, dict):
+            auth = MysqlAuth(**auth)
+        if isinstance(primary, dict):
+            primary = MysqlPrimary(**primary)
+        if isinstance(secondary, dict):
+            secondary = MysqlSecondary(**secondary)
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__ba4b7249d1a1862400c9b19cff8ae48324c2ce9cf5eddeb6ee91753a02247696)
+            check_type(argname=\\"argument additional_values\\", value=additional_values, expected_type=type_hints[\\"additional_values\\"])
+            check_type(argname=\\"argument architecture\\", value=architecture, expected_type=type_hints[\\"architecture\\"])
+            check_type(argname=\\"argument auth\\", value=auth, expected_type=type_hints[\\"auth\\"])
+            check_type(argname=\\"argument common\\", value=common, expected_type=type_hints[\\"common\\"])
+            check_type(argname=\\"argument global_\\", value=global_, expected_type=type_hints[\\"global_\\"])
+            check_type(argname=\\"argument primary\\", value=primary, expected_type=type_hints[\\"primary\\"])
+            check_type(argname=\\"argument secondary\\", value=secondary, expected_type=type_hints[\\"secondary\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if additional_values is not None:
+            self._values[\\"additional_values\\"] = additional_values
+        if architecture is not None:
+            self._values[\\"architecture\\"] = architecture
+        if auth is not None:
+            self._values[\\"auth\\"] = auth
+        if common is not None:
+            self._values[\\"common\\"] = common
+        if global_ is not None:
+            self._values[\\"global_\\"] = global_
+        if primary is not None:
+            self._values[\\"primary\\"] = primary
+        if secondary is not None:
+            self._values[\\"secondary\\"] = secondary
+
+    @builtins.property
+    def additional_values(
+        self,
+    ) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+
+        :schema: mysql#additionalValues
+        '''
+        result = self._values.get(\\"additional_values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def architecture(self) -> typing.Optional[MysqlArchitecture]:
+        '''Allowed values: \`\`standalone\`\` or \`\`replication\`\`.
+
+        :schema: mysql#architecture
+        '''
+        result = self._values.get(\\"architecture\\")
+        return typing.cast(typing.Optional[MysqlArchitecture], result)
+
+    @builtins.property
+    def auth(self) -> typing.Optional[MysqlAuth]:
+        '''
+        :schema: mysql#auth
+        '''
+        result = self._values.get(\\"auth\\")
+        return typing.cast(typing.Optional[MysqlAuth], result)
+
+    @builtins.property
+    def common(self) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''
+        :schema: mysql#common
+        '''
+        result = self._values.get(\\"common\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def global_(self) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        '''
+        :schema: mysql#global
+        '''
+        result = self._values.get(\\"global_\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    @builtins.property
+    def primary(self) -> typing.Optional[MysqlPrimary]:
+        '''
+        :schema: mysql#primary
+        '''
+        result = self._values.get(\\"primary\\")
+        return typing.cast(typing.Optional[MysqlPrimary], result)
+
+    @builtins.property
+    def secondary(self) -> typing.Optional[MysqlSecondary]:
+        '''
+        :schema: mysql#secondary
+        '''
+        result = self._values.get(\\"secondary\\")
+        return typing.cast(typing.Optional[MysqlSecondary], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"MysqlValues(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+__all__ = [
+    \\"Mysql\\",
+    \\"MysqlArchitecture\\",
+    \\"MysqlAuth\\",
+    \\"MysqlPrimary\\",
+    \\"MysqlPrimaryContainerSecurityContext\\",
+    \\"MysqlPrimaryPersistence\\",
+    \\"MysqlPrimaryPodSecurityContext\\",
+    \\"MysqlProps\\",
+    \\"MysqlSecondary\\",
+    \\"MysqlSecondaryContainerSecurityContext\\",
+    \\"MysqlSecondaryPersistence\\",
+    \\"MysqlSecondaryPodSecurityContext\\",
+    \\"MysqlValues\\",
+]
+
+publication.publish()
+
+def _typecheckingstub__95a811b01af67eee2d8e2ae24fcefa9fa2ac995a1f9685f3e921af5330ef82ff(
+    scope: _constructs_77d1e7e8.Construct,
+    id: builtins.str,
+    *,
+    helm_executable: typing.Optional[builtins.str] = None,
+    helm_flags: typing.Optional[typing.Sequence[builtins.str]] = None,
+    namespace: typing.Optional[builtins.str] = None,
+    release_name: typing.Optional[builtins.str] = None,
+    values: typing.Optional[typing.Union[MysqlValues, typing.Dict[builtins.str, typing.Any]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__ee06bc5fa81868398bad26c41946af017c8765bcca5abe66e5d88d360a20e315(
+    *,
+    password: builtins.str,
+    username: builtins.str,
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    create_database: typing.Optional[builtins.bool] = None,
+    database: typing.Optional[builtins.str] = None,
+    replication_password: typing.Optional[builtins.str] = None,
+    replication_user: typing.Optional[builtins.str] = None,
+    root_password: typing.Optional[builtins.str] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__5f80f16db85307f6e2dc2fd18749079a45e96857945ee617d44938b1e1fa49dd(
+    *,
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    container_security_context: typing.Optional[typing.Union[MysqlPrimaryContainerSecurityContext, typing.Dict[builtins.str, typing.Any]]] = None,
+    persistence: typing.Optional[typing.Union[MysqlPrimaryPersistence, typing.Dict[builtins.str, typing.Any]]] = None,
+    pod_security_context: typing.Optional[typing.Union[MysqlPrimaryPodSecurityContext, typing.Dict[builtins.str, typing.Any]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__b6c44d7f91b4cf3cb542cb1506165f060a9a15243f09931b735b74af15eaf7ae(
+    *,
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    enabled: typing.Optional[builtins.bool] = None,
+    run_as_user: typing.Optional[jsii.Number] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__da573ccf5d6dca82a8d1cb770a6c85bd0dd98f4b5fe00a7260e815a7140dc9ba(
+    *,
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    enabled: typing.Optional[builtins.bool] = None,
+    size: typing.Optional[builtins.str] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__f093d2c1e555d5d67dfb226a625b4abd2741a6b3333a3f12627a45d66a375c7c(
+    *,
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    enabled: typing.Optional[builtins.bool] = None,
+    fs_group: typing.Optional[jsii.Number] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__e0f01c3bcbff3f33dcd5e42ea1dca1754a4ffa560d4ed4393b91bf8167da3e71(
+    *,
+    helm_executable: typing.Optional[builtins.str] = None,
+    helm_flags: typing.Optional[typing.Sequence[builtins.str]] = None,
+    namespace: typing.Optional[builtins.str] = None,
+    release_name: typing.Optional[builtins.str] = None,
+    values: typing.Optional[typing.Union[MysqlValues, typing.Dict[builtins.str, typing.Any]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__9f5e9436f8b23b1168f49948e6f47f206871fa357437067fe13eb80a1e4844f2(
+    *,
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    container_security_context: typing.Optional[typing.Union[MysqlSecondaryContainerSecurityContext, typing.Dict[builtins.str, typing.Any]]] = None,
+    persistence: typing.Optional[typing.Union[MysqlSecondaryPersistence, typing.Dict[builtins.str, typing.Any]]] = None,
+    pod_security_context: typing.Optional[typing.Union[MysqlSecondaryPodSecurityContext, typing.Dict[builtins.str, typing.Any]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__1ae0b9a8b2ed30dd59da81691df3e07509c48d79c4bae3cf246ab40221c987b1(
+    *,
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    enabled: typing.Optional[builtins.bool] = None,
+    run_as_user: typing.Optional[jsii.Number] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__948c5c8f94b41fa54e53ae6a34ae87281865e016dcca8ad5308b1666738cbd56(
+    *,
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    enabled: typing.Optional[builtins.bool] = None,
+    size: typing.Optional[builtins.str] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__c3d21a01f61c5c4594bfd80de49afce454aa452afa8cc380cf0792cf29872ce7(
+    *,
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    enabled: typing.Optional[builtins.bool] = None,
+    fs_group: typing.Optional[jsii.Number] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__ba4b7249d1a1862400c9b19cff8ae48324c2ce9cf5eddeb6ee91753a02247696(
+    *,
+    additional_values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    architecture: typing.Optional[MysqlArchitecture] = None,
+    auth: typing.Optional[typing.Union[MysqlAuth, typing.Dict[builtins.str, typing.Any]]] = None,
+    common: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    global_: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    primary: typing.Optional[typing.Union[MysqlPrimary, typing.Dict[builtins.str, typing.Any]]] = None,
+    secondary: typing.Optional[typing.Union[MysqlSecondary, typing.Dict[builtins.str, typing.Any]]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+",
+  "mysql/_jsii/__init__.py": "import abc
+import builtins
+import datetime
+import enum
+import typing
+
+import jsii
+import publication
+import typing_extensions
+
+from typeguard import check_type
+
+import cdk8s._jsii
+import constructs._jsii
+
+__jsii_assembly__ = jsii.JSIIAssembly.load(
+    \\"mysql\\", \\"0.0.0\\", __name__[0:-6], \\"mysql@0.0.0.jsii.tgz\\"
+)
+
+__all__ = [
+    \\"__jsii_assembly__\\",
+]
+
+publication.publish()
+",
+  "mysql/py.typed": "
+",
+}
+`;
+
+exports[`importing helm chart helm:oci://registry-1.docker.io/bitnamicharts/mysql@9.12.5 with typescript lanugage 1`] = `
+Object {
+  "author": Object {
+    "name": "generated@generated.com",
+    "roles": Array [
+      "author",
+    ],
+  },
+  "dependencies": "__omitted__",
+  "dependencyClosure": Object {
+    "cdk8s": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Org.Cdk8s",
+          "packageId": "Org.Cdk8s",
+        },
+        "go": Object {
+          "moduleName": "github.com/cdk8s-team/cdk8s-core-go",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "cdk8s",
+            "groupId": "org.cdk8s",
+          },
+          "package": "org.cdk8s",
+        },
+        "js": Object {
+          "npm": "cdk8s",
+        },
+        "python": Object {
+          "distName": "cdk8s",
+          "module": "cdk8s",
+        },
+      },
+    },
+    "constructs": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Constructs",
+          "packageId": "Constructs",
+        },
+        "go": Object {
+          "moduleName": "github.com/aws/constructs-go",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "constructs",
+            "groupId": "software.constructs",
+          },
+          "package": "software.constructs",
+        },
+        "js": Object {
+          "npm": "constructs",
+        },
+        "python": Object {
+          "distName": "constructs",
+          "module": "constructs",
+        },
+      },
+    },
+  },
+  "description": "mysql",
+  "fingerprint": "<fingerprint>",
+  "homepage": "http://generated",
+  "jsiiVersion": "__omitted__",
+  "license": "UNLICENSED",
+  "metadata": Object {
+    "jsii": Object {
+      "pacmak": Object {
+        "hasDefaultInterfaces": true,
+      },
+    },
+  },
+  "name": "mysql",
+  "repository": Object {
+    "type": "git",
+    "url": "http://generated",
+  },
+  "schema": "jsii/0.10.0",
+  "targets": Object {
+    "js": Object {
+      "npm": "mysql",
+    },
+  },
+  "types": Object {
+    "mysql.Mysql": Object {
+      "assembly": "mysql",
+      "base": "constructs.Construct",
+      "fqn": "mysql.Mysql",
+      "initializer": Object {
+        "locationInModule": Object {
+          "filename": "mysql.ts",
+          "line": 14,
+        },
+        "parameters": Array [
+          Object {
+            "name": "scope",
+            "type": Object {
+              "fqn": "constructs.Construct",
+            },
+          },
+          Object {
+            "name": "id",
+            "type": Object {
+              "primitive": "string",
+            },
+          },
+          Object {
+            "name": "props",
+            "optional": true,
+            "type": Object {
+              "fqn": "mysql.MysqlProps",
+            },
+          },
+        ],
+      },
+      "kind": "class",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 13,
+      },
+      "name": "Mysql",
+      "symbolId": "mysql:Mysql",
+    },
+    "mysql.MysqlArchitecture": Object {
+      "assembly": "mysql",
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlArchitecture",
+        },
+        "summary": "Allowed values: \`standalone\` or \`replication\`.",
+      },
+      "fqn": "mysql.MysqlArchitecture",
+      "kind": "enum",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 104,
+      },
+      "members": Array [
+        Object {
+          "docs": Object {
+            "summary": "standalone.",
+          },
+          "name": "STANDALONE",
+        },
+        Object {
+          "docs": Object {
+            "summary": "replication.",
+          },
+          "name": "REPLICATION",
+        },
+      ],
+      "name": "MysqlArchitecture",
+      "symbolId": "mysql:MysqlArchitecture",
+    },
+    "mysql.MysqlAuth": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlAuth",
+        },
+      },
+      "fqn": "mysql.MysqlAuth",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 114,
+      },
+      "name": "MysqlAuth",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlAuth#password",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 136,
+          },
+          "name": "password",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlAuth#username",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 131,
+          },
+          "name": "username",
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlAuth#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 158,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlAuth#createDatabase",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 151,
+          },
+          "name": "createDatabase",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlAuth#database",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 126,
+          },
+          "name": "database",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlAuth#replicationPassword",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 146,
+          },
+          "name": "replicationPassword",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlAuth#replicationUser",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 141,
+          },
+          "name": "replicationUser",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlAuth#rootPassword",
+            },
+            "default": "a random 10-character alphanumeric string if not set",
+            "summary": "Defaults to a random 10-character alphanumeric string if not set.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 121,
+          },
+          "name": "rootPassword",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlAuth",
+    },
+    "mysql.MysqlPrimary": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlPrimary",
+        },
+      },
+      "fqn": "mysql.MysqlPrimary",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 165,
+      },
+      "name": "MysqlPrimary",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimary#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 186,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimary#containerSecurityContext",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 174,
+          },
+          "name": "containerSecurityContext",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlPrimaryContainerSecurityContext",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimary#persistence",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 179,
+          },
+          "name": "persistence",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlPrimaryPersistence",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimary#podSecurityContext",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 169,
+          },
+          "name": "podSecurityContext",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlPrimaryPodSecurityContext",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlPrimary",
+    },
+    "mysql.MysqlPrimaryContainerSecurityContext": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlPrimaryContainerSecurityContext",
+        },
+      },
+      "fqn": "mysql.MysqlPrimaryContainerSecurityContext",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 244,
+      },
+      "name": "MysqlPrimaryContainerSecurityContext",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryContainerSecurityContext#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 260,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryContainerSecurityContext#enabled",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 248,
+          },
+          "name": "enabled",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryContainerSecurityContext#runAsUser",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 253,
+          },
+          "name": "runAsUser",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlPrimaryContainerSecurityContext",
+    },
+    "mysql.MysqlPrimaryPersistence": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlPrimaryPersistence",
+        },
+      },
+      "fqn": "mysql.MysqlPrimaryPersistence",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 267,
+      },
+      "name": "MysqlPrimaryPersistence",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryPersistence#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 283,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryPersistence#enabled",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 271,
+          },
+          "name": "enabled",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryPersistence#size",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 276,
+          },
+          "name": "size",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlPrimaryPersistence",
+    },
+    "mysql.MysqlPrimaryPodSecurityContext": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlPrimaryPodSecurityContext",
+        },
+      },
+      "fqn": "mysql.MysqlPrimaryPodSecurityContext",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 221,
+      },
+      "name": "MysqlPrimaryPodSecurityContext",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryPodSecurityContext#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 237,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryPodSecurityContext#enabled",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 225,
+          },
+          "name": "enabled",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlPrimaryPodSecurityContext#fsGroup",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 230,
+          },
+          "name": "fsGroup",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlPrimaryPodSecurityContext",
+    },
+    "mysql.MysqlProps": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "fqn": "mysql.MysqlProps",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 5,
+      },
+      "name": "MysqlProps",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 8,
+          },
+          "name": "helmExecutable",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 9,
+          },
+          "name": "helmFlags",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 6,
+          },
+          "name": "namespace",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 7,
+          },
+          "name": "releaseName",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 10,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlValues",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlProps",
+    },
+    "mysql.MysqlSecondary": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlSecondary",
+        },
+      },
+      "fqn": "mysql.MysqlSecondary",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 193,
+      },
+      "name": "MysqlSecondary",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondary#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 214,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondary#containerSecurityContext",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 202,
+          },
+          "name": "containerSecurityContext",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlSecondaryContainerSecurityContext",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondary#persistence",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 207,
+          },
+          "name": "persistence",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlSecondaryPersistence",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondary#podSecurityContext",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 197,
+          },
+          "name": "podSecurityContext",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlSecondaryPodSecurityContext",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlSecondary",
+    },
+    "mysql.MysqlSecondaryContainerSecurityContext": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlSecondaryContainerSecurityContext",
+        },
+      },
+      "fqn": "mysql.MysqlSecondaryContainerSecurityContext",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 313,
+      },
+      "name": "MysqlSecondaryContainerSecurityContext",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryContainerSecurityContext#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 329,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryContainerSecurityContext#enabled",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 317,
+          },
+          "name": "enabled",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryContainerSecurityContext#runAsUser",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 322,
+          },
+          "name": "runAsUser",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlSecondaryContainerSecurityContext",
+    },
+    "mysql.MysqlSecondaryPersistence": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlSecondaryPersistence",
+        },
+      },
+      "fqn": "mysql.MysqlSecondaryPersistence",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 336,
+      },
+      "name": "MysqlSecondaryPersistence",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryPersistence#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 352,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryPersistence#enabled",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 340,
+          },
+          "name": "enabled",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryPersistence#size",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 345,
+          },
+          "name": "size",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlSecondaryPersistence",
+    },
+    "mysql.MysqlSecondaryPodSecurityContext": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "MysqlSecondaryPodSecurityContext",
+        },
+      },
+      "fqn": "mysql.MysqlSecondaryPodSecurityContext",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 290,
+      },
+      "name": "MysqlSecondaryPodSecurityContext",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryPodSecurityContext#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 306,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryPodSecurityContext#enabled",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 294,
+          },
+          "name": "enabled",
+          "optional": true,
+          "type": Object {
+            "primitive": "boolean",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "MysqlSecondaryPodSecurityContext#fsGroup",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 299,
+          },
+          "name": "fsGroup",
+          "optional": true,
+          "type": Object {
+            "primitive": "number",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlSecondaryPodSecurityContext",
+    },
+    "mysql.MysqlValues": Object {
+      "assembly": "mysql",
+      "datatype": true,
+      "docs": Object {
+        "custom": Object {
+          "schema": "mysql",
+        },
+      },
+      "fqn": "mysql.MysqlValues",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "mysql.ts",
+        "line": 57,
+      },
+      "name": "MysqlValues",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "mysql#additionalValues",
+            },
+            "summary": "Values that are not available in values.schema.json will not be code generated. You can add such values to this property.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 95,
+          },
+          "name": "additionalValues",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "mysql#architecture",
+            },
+            "summary": "Allowed values: \`standalone\` or \`replication\`.",
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 63,
+          },
+          "name": "architecture",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlArchitecture",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "mysql#auth",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 68,
+          },
+          "name": "auth",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlAuth",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "mysql#common",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 83,
+          },
+          "name": "common",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "mysql#global",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 88,
+          },
+          "name": "global",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "mysql#primary",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 73,
+          },
+          "name": "primary",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlPrimary",
+          },
+        },
+        Object {
+          "abstract": true,
+          "docs": Object {
+            "custom": Object {
+              "schema": "mysql#secondary",
+            },
+          },
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 78,
+          },
+          "name": "secondary",
+          "optional": true,
+          "type": Object {
+            "fqn": "mysql.MysqlSecondary",
+          },
+        },
+      ],
+      "symbolId": "mysql:MysqlValues",
+    },
+  },
+  "version": "0.0.0",
+}
+`;
+
+exports[`importing helm chart helm:oci://registry-1.docker.io/bitnamicharts/mysql@9.12.5 with typescript lanugage 2`] = `
+Object {
+  "mysql.ts": "// generated by cdk8s
+import { Helm, HelmProps } from 'cdk8s';
+import { Construct } from 'constructs';
+
+export interface MysqlProps {
+  readonly namespace?: string;
+  readonly releaseName?: string;
+  readonly helmExecutable?: string;
+  readonly helmFlags?: string[];
+  readonly values?: MysqlValues;
+}
+
+export class Mysql extends Construct {
+  public constructor(scope: Construct, id: string, props: MysqlProps = {}) {
+    super(scope, id)
+    let updatedProps = {};
+
+    if (props.values) {
+      const { additionalValues, ...valuesWithoutAdditionalValues } = props.values;
+      updatedProps = {
+        ...props,
+        values: {
+          ...this.flattenAdditionalValues(valuesWithoutAdditionalValues),
+          ...additionalValues,
+        }
+      };
+    }
+
+    const finalProps: HelmProps = {
+      chart: 'oci://registry-1.docker.io/bitnamicharts/mysql',
+      version: '9.12.5',
+      ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
+    };
+
+    new Helm(scope, 'Helm', finalProps)
+  }
+
+  private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
+    for (let prop in props) {
+      if (typeof(props[prop]) === 'object' && prop !== 'additionalValues') {
+        props[prop] = this.flattenAdditionalValues(props[prop]);
+      }
+    }
+
+    const { additionalValues, ...valuesWithoutAdditionalValues } = props;
+
+    return {
+      ...valuesWithoutAdditionalValues,
+      ...additionalValues,
+    };
+  }
+}
+
+/**
+ * @schema mysql
+ */
+export interface MysqlValues {
+  /**
+   * Allowed values: \`standalone\` or \`replication\`
+   *
+   * @schema mysql#architecture
+   */
+  readonly architecture?: MysqlArchitecture;
+
+  /**
+   * @schema mysql#auth
+   */
+  readonly auth?: MysqlAuth;
+
+  /**
+   * @schema mysql#primary
+   */
+  readonly primary?: MysqlPrimary;
+
+  /**
+   * @schema mysql#secondary
+   */
+  readonly secondary?: MysqlSecondary;
+
+  /**
+   * @schema mysql#common
+   */
+  readonly common?: { [key: string]: any };
+
+  /**
+   * @schema mysql#global
+   */
+  readonly global?: { [key: string]: any };
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema mysql#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * Allowed values: \`standalone\` or \`replication\`
+ *
+ * @schema MysqlArchitecture
+ */
+export enum MysqlArchitecture {
+  /** standalone */
+  STANDALONE = \\"standalone\\",
+  /** replication */
+  REPLICATION = \\"replication\\",
+}
+
+/**
+ * @schema MysqlAuth
+ */
+export interface MysqlAuth {
+  /**
+   * Defaults to a random 10-character alphanumeric string if not set
+   *
+   * @default a random 10-character alphanumeric string if not set
+   * @schema MysqlAuth#rootPassword
+   */
+  readonly rootPassword?: string;
+
+  /**
+   * @schema MysqlAuth#database
+   */
+  readonly database?: string;
+
+  /**
+   * @schema MysqlAuth#username
+   */
+  readonly username: string;
+
+  /**
+   * @schema MysqlAuth#password
+   */
+  readonly password: string;
+
+  /**
+   * @schema MysqlAuth#replicationUser
+   */
+  readonly replicationUser?: string;
+
+  /**
+   * @schema MysqlAuth#replicationPassword
+   */
+  readonly replicationPassword?: string;
+
+  /**
+   * @schema MysqlAuth#createDatabase
+   */
+  readonly createDatabase?: boolean;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlAuth#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema MysqlPrimary
+ */
+export interface MysqlPrimary {
+  /**
+   * @schema MysqlPrimary#podSecurityContext
+   */
+  readonly podSecurityContext?: MysqlPrimaryPodSecurityContext;
+
+  /**
+   * @schema MysqlPrimary#containerSecurityContext
+   */
+  readonly containerSecurityContext?: MysqlPrimaryContainerSecurityContext;
+
+  /**
+   * @schema MysqlPrimary#persistence
+   */
+  readonly persistence?: MysqlPrimaryPersistence;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlPrimary#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema MysqlSecondary
+ */
+export interface MysqlSecondary {
+  /**
+   * @schema MysqlSecondary#podSecurityContext
+   */
+  readonly podSecurityContext?: MysqlSecondaryPodSecurityContext;
+
+  /**
+   * @schema MysqlSecondary#containerSecurityContext
+   */
+  readonly containerSecurityContext?: MysqlSecondaryContainerSecurityContext;
+
+  /**
+   * @schema MysqlSecondary#persistence
+   */
+  readonly persistence?: MysqlSecondaryPersistence;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlSecondary#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema MysqlPrimaryPodSecurityContext
+ */
+export interface MysqlPrimaryPodSecurityContext {
+  /**
+   * @schema MysqlPrimaryPodSecurityContext#enabled
+   */
+  readonly enabled?: boolean;
+
+  /**
+   * @schema MysqlPrimaryPodSecurityContext#fsGroup
+   */
+  readonly fsGroup?: number;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlPrimaryPodSecurityContext#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema MysqlPrimaryContainerSecurityContext
+ */
+export interface MysqlPrimaryContainerSecurityContext {
+  /**
+   * @schema MysqlPrimaryContainerSecurityContext#enabled
+   */
+  readonly enabled?: boolean;
+
+  /**
+   * @schema MysqlPrimaryContainerSecurityContext#runAsUser
+   */
+  readonly runAsUser?: number;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlPrimaryContainerSecurityContext#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema MysqlPrimaryPersistence
+ */
+export interface MysqlPrimaryPersistence {
+  /**
+   * @schema MysqlPrimaryPersistence#enabled
+   */
+  readonly enabled?: boolean;
+
+  /**
+   * @schema MysqlPrimaryPersistence#size
+   */
+  readonly size?: string;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlPrimaryPersistence#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema MysqlSecondaryPodSecurityContext
+ */
+export interface MysqlSecondaryPodSecurityContext {
+  /**
+   * @schema MysqlSecondaryPodSecurityContext#enabled
+   */
+  readonly enabled?: boolean;
+
+  /**
+   * @schema MysqlSecondaryPodSecurityContext#fsGroup
+   */
+  readonly fsGroup?: number;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlSecondaryPodSecurityContext#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema MysqlSecondaryContainerSecurityContext
+ */
+export interface MysqlSecondaryContainerSecurityContext {
+  /**
+   * @schema MysqlSecondaryContainerSecurityContext#enabled
+   */
+  readonly enabled?: boolean;
+
+  /**
+   * @schema MysqlSecondaryContainerSecurityContext#runAsUser
+   */
+  readonly runAsUser?: number;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlSecondaryContainerSecurityContext#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema MysqlSecondaryPersistence
+ */
+export interface MysqlSecondaryPersistence {
+  /**
+   * @schema MysqlSecondaryPersistence#enabled
+   */
+  readonly enabled?: boolean;
+
+  /**
+   * @schema MysqlSecondaryPersistence#size
+   */
+  readonly size?: string;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlSecondaryPersistence#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+",
+}
+`;

--- a/test/import/import-helm.test.ts
+++ b/test/import/import-helm.test.ts
@@ -7,7 +7,8 @@ import { parseImports } from '../../src/util';
 describe.each([
   'helm:https://charts.bitnami.com/bitnami/mysql@9.10.10', // Contains schema and dependencies
   'helm:https://kubernetes.github.io/ingress-nginx/ingress-nginx@4.8.0', // Does not contain schema
-  'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0', //
+  'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0',
+  'helm:oci://registry-1.docker.io/bitnamicharts/mysql@9.12.5',
 ])('importing helm chart %s', (testChartUrl) => {
   const spec = parseImports(testChartUrl);
 


### PR DESCRIPTION
Helm import currently is unable to import helm charts store in OCI repositories. This PR is enabling import from such repositories. 


Resolves https://github.com/cdk8s-team/cdk8s-cli/issues/1525