### PR TITLE
fix(import):  `flattenAdditionalValues` does not handle arrays properly

### DIFF
--- a/src/import/codegen.ts
+++ b/src/import/codegen.ts
@@ -384,14 +384,21 @@ export function generateHelmConstruct(typegen: TypeGenerator, def: HelmObjectDef
       code.close('};');
 
       code.line();
-      code.line('new Helm(scope, \'Helm\', finalProps)');
+      code.line('new Helm(scope, `Helm${id`f}`, finalProps)');
       code.closeBlock();
     }
 
     function emitAdditionalValuesFlattenFunc() {
       code.openBlock('private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any }');
       code.open('for (let prop in props) {');
-      code.open('if (typeof(props[prop]) === \'object\' && prop !== \'additionalValues\') {');
+      code.open('if (Array.isArray(props[prop])) {');
+      code.open('props[prop].map((item: any) => {');
+      code.open('if (typeof(item) === \'object\' && prop !== \'additionalValues\') {');
+      code.line('return this.flattenAdditionalValues(item);');
+      code.close('}');
+      code.line('return item;');
+      code.close('});');
+      code.open('} else if (typeof(props[prop]) === \'object\' && prop !== \'additionalValues\') {');
       code.line('props[prop] = this.flattenAdditionalValues(props[prop]);');
       code.close('}');
       code.close('}');

--- a/src/import/codegen.ts
+++ b/src/import/codegen.ts
@@ -360,7 +360,7 @@ export function generateHelmConstruct(typegen: TypeGenerator, def: HelmObjectDef
       const propsDefinition = schema && hasRequiredProps(schema) ? `${chartName}Props` : `${chartName}Props = {}`;
 
       code.openBlock(`public constructor(scope: Construct, id: string, props: ${propsDefinition})`);
-      code.line('super(scope, id)');
+      code.line('super(scope, id);');
 
       code.line('let updatedProps = {};');
       code.line();
@@ -371,7 +371,7 @@ export function generateHelmConstruct(typegen: TypeGenerator, def: HelmObjectDef
       code.open('values: {');
       code.line('...this.flattenAdditionalValues(valuesWithoutAdditionalValues),');
       code.line('...additionalValues,');
-      code.close('}');
+      code.close('},');
       code.close('};');
       code.closeBlock();
       code.line();
@@ -384,7 +384,7 @@ export function generateHelmConstruct(typegen: TypeGenerator, def: HelmObjectDef
       code.close('};');
 
       code.line();
-      code.line('new Helm(scope, `Helm${id}`, finalProps)');
+      code.line('new Helm(this, \'Helm\', finalProps);');
       code.closeBlock();
     }
 
@@ -393,12 +393,13 @@ export function generateHelmConstruct(typegen: TypeGenerator, def: HelmObjectDef
       code.open('for (let prop in props) {');
       code.open('if (Array.isArray(props[prop])) {');
       code.open('props[prop].map((item: any) => {');
-      code.open('if (typeof(item) === \'object\' && prop !== \'additionalValues\') {');
+      code.open('if (typeof item === \'object\' && prop !== \'additionalValues\') {');
       code.line('return this.flattenAdditionalValues(item);');
       code.close('}');
       code.line('return item;');
       code.close('});');
-      code.open('} else if (typeof(props[prop]) === \'object\' && prop !== \'additionalValues\') {');
+      code.close('}');
+      code.open('else if (typeof props[prop] === \'object\' && prop !== \'additionalValues\') {');
       code.line('props[prop] = this.flattenAdditionalValues(props[prop]);');
       code.close('}');
       code.close('}');

--- a/src/import/codegen.ts
+++ b/src/import/codegen.ts
@@ -384,7 +384,7 @@ export function generateHelmConstruct(typegen: TypeGenerator, def: HelmObjectDef
       code.close('};');
 
       code.line();
-      code.line('new Helm(scope, `Helm${id`f}`, finalProps)');
+      code.line('new Helm(scope, `Helm${id}`, finalProps)');
       code.closeBlock();
     }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -326,7 +326,7 @@ export function isK8sImport(value: string): boolean {
 }
 
 export function isHelmImport(value: string): boolean {
-  if (!value.startsWith('helm:')) {
+  if (!value.startsWith('helm:') && !value.includes(':=helm:')) {
     return false;
   }
 

--- a/test/import/__snapshots__/import-helm.test.ts.snap
+++ b/test/import/__snapshots__/import-helm.test.ts.snap
@@ -140,7 +140,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 105,
+        "line": 112,
       },
       "members": Array [
         Object {
@@ -171,7 +171,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 115,
+        "line": 122,
       },
       "name": "MysqlAuth",
       "properties": Array [
@@ -185,7 +185,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 137,
+            "line": 144,
           },
           "name": "password",
           "type": Object {
@@ -202,7 +202,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 132,
+            "line": 139,
           },
           "name": "username",
           "type": Object {
@@ -220,7 +220,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 159,
+            "line": 166,
           },
           "name": "additionalValues",
           "optional": true,
@@ -243,7 +243,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 152,
+            "line": 159,
           },
           "name": "createDatabase",
           "optional": true,
@@ -261,7 +261,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 127,
+            "line": 134,
           },
           "name": "database",
           "optional": true,
@@ -279,7 +279,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 147,
+            "line": 154,
           },
           "name": "replicationPassword",
           "optional": true,
@@ -297,7 +297,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 142,
+            "line": 149,
           },
           "name": "replicationUser",
           "optional": true,
@@ -317,7 +317,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 122,
+            "line": 129,
           },
           "name": "rootPassword",
           "optional": true,
@@ -340,7 +340,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 166,
+        "line": 173,
       },
       "name": "MysqlPrimary",
       "properties": Array [
@@ -355,7 +355,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 187,
+            "line": 194,
           },
           "name": "additionalValues",
           "optional": true,
@@ -378,7 +378,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 175,
+            "line": 182,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -396,7 +396,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 180,
+            "line": 187,
           },
           "name": "persistence",
           "optional": true,
@@ -414,7 +414,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 170,
+            "line": 177,
           },
           "name": "podSecurityContext",
           "optional": true,
@@ -437,7 +437,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 245,
+        "line": 252,
       },
       "name": "MysqlPrimaryContainerSecurityContext",
       "properties": Array [
@@ -452,7 +452,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 261,
+            "line": 268,
           },
           "name": "additionalValues",
           "optional": true,
@@ -475,7 +475,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 249,
+            "line": 256,
           },
           "name": "enabled",
           "optional": true,
@@ -493,7 +493,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 254,
+            "line": 261,
           },
           "name": "runAsUser",
           "optional": true,
@@ -516,7 +516,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 268,
+        "line": 275,
       },
       "name": "MysqlPrimaryPersistence",
       "properties": Array [
@@ -531,7 +531,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 284,
+            "line": 291,
           },
           "name": "additionalValues",
           "optional": true,
@@ -554,7 +554,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 272,
+            "line": 279,
           },
           "name": "enabled",
           "optional": true,
@@ -572,7 +572,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 277,
+            "line": 284,
           },
           "name": "size",
           "optional": true,
@@ -595,7 +595,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 222,
+        "line": 229,
       },
       "name": "MysqlPrimaryPodSecurityContext",
       "properties": Array [
@@ -610,7 +610,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 238,
+            "line": 245,
           },
           "name": "additionalValues",
           "optional": true,
@@ -633,7 +633,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 226,
+            "line": 233,
           },
           "name": "enabled",
           "optional": true,
@@ -651,7 +651,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 231,
+            "line": 238,
           },
           "name": "fsGroup",
           "optional": true,
@@ -758,7 +758,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 194,
+        "line": 201,
       },
       "name": "MysqlSecondary",
       "properties": Array [
@@ -773,7 +773,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 215,
+            "line": 222,
           },
           "name": "additionalValues",
           "optional": true,
@@ -796,7 +796,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 203,
+            "line": 210,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -814,7 +814,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 208,
+            "line": 215,
           },
           "name": "persistence",
           "optional": true,
@@ -832,7 +832,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 198,
+            "line": 205,
           },
           "name": "podSecurityContext",
           "optional": true,
@@ -855,7 +855,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 314,
+        "line": 321,
       },
       "name": "MysqlSecondaryContainerSecurityContext",
       "properties": Array [
@@ -870,7 +870,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 330,
+            "line": 337,
           },
           "name": "additionalValues",
           "optional": true,
@@ -893,7 +893,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 318,
+            "line": 325,
           },
           "name": "enabled",
           "optional": true,
@@ -911,7 +911,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 323,
+            "line": 330,
           },
           "name": "runAsUser",
           "optional": true,
@@ -934,7 +934,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 337,
+        "line": 344,
       },
       "name": "MysqlSecondaryPersistence",
       "properties": Array [
@@ -949,7 +949,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 353,
+            "line": 360,
           },
           "name": "additionalValues",
           "optional": true,
@@ -972,7 +972,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 341,
+            "line": 348,
           },
           "name": "enabled",
           "optional": true,
@@ -990,7 +990,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 346,
+            "line": 353,
           },
           "name": "size",
           "optional": true,
@@ -1013,7 +1013,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 291,
+        "line": 298,
       },
       "name": "MysqlSecondaryPodSecurityContext",
       "properties": Array [
@@ -1028,7 +1028,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 307,
+            "line": 314,
           },
           "name": "additionalValues",
           "optional": true,
@@ -1051,7 +1051,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 295,
+            "line": 302,
           },
           "name": "enabled",
           "optional": true,
@@ -1069,7 +1069,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 300,
+            "line": 307,
           },
           "name": "fsGroup",
           "optional": true,
@@ -1092,7 +1092,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 58,
+        "line": 65,
       },
       "name": "MysqlValues",
       "properties": Array [
@@ -1107,7 +1107,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 96,
+            "line": 103,
           },
           "name": "additionalValues",
           "optional": true,
@@ -1131,7 +1131,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 64,
+            "line": 71,
           },
           "name": "architecture",
           "optional": true,
@@ -1149,7 +1149,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 69,
+            "line": 76,
           },
           "name": "auth",
           "optional": true,
@@ -1167,7 +1167,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 84,
+            "line": 91,
           },
           "name": "common",
           "optional": true,
@@ -1190,7 +1190,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 89,
+            "line": 96,
           },
           "name": "global",
           "optional": true,
@@ -1213,7 +1213,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 74,
+            "line": 81,
           },
           "name": "primary",
           "optional": true,
@@ -1231,7 +1231,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 79,
+            "line": 86,
           },
           "name": "secondary",
           "optional": true,
@@ -2657,7 +2657,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 105,
+        "line": 112,
       },
       "members": Array [
         Object {
@@ -2688,7 +2688,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 115,
+        "line": 122,
       },
       "name": "MysqlAuth",
       "properties": Array [
@@ -2702,7 +2702,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 137,
+            "line": 144,
           },
           "name": "password",
           "type": Object {
@@ -2719,7 +2719,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 132,
+            "line": 139,
           },
           "name": "username",
           "type": Object {
@@ -2737,7 +2737,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 159,
+            "line": 166,
           },
           "name": "additionalValues",
           "optional": true,
@@ -2760,7 +2760,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 152,
+            "line": 159,
           },
           "name": "createDatabase",
           "optional": true,
@@ -2778,7 +2778,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 127,
+            "line": 134,
           },
           "name": "database",
           "optional": true,
@@ -2796,7 +2796,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 147,
+            "line": 154,
           },
           "name": "replicationPassword",
           "optional": true,
@@ -2814,7 +2814,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 142,
+            "line": 149,
           },
           "name": "replicationUser",
           "optional": true,
@@ -2834,7 +2834,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 122,
+            "line": 129,
           },
           "name": "rootPassword",
           "optional": true,
@@ -2857,7 +2857,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 166,
+        "line": 173,
       },
       "name": "MysqlPrimary",
       "properties": Array [
@@ -2872,7 +2872,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 187,
+            "line": 194,
           },
           "name": "additionalValues",
           "optional": true,
@@ -2895,7 +2895,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 175,
+            "line": 182,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -2913,7 +2913,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 180,
+            "line": 187,
           },
           "name": "persistence",
           "optional": true,
@@ -2931,7 +2931,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 170,
+            "line": 177,
           },
           "name": "podSecurityContext",
           "optional": true,
@@ -2954,7 +2954,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 245,
+        "line": 252,
       },
       "name": "MysqlPrimaryContainerSecurityContext",
       "properties": Array [
@@ -2969,7 +2969,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 261,
+            "line": 268,
           },
           "name": "additionalValues",
           "optional": true,
@@ -2992,7 +2992,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 249,
+            "line": 256,
           },
           "name": "enabled",
           "optional": true,
@@ -3010,7 +3010,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 254,
+            "line": 261,
           },
           "name": "runAsUser",
           "optional": true,
@@ -3033,7 +3033,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 268,
+        "line": 275,
       },
       "name": "MysqlPrimaryPersistence",
       "properties": Array [
@@ -3048,7 +3048,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 284,
+            "line": 291,
           },
           "name": "additionalValues",
           "optional": true,
@@ -3071,7 +3071,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 272,
+            "line": 279,
           },
           "name": "enabled",
           "optional": true,
@@ -3089,7 +3089,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 277,
+            "line": 284,
           },
           "name": "size",
           "optional": true,
@@ -3112,7 +3112,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 222,
+        "line": 229,
       },
       "name": "MysqlPrimaryPodSecurityContext",
       "properties": Array [
@@ -3127,7 +3127,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 238,
+            "line": 245,
           },
           "name": "additionalValues",
           "optional": true,
@@ -3150,7 +3150,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 226,
+            "line": 233,
           },
           "name": "enabled",
           "optional": true,
@@ -3168,7 +3168,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 231,
+            "line": 238,
           },
           "name": "fsGroup",
           "optional": true,
@@ -3275,7 +3275,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 194,
+        "line": 201,
       },
       "name": "MysqlSecondary",
       "properties": Array [
@@ -3290,7 +3290,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 215,
+            "line": 222,
           },
           "name": "additionalValues",
           "optional": true,
@@ -3313,7 +3313,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 203,
+            "line": 210,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -3331,7 +3331,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 208,
+            "line": 215,
           },
           "name": "persistence",
           "optional": true,
@@ -3349,7 +3349,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 198,
+            "line": 205,
           },
           "name": "podSecurityContext",
           "optional": true,
@@ -3372,7 +3372,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 314,
+        "line": 321,
       },
       "name": "MysqlSecondaryContainerSecurityContext",
       "properties": Array [
@@ -3387,7 +3387,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 330,
+            "line": 337,
           },
           "name": "additionalValues",
           "optional": true,
@@ -3410,7 +3410,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 318,
+            "line": 325,
           },
           "name": "enabled",
           "optional": true,
@@ -3428,7 +3428,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 323,
+            "line": 330,
           },
           "name": "runAsUser",
           "optional": true,
@@ -3451,7 +3451,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 337,
+        "line": 344,
       },
       "name": "MysqlSecondaryPersistence",
       "properties": Array [
@@ -3466,7 +3466,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 353,
+            "line": 360,
           },
           "name": "additionalValues",
           "optional": true,
@@ -3489,7 +3489,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 341,
+            "line": 348,
           },
           "name": "enabled",
           "optional": true,
@@ -3507,7 +3507,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 346,
+            "line": 353,
           },
           "name": "size",
           "optional": true,
@@ -3530,7 +3530,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 291,
+        "line": 298,
       },
       "name": "MysqlSecondaryPodSecurityContext",
       "properties": Array [
@@ -3545,7 +3545,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 307,
+            "line": 314,
           },
           "name": "additionalValues",
           "optional": true,
@@ -3568,7 +3568,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 295,
+            "line": 302,
           },
           "name": "enabled",
           "optional": true,
@@ -3586,7 +3586,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 300,
+            "line": 307,
           },
           "name": "fsGroup",
           "optional": true,
@@ -3609,7 +3609,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 58,
+        "line": 65,
       },
       "name": "MysqlValues",
       "properties": Array [
@@ -3624,7 +3624,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 96,
+            "line": 103,
           },
           "name": "additionalValues",
           "optional": true,
@@ -3648,7 +3648,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 64,
+            "line": 71,
           },
           "name": "architecture",
           "optional": true,
@@ -3666,7 +3666,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 69,
+            "line": 76,
           },
           "name": "auth",
           "optional": true,
@@ -3684,7 +3684,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 84,
+            "line": 91,
           },
           "name": "common",
           "optional": true,
@@ -3707,7 +3707,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 89,
+            "line": 96,
           },
           "name": "global",
           "optional": true,
@@ -3730,7 +3730,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 74,
+            "line": 81,
           },
           "name": "primary",
           "optional": true,
@@ -3748,7 +3748,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 79,
+            "line": 86,
           },
           "name": "secondary",
           "optional": true,
@@ -3801,326 +3801,1044 @@ export class Mysql extends Construct {
       ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
     };
 
-    new Helm(scope, 'Helm', finalProps)
+    new Helm(scope, \`Helm\${id}\`, finalProps)
   }
 
   private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
     for (let prop in props) {
-      if (typeof(props[prop]) === 'object' && prop !== 'additionalValues') {
-        props[prop] = this.flattenAdditionalValues(props[prop]);
+      if (Array.isArray(props[prop])) {
+        props[prop].map((item: any) => {
+          if (typeof(item) === 'object' && prop !== 'additionalValues') {
+            return this.flattenAdditionalValues(item);
+          }
+          return item;
+        });
+        } else if (typeof(props[prop]) === 'object' && prop !== 'additionalValues') {
+          props[prop] = this.flattenAdditionalValues(props[prop]);
+        }
       }
+
+      const { additionalValues, ...valuesWithoutAdditionalValues } = props;
+
+      return {
+        ...valuesWithoutAdditionalValues,
+        ...additionalValues,
+      };
     }
-
-    const { additionalValues, ...valuesWithoutAdditionalValues } = props;
-
-    return {
-      ...valuesWithoutAdditionalValues,
-      ...additionalValues,
-    };
   }
-}
 
-/**
- * @schema mysql
- */
-export interface MysqlValues {
+  /**
+   * @schema mysql
+   */
+  export interface MysqlValues {
+    /**
+     * Allowed values: \`standalone\` or \`replication\`
+     *
+     * @schema mysql#architecture
+     */
+    readonly architecture?: MysqlArchitecture;
+
+    /**
+     * @schema mysql#auth
+     */
+    readonly auth?: MysqlAuth;
+
+    /**
+     * @schema mysql#primary
+     */
+    readonly primary?: MysqlPrimary;
+
+    /**
+     * @schema mysql#secondary
+     */
+    readonly secondary?: MysqlSecondary;
+
+    /**
+     * @schema mysql#common
+     */
+    readonly common?: { [key: string]: any };
+
+    /**
+     * @schema mysql#global
+     */
+    readonly global?: { [key: string]: any };
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema mysql#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
+
   /**
    * Allowed values: \`standalone\` or \`replication\`
    *
-   * @schema mysql#architecture
+   * @schema MysqlArchitecture
    */
-  readonly architecture?: MysqlArchitecture;
+  export enum MysqlArchitecture {
+    /** standalone */
+    STANDALONE = \\"standalone\\",
+    /** replication */
+    REPLICATION = \\"replication\\",
+  }
 
   /**
-   * @schema mysql#auth
+   * @schema MysqlAuth
    */
-  readonly auth?: MysqlAuth;
+  export interface MysqlAuth {
+    /**
+     * Defaults to a random 10-character alphanumeric string if not set
+     *
+     * @default a random 10-character alphanumeric string if not set
+     * @schema MysqlAuth#rootPassword
+     */
+    readonly rootPassword?: string;
+
+    /**
+     * @schema MysqlAuth#database
+     */
+    readonly database?: string;
+
+    /**
+     * @schema MysqlAuth#username
+     */
+    readonly username: string;
+
+    /**
+     * @schema MysqlAuth#password
+     */
+    readonly password: string;
+
+    /**
+     * @schema MysqlAuth#replicationUser
+     */
+    readonly replicationUser?: string;
+
+    /**
+     * @schema MysqlAuth#replicationPassword
+     */
+    readonly replicationPassword?: string;
+
+    /**
+     * @schema MysqlAuth#createDatabase
+     */
+    readonly createDatabase?: boolean;
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema MysqlAuth#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
 
   /**
-   * @schema mysql#primary
+   * @schema MysqlPrimary
    */
-  readonly primary?: MysqlPrimary;
+  export interface MysqlPrimary {
+    /**
+     * @schema MysqlPrimary#podSecurityContext
+     */
+    readonly podSecurityContext?: MysqlPrimaryPodSecurityContext;
+
+    /**
+     * @schema MysqlPrimary#containerSecurityContext
+     */
+    readonly containerSecurityContext?: MysqlPrimaryContainerSecurityContext;
+
+    /**
+     * @schema MysqlPrimary#persistence
+     */
+    readonly persistence?: MysqlPrimaryPersistence;
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema MysqlPrimary#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
 
   /**
-   * @schema mysql#secondary
+   * @schema MysqlSecondary
    */
-  readonly secondary?: MysqlSecondary;
+  export interface MysqlSecondary {
+    /**
+     * @schema MysqlSecondary#podSecurityContext
+     */
+    readonly podSecurityContext?: MysqlSecondaryPodSecurityContext;
+
+    /**
+     * @schema MysqlSecondary#containerSecurityContext
+     */
+    readonly containerSecurityContext?: MysqlSecondaryContainerSecurityContext;
+
+    /**
+     * @schema MysqlSecondary#persistence
+     */
+    readonly persistence?: MysqlSecondaryPersistence;
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema MysqlSecondary#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
 
   /**
-   * @schema mysql#common
+   * @schema MysqlPrimaryPodSecurityContext
    */
-  readonly common?: { [key: string]: any };
+  export interface MysqlPrimaryPodSecurityContext {
+    /**
+     * @schema MysqlPrimaryPodSecurityContext#enabled
+     */
+    readonly enabled?: boolean;
+
+    /**
+     * @schema MysqlPrimaryPodSecurityContext#fsGroup
+     */
+    readonly fsGroup?: number;
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema MysqlPrimaryPodSecurityContext#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
 
   /**
-   * @schema mysql#global
+   * @schema MysqlPrimaryContainerSecurityContext
    */
-  readonly global?: { [key: string]: any };
+  export interface MysqlPrimaryContainerSecurityContext {
+    /**
+     * @schema MysqlPrimaryContainerSecurityContext#enabled
+     */
+    readonly enabled?: boolean;
+
+    /**
+     * @schema MysqlPrimaryContainerSecurityContext#runAsUser
+     */
+    readonly runAsUser?: number;
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema MysqlPrimaryContainerSecurityContext#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
 
   /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema mysql#additionalValues
+   * @schema MysqlPrimaryPersistence
    */
-  readonly additionalValues?: { [key: string]: any };
+  export interface MysqlPrimaryPersistence {
+    /**
+     * @schema MysqlPrimaryPersistence#enabled
+     */
+    readonly enabled?: boolean;
 
+    /**
+     * @schema MysqlPrimaryPersistence#size
+     */
+    readonly size?: string;
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema MysqlPrimaryPersistence#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
+
+  /**
+   * @schema MysqlSecondaryPodSecurityContext
+   */
+  export interface MysqlSecondaryPodSecurityContext {
+    /**
+     * @schema MysqlSecondaryPodSecurityContext#enabled
+     */
+    readonly enabled?: boolean;
+
+    /**
+     * @schema MysqlSecondaryPodSecurityContext#fsGroup
+     */
+    readonly fsGroup?: number;
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema MysqlSecondaryPodSecurityContext#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
+
+  /**
+   * @schema MysqlSecondaryContainerSecurityContext
+   */
+  export interface MysqlSecondaryContainerSecurityContext {
+    /**
+     * @schema MysqlSecondaryContainerSecurityContext#enabled
+     */
+    readonly enabled?: boolean;
+
+    /**
+     * @schema MysqlSecondaryContainerSecurityContext#runAsUser
+     */
+    readonly runAsUser?: number;
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema MysqlSecondaryContainerSecurityContext#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
+
+  /**
+   * @schema MysqlSecondaryPersistence
+   */
+  export interface MysqlSecondaryPersistence {
+    /**
+     * @schema MysqlSecondaryPersistence#enabled
+     */
+    readonly enabled?: boolean;
+
+    /**
+     * @schema MysqlSecondaryPersistence#size
+     */
+    readonly size?: string;
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema MysqlSecondaryPersistence#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
+
+",
+}
+`;
+
+exports[`importing helm chart helm:https://grafana.github.io/helm-charts/loki@5.27.0 with python lanugage 1`] = `
+Object {
+  "author": Object {
+    "name": "generated@generated.com",
+    "roles": Array [
+      "author",
+    ],
+  },
+  "dependencies": "__omitted__",
+  "dependencyClosure": Object {
+    "cdk8s": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Org.Cdk8s",
+          "packageId": "Org.Cdk8s",
+        },
+        "go": Object {
+          "moduleName": "github.com/cdk8s-team/cdk8s-core-go",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "cdk8s",
+            "groupId": "org.cdk8s",
+          },
+          "package": "org.cdk8s",
+        },
+        "js": Object {
+          "npm": "cdk8s",
+        },
+        "python": Object {
+          "distName": "cdk8s",
+          "module": "cdk8s",
+        },
+      },
+    },
+    "constructs": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Constructs",
+          "packageId": "Constructs",
+        },
+        "go": Object {
+          "moduleName": "github.com/aws/constructs-go",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "constructs",
+            "groupId": "software.constructs",
+          },
+          "package": "software.constructs",
+        },
+        "js": Object {
+          "npm": "constructs",
+        },
+        "python": Object {
+          "distName": "constructs",
+          "module": "constructs",
+        },
+      },
+    },
+  },
+  "description": "loki",
+  "fingerprint": "<fingerprint>",
+  "homepage": "http://generated",
+  "jsiiVersion": "__omitted__",
+  "license": "UNLICENSED",
+  "metadata": Object {
+    "jsii": Object {
+      "pacmak": Object {
+        "hasDefaultInterfaces": true,
+      },
+    },
+  },
+  "name": "loki",
+  "repository": Object {
+    "type": "git",
+    "url": "http://generated",
+  },
+  "schema": "jsii/0.10.0",
+  "targets": Object {
+    "js": Object {
+      "npm": "loki",
+    },
+    "python": Object {
+      "distName": "generated",
+      "module": "loki",
+    },
+  },
+  "types": Object {
+    "loki.Loki": Object {
+      "assembly": "loki",
+      "base": "constructs.Construct",
+      "fqn": "loki.Loki",
+      "initializer": Object {
+        "locationInModule": Object {
+          "filename": "loki.ts",
+          "line": 14,
+        },
+        "parameters": Array [
+          Object {
+            "name": "scope",
+            "type": Object {
+              "fqn": "constructs.Construct",
+            },
+          },
+          Object {
+            "name": "id",
+            "type": Object {
+              "primitive": "string",
+            },
+          },
+          Object {
+            "name": "props",
+            "optional": true,
+            "type": Object {
+              "fqn": "loki.LokiProps",
+            },
+          },
+        ],
+      },
+      "kind": "class",
+      "locationInModule": Object {
+        "filename": "loki.ts",
+        "line": 13,
+      },
+      "name": "Loki",
+      "symbolId": "loki:Loki",
+    },
+    "loki.LokiProps": Object {
+      "assembly": "loki",
+      "datatype": true,
+      "fqn": "loki.LokiProps",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "loki.ts",
+        "line": 5,
+      },
+      "name": "LokiProps",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "loki.ts",
+            "line": 8,
+          },
+          "name": "helmExecutable",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "loki.ts",
+            "line": 9,
+          },
+          "name": "helmFlags",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "loki.ts",
+            "line": 6,
+          },
+          "name": "namespace",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "loki.ts",
+            "line": 7,
+          },
+          "name": "releaseName",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "loki.ts",
+            "line": 10,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "loki:LokiProps",
+    },
+  },
+  "version": "0.0.0",
+}
+`;
+
+exports[`importing helm chart helm:https://grafana.github.io/helm-charts/loki@5.27.0 with python lanugage 2`] = `
+Object {
+  "loki/__init__.py": "import abc
+import builtins
+import datetime
+import enum
+import typing
+
+import jsii
+import publication
+import typing_extensions
+
+from typeguard import check_type
+
+from ._jsii import *
+
+import constructs as _constructs_77d1e7e8
+
+
+class Loki(
+    _constructs_77d1e7e8.Construct,
+    metaclass=jsii.JSIIMeta,
+    jsii_type=\\"loki.Loki\\",
+):
+    def __init__(
+        self,
+        scope: _constructs_77d1e7e8.Construct,
+        id: builtins.str,
+        *,
+        helm_executable: typing.Optional[builtins.str] = None,
+        helm_flags: typing.Optional[typing.Sequence[builtins.str]] = None,
+        namespace: typing.Optional[builtins.str] = None,
+        release_name: typing.Optional[builtins.str] = None,
+        values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    ) -> None:
+        '''
+        :param scope: -
+        :param id: -
+        :param helm_executable: -
+        :param helm_flags: -
+        :param namespace: -
+        :param release_name: -
+        :param values: -
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__f1d23af9ace606bd925629648645169df04574e2a303e09d4fcaf42d666e0f62)
+            check_type(argname=\\"argument scope\\", value=scope, expected_type=type_hints[\\"scope\\"])
+            check_type(argname=\\"argument id\\", value=id, expected_type=type_hints[\\"id\\"])
+        props = LokiProps(
+            helm_executable=helm_executable,
+            helm_flags=helm_flags,
+            namespace=namespace,
+            release_name=release_name,
+            values=values,
+        )
+
+        jsii.create(self.__class__, self, [scope, id, props])
+
+
+@jsii.data_type(
+    jsii_type=\\"loki.LokiProps\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"helm_executable\\": \\"helmExecutable\\",
+        \\"helm_flags\\": \\"helmFlags\\",
+        \\"namespace\\": \\"namespace\\",
+        \\"release_name\\": \\"releaseName\\",
+        \\"values\\": \\"values\\",
+    },
+)
+class LokiProps:
+    def __init__(
+        self,
+        *,
+        helm_executable: typing.Optional[builtins.str] = None,
+        helm_flags: typing.Optional[typing.Sequence[builtins.str]] = None,
+        namespace: typing.Optional[builtins.str] = None,
+        release_name: typing.Optional[builtins.str] = None,
+        values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    ) -> None:
+        '''
+        :param helm_executable: -
+        :param helm_flags: -
+        :param namespace: -
+        :param release_name: -
+        :param values: -
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__c8e7d6706b1656a9b1ed96c19860786a777f4336504fed38f4230700ca183292)
+            check_type(argname=\\"argument helm_executable\\", value=helm_executable, expected_type=type_hints[\\"helm_executable\\"])
+            check_type(argname=\\"argument helm_flags\\", value=helm_flags, expected_type=type_hints[\\"helm_flags\\"])
+            check_type(argname=\\"argument namespace\\", value=namespace, expected_type=type_hints[\\"namespace\\"])
+            check_type(argname=\\"argument release_name\\", value=release_name, expected_type=type_hints[\\"release_name\\"])
+            check_type(argname=\\"argument values\\", value=values, expected_type=type_hints[\\"values\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if helm_executable is not None:
+            self._values[\\"helm_executable\\"] = helm_executable
+        if helm_flags is not None:
+            self._values[\\"helm_flags\\"] = helm_flags
+        if namespace is not None:
+            self._values[\\"namespace\\"] = namespace
+        if release_name is not None:
+            self._values[\\"release_name\\"] = release_name
+        if values is not None:
+            self._values[\\"values\\"] = values
+
+    @builtins.property
+    def helm_executable(self) -> typing.Optional[builtins.str]:
+        result = self._values.get(\\"helm_executable\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def helm_flags(self) -> typing.Optional[typing.List[builtins.str]]:
+        result = self._values.get(\\"helm_flags\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    @builtins.property
+    def namespace(self) -> typing.Optional[builtins.str]:
+        result = self._values.get(\\"namespace\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def release_name(self) -> typing.Optional[builtins.str]:
+        result = self._values.get(\\"release_name\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def values(self) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        result = self._values.get(\\"values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"LokiProps(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+__all__ = [
+    \\"Loki\\",
+    \\"LokiProps\\",
+]
+
+publication.publish()
+
+def _typecheckingstub__f1d23af9ace606bd925629648645169df04574e2a303e09d4fcaf42d666e0f62(
+    scope: _constructs_77d1e7e8.Construct,
+    id: builtins.str,
+    *,
+    helm_executable: typing.Optional[builtins.str] = None,
+    helm_flags: typing.Optional[typing.Sequence[builtins.str]] = None,
+    namespace: typing.Optional[builtins.str] = None,
+    release_name: typing.Optional[builtins.str] = None,
+    values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__c8e7d6706b1656a9b1ed96c19860786a777f4336504fed38f4230700ca183292(
+    *,
+    helm_executable: typing.Optional[builtins.str] = None,
+    helm_flags: typing.Optional[typing.Sequence[builtins.str]] = None,
+    namespace: typing.Optional[builtins.str] = None,
+    release_name: typing.Optional[builtins.str] = None,
+    values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+",
+  "loki/_jsii/__init__.py": "import abc
+import builtins
+import datetime
+import enum
+import typing
+
+import jsii
+import publication
+import typing_extensions
+
+from typeguard import check_type
+
+import cdk8s._jsii
+import constructs._jsii
+
+__jsii_assembly__ = jsii.JSIIAssembly.load(
+    \\"loki\\", \\"0.0.0\\", __name__[0:-6], \\"loki@0.0.0.jsii.tgz\\"
+)
+
+__all__ = [
+    \\"__jsii_assembly__\\",
+]
+
+publication.publish()
+",
+  "loki/py.typed": "
+",
+}
+`;
+
+exports[`importing helm chart helm:https://grafana.github.io/helm-charts/loki@5.27.0 with typescript lanugage 1`] = `
+Object {
+  "author": Object {
+    "name": "generated@generated.com",
+    "roles": Array [
+      "author",
+    ],
+  },
+  "dependencies": "__omitted__",
+  "dependencyClosure": Object {
+    "cdk8s": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Org.Cdk8s",
+          "packageId": "Org.Cdk8s",
+        },
+        "go": Object {
+          "moduleName": "github.com/cdk8s-team/cdk8s-core-go",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "cdk8s",
+            "groupId": "org.cdk8s",
+          },
+          "package": "org.cdk8s",
+        },
+        "js": Object {
+          "npm": "cdk8s",
+        },
+        "python": Object {
+          "distName": "cdk8s",
+          "module": "cdk8s",
+        },
+      },
+    },
+    "constructs": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Constructs",
+          "packageId": "Constructs",
+        },
+        "go": Object {
+          "moduleName": "github.com/aws/constructs-go",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "constructs",
+            "groupId": "software.constructs",
+          },
+          "package": "software.constructs",
+        },
+        "js": Object {
+          "npm": "constructs",
+        },
+        "python": Object {
+          "distName": "constructs",
+          "module": "constructs",
+        },
+      },
+    },
+  },
+  "description": "loki",
+  "fingerprint": "<fingerprint>",
+  "homepage": "http://generated",
+  "jsiiVersion": "__omitted__",
+  "license": "UNLICENSED",
+  "metadata": Object {
+    "jsii": Object {
+      "pacmak": Object {
+        "hasDefaultInterfaces": true,
+      },
+    },
+  },
+  "name": "loki",
+  "repository": Object {
+    "type": "git",
+    "url": "http://generated",
+  },
+  "schema": "jsii/0.10.0",
+  "targets": Object {
+    "js": Object {
+      "npm": "loki",
+    },
+  },
+  "types": Object {
+    "loki.Loki": Object {
+      "assembly": "loki",
+      "base": "constructs.Construct",
+      "fqn": "loki.Loki",
+      "initializer": Object {
+        "locationInModule": Object {
+          "filename": "loki.ts",
+          "line": 14,
+        },
+        "parameters": Array [
+          Object {
+            "name": "scope",
+            "type": Object {
+              "fqn": "constructs.Construct",
+            },
+          },
+          Object {
+            "name": "id",
+            "type": Object {
+              "primitive": "string",
+            },
+          },
+          Object {
+            "name": "props",
+            "optional": true,
+            "type": Object {
+              "fqn": "loki.LokiProps",
+            },
+          },
+        ],
+      },
+      "kind": "class",
+      "locationInModule": Object {
+        "filename": "loki.ts",
+        "line": 13,
+      },
+      "name": "Loki",
+      "symbolId": "loki:Loki",
+    },
+    "loki.LokiProps": Object {
+      "assembly": "loki",
+      "datatype": true,
+      "fqn": "loki.LokiProps",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "loki.ts",
+        "line": 5,
+      },
+      "name": "LokiProps",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "loki.ts",
+            "line": 8,
+          },
+          "name": "helmExecutable",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "loki.ts",
+            "line": 9,
+          },
+          "name": "helmFlags",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "loki.ts",
+            "line": 6,
+          },
+          "name": "namespace",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "loki.ts",
+            "line": 7,
+          },
+          "name": "releaseName",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "loki.ts",
+            "line": 10,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "loki:LokiProps",
+    },
+  },
+  "version": "0.0.0",
+}
+`;
+
+exports[`importing helm chart helm:https://grafana.github.io/helm-charts/loki@5.27.0 with typescript lanugage 2`] = `
+Object {
+  "loki.ts": "// generated by cdk8s
+import { Helm, HelmProps } from 'cdk8s';
+import { Construct } from 'constructs';
+
+export interface LokiProps {
+  readonly namespace?: string;
+  readonly releaseName?: string;
+  readonly helmExecutable?: string;
+  readonly helmFlags?: string[];
+  readonly values?: { [key: string]: any };
 }
 
-/**
- * Allowed values: \`standalone\` or \`replication\`
- *
- * @schema MysqlArchitecture
- */
-export enum MysqlArchitecture {
-  /** standalone */
-  STANDALONE = \\"standalone\\",
-  /** replication */
-  REPLICATION = \\"replication\\",
-}
+export class Loki extends Construct {
+  public constructor(scope: Construct, id: string, props: LokiProps = {}) {
+    super(scope, id)
+    let updatedProps = {};
 
-/**
- * @schema MysqlAuth
- */
-export interface MysqlAuth {
-  /**
-   * Defaults to a random 10-character alphanumeric string if not set
-   *
-   * @default a random 10-character alphanumeric string if not set
-   * @schema MysqlAuth#rootPassword
-   */
-  readonly rootPassword?: string;
+    if (props.values) {
+      const { additionalValues, ...valuesWithoutAdditionalValues } = props.values;
+      updatedProps = {
+        ...props,
+        values: {
+          ...this.flattenAdditionalValues(valuesWithoutAdditionalValues),
+          ...additionalValues,
+        }
+      };
+    }
 
-  /**
-   * @schema MysqlAuth#database
-   */
-  readonly database?: string;
+    const finalProps: HelmProps = {
+      chart: 'loki',
+      repo: 'https://grafana.github.io/helm-charts',
+      version: '5.27.0',
+      ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
+    };
 
-  /**
-   * @schema MysqlAuth#username
-   */
-  readonly username: string;
+    new Helm(scope, \`Helm\${id}\`, finalProps)
+  }
 
-  /**
-   * @schema MysqlAuth#password
-   */
-  readonly password: string;
+  private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
+    for (let prop in props) {
+      if (Array.isArray(props[prop])) {
+        props[prop].map((item: any) => {
+          if (typeof(item) === 'object' && prop !== 'additionalValues') {
+            return this.flattenAdditionalValues(item);
+          }
+          return item;
+        });
+        } else if (typeof(props[prop]) === 'object' && prop !== 'additionalValues') {
+          props[prop] = this.flattenAdditionalValues(props[prop]);
+        }
+      }
 
-  /**
-   * @schema MysqlAuth#replicationUser
-   */
-  readonly replicationUser?: string;
+      const { additionalValues, ...valuesWithoutAdditionalValues } = props;
 
-  /**
-   * @schema MysqlAuth#replicationPassword
-   */
-  readonly replicationPassword?: string;
-
-  /**
-   * @schema MysqlAuth#createDatabase
-   */
-  readonly createDatabase?: boolean;
-
-  /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema MysqlAuth#additionalValues
-   */
-  readonly additionalValues?: { [key: string]: any };
-
-}
-
-/**
- * @schema MysqlPrimary
- */
-export interface MysqlPrimary {
-  /**
-   * @schema MysqlPrimary#podSecurityContext
-   */
-  readonly podSecurityContext?: MysqlPrimaryPodSecurityContext;
-
-  /**
-   * @schema MysqlPrimary#containerSecurityContext
-   */
-  readonly containerSecurityContext?: MysqlPrimaryContainerSecurityContext;
-
-  /**
-   * @schema MysqlPrimary#persistence
-   */
-  readonly persistence?: MysqlPrimaryPersistence;
-
-  /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema MysqlPrimary#additionalValues
-   */
-  readonly additionalValues?: { [key: string]: any };
-
-}
-
-/**
- * @schema MysqlSecondary
- */
-export interface MysqlSecondary {
-  /**
-   * @schema MysqlSecondary#podSecurityContext
-   */
-  readonly podSecurityContext?: MysqlSecondaryPodSecurityContext;
-
-  /**
-   * @schema MysqlSecondary#containerSecurityContext
-   */
-  readonly containerSecurityContext?: MysqlSecondaryContainerSecurityContext;
-
-  /**
-   * @schema MysqlSecondary#persistence
-   */
-  readonly persistence?: MysqlSecondaryPersistence;
-
-  /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema MysqlSecondary#additionalValues
-   */
-  readonly additionalValues?: { [key: string]: any };
-
-}
-
-/**
- * @schema MysqlPrimaryPodSecurityContext
- */
-export interface MysqlPrimaryPodSecurityContext {
-  /**
-   * @schema MysqlPrimaryPodSecurityContext#enabled
-   */
-  readonly enabled?: boolean;
-
-  /**
-   * @schema MysqlPrimaryPodSecurityContext#fsGroup
-   */
-  readonly fsGroup?: number;
-
-  /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema MysqlPrimaryPodSecurityContext#additionalValues
-   */
-  readonly additionalValues?: { [key: string]: any };
-
-}
-
-/**
- * @schema MysqlPrimaryContainerSecurityContext
- */
-export interface MysqlPrimaryContainerSecurityContext {
-  /**
-   * @schema MysqlPrimaryContainerSecurityContext#enabled
-   */
-  readonly enabled?: boolean;
-
-  /**
-   * @schema MysqlPrimaryContainerSecurityContext#runAsUser
-   */
-  readonly runAsUser?: number;
-
-  /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema MysqlPrimaryContainerSecurityContext#additionalValues
-   */
-  readonly additionalValues?: { [key: string]: any };
-
-}
-
-/**
- * @schema MysqlPrimaryPersistence
- */
-export interface MysqlPrimaryPersistence {
-  /**
-   * @schema MysqlPrimaryPersistence#enabled
-   */
-  readonly enabled?: boolean;
-
-  /**
-   * @schema MysqlPrimaryPersistence#size
-   */
-  readonly size?: string;
-
-  /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema MysqlPrimaryPersistence#additionalValues
-   */
-  readonly additionalValues?: { [key: string]: any };
-
-}
-
-/**
- * @schema MysqlSecondaryPodSecurityContext
- */
-export interface MysqlSecondaryPodSecurityContext {
-  /**
-   * @schema MysqlSecondaryPodSecurityContext#enabled
-   */
-  readonly enabled?: boolean;
-
-  /**
-   * @schema MysqlSecondaryPodSecurityContext#fsGroup
-   */
-  readonly fsGroup?: number;
-
-  /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema MysqlSecondaryPodSecurityContext#additionalValues
-   */
-  readonly additionalValues?: { [key: string]: any };
-
-}
-
-/**
- * @schema MysqlSecondaryContainerSecurityContext
- */
-export interface MysqlSecondaryContainerSecurityContext {
-  /**
-   * @schema MysqlSecondaryContainerSecurityContext#enabled
-   */
-  readonly enabled?: boolean;
-
-  /**
-   * @schema MysqlSecondaryContainerSecurityContext#runAsUser
-   */
-  readonly runAsUser?: number;
-
-  /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema MysqlSecondaryContainerSecurityContext#additionalValues
-   */
-  readonly additionalValues?: { [key: string]: any };
-
-}
-
-/**
- * @schema MysqlSecondaryPersistence
- */
-export interface MysqlSecondaryPersistence {
-  /**
-   * @schema MysqlSecondaryPersistence#enabled
-   */
-  readonly enabled?: boolean;
-
-  /**
-   * @schema MysqlSecondaryPersistence#size
-   */
-  readonly size?: string;
-
-  /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema MysqlSecondaryPersistence#additionalValues
-   */
-  readonly additionalValues?: { [key: string]: any };
-
-}
+      return {
+        ...valuesWithoutAdditionalValues,
+        ...additionalValues,
+      };
+    }
+  }
 
 ",
 }
@@ -4807,24 +5525,31 @@ export class Ingressnginx extends Construct {
       ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
     };
 
-    new Helm(scope, 'Helm', finalProps)
+    new Helm(scope, \`Helm\${id}\`, finalProps)
   }
 
   private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
     for (let prop in props) {
-      if (typeof(props[prop]) === 'object' && prop !== 'additionalValues') {
-        props[prop] = this.flattenAdditionalValues(props[prop]);
+      if (Array.isArray(props[prop])) {
+        props[prop].map((item: any) => {
+          if (typeof(item) === 'object' && prop !== 'additionalValues') {
+            return this.flattenAdditionalValues(item);
+          }
+          return item;
+        });
+        } else if (typeof(props[prop]) === 'object' && prop !== 'additionalValues') {
+          props[prop] = this.flattenAdditionalValues(props[prop]);
+        }
       }
+
+      const { additionalValues, ...valuesWithoutAdditionalValues } = props;
+
+      return {
+        ...valuesWithoutAdditionalValues,
+        ...additionalValues,
+      };
     }
-
-    const { additionalValues, ...valuesWithoutAdditionalValues } = props;
-
-    return {
-      ...valuesWithoutAdditionalValues,
-      ...additionalValues,
-    };
   }
-}
 
 ",
 }
@@ -4932,7 +5657,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 583,
+        "line": 590,
       },
       "name": "IoK8SApiCoreV1Affinity",
       "properties": Array [
@@ -4947,7 +5672,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 589,
+            "line": 596,
           },
           "name": "nodeAffinity",
           "optional": true,
@@ -4966,7 +5691,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 596,
+            "line": 603,
           },
           "name": "podAffinity",
           "optional": true,
@@ -4985,7 +5710,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 603,
+            "line": 610,
           },
           "name": "podAntiAffinity",
           "optional": true,
@@ -5009,7 +5734,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 952,
+        "line": 959,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinity",
       "properties": Array [
@@ -5025,7 +5750,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 958,
+            "line": 965,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -5050,7 +5775,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 965,
+            "line": 972,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -5074,7 +5799,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1073,
+        "line": 1080,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -5090,7 +5815,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1079,
+            "line": 1086,
           },
           "name": "preference",
           "optional": true,
@@ -5109,7 +5834,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1086,
+            "line": 1093,
           },
           "name": "weight",
           "optional": true,
@@ -5134,7 +5859,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1226,
+        "line": 1233,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
       "properties": Array [
@@ -5149,7 +5874,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1232,
+            "line": 1239,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -5173,7 +5898,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1239,
+            "line": 1246,
           },
           "name": "matchFields",
           "optional": true,
@@ -5202,7 +5927,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1430,
+        "line": 1437,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
       "properties": Array [
@@ -5217,7 +5942,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1436,
+            "line": 1443,
           },
           "name": "key",
           "optional": true,
@@ -5243,7 +5968,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1451,
+            "line": 1458,
           },
           "name": "operator",
           "optional": true,
@@ -5263,7 +5988,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1458,
+            "line": 1465,
           },
           "name": "values",
           "optional": true,
@@ -5298,7 +6023,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1790,
+        "line": 1797,
       },
       "members": Array [
         Object {
@@ -5354,7 +6079,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1467,
+        "line": 1474,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
       "properties": Array [
@@ -5369,7 +6094,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1473,
+            "line": 1480,
           },
           "name": "key",
           "optional": true,
@@ -5395,7 +6120,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1488,
+            "line": 1495,
           },
           "name": "operator",
           "optional": true,
@@ -5415,7 +6140,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1495,
+            "line": 1502,
           },
           "name": "values",
           "optional": true,
@@ -5450,7 +6175,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1818,
+        "line": 1825,
       },
       "members": Array [
         Object {
@@ -5507,7 +6232,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1095,
+        "line": 1102,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -5523,7 +6248,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1101,
+            "line": 1108,
           },
           "name": "nodeSelectorTerms",
           "optional": true,
@@ -5553,7 +6278,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1248,
+        "line": 1255,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
       "properties": Array [
@@ -5568,7 +6293,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1254,
+            "line": 1261,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -5592,7 +6317,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1261,
+            "line": 1268,
           },
           "name": "matchFields",
           "optional": true,
@@ -5621,7 +6346,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1504,
+        "line": 1511,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
       "properties": Array [
@@ -5636,7 +6361,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1510,
+            "line": 1517,
           },
           "name": "key",
           "optional": true,
@@ -5662,7 +6387,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1525,
+            "line": 1532,
           },
           "name": "operator",
           "optional": true,
@@ -5682,7 +6407,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1532,
+            "line": 1539,
           },
           "name": "values",
           "optional": true,
@@ -5717,7 +6442,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1846,
+        "line": 1853,
       },
       "members": Array [
         Object {
@@ -5773,7 +6498,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1541,
+        "line": 1548,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
       "properties": Array [
@@ -5788,7 +6513,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1547,
+            "line": 1554,
           },
           "name": "key",
           "optional": true,
@@ -5814,7 +6539,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1562,
+            "line": 1569,
           },
           "name": "operator",
           "optional": true,
@@ -5834,7 +6559,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1569,
+            "line": 1576,
           },
           "name": "values",
           "optional": true,
@@ -5869,7 +6594,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1874,
+        "line": 1881,
       },
       "members": Array [
         Object {
@@ -5925,7 +6650,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 974,
+        "line": 981,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinity",
       "properties": Array [
@@ -5941,7 +6666,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 980,
+            "line": 987,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -5966,7 +6691,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 987,
+            "line": 994,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -5995,7 +6720,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1110,
+        "line": 1117,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -6010,7 +6735,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1116,
+            "line": 1123,
           },
           "name": "podAffinityTerm",
           "optional": true,
@@ -6029,7 +6754,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1123,
+            "line": 1130,
           },
           "name": "weight",
           "optional": true,
@@ -6053,7 +6778,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1270,
+        "line": 1277,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "properties": Array [
@@ -6069,7 +6794,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1297,
+            "line": 1304,
           },
           "name": "topologyKey",
           "type": Object {
@@ -6088,7 +6813,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1276,
+            "line": 1283,
           },
           "name": "labelSelector",
           "optional": true,
@@ -6108,7 +6833,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1290,
+            "line": 1297,
           },
           "name": "namespaces",
           "optional": true,
@@ -6133,7 +6858,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1283,
+            "line": 1290,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -6158,7 +6883,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1578,
+        "line": 1585,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "properties": Array [
@@ -6174,7 +6899,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1584,
+            "line": 1591,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -6199,7 +6924,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1591,
+            "line": 1598,
           },
           "name": "matchLabels",
           "optional": true,
@@ -6228,7 +6953,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1894,
+        "line": 1901,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "properties": Array [
@@ -6243,7 +6968,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1900,
+            "line": 1907,
           },
           "name": "key",
           "optional": true,
@@ -6263,7 +6988,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1907,
+            "line": 1914,
           },
           "name": "operator",
           "optional": true,
@@ -6283,7 +7008,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1914,
+            "line": 1921,
           },
           "name": "values",
           "optional": true,
@@ -6313,7 +7038,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1600,
+        "line": 1607,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
       "properties": Array [
@@ -6329,7 +7054,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1606,
+            "line": 1613,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -6354,7 +7079,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1613,
+            "line": 1620,
           },
           "name": "matchLabels",
           "optional": true,
@@ -6383,7 +7108,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1923,
+        "line": 1930,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -6398,7 +7123,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1929,
+            "line": 1936,
           },
           "name": "key",
           "optional": true,
@@ -6418,7 +7143,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1936,
+            "line": 1943,
           },
           "name": "operator",
           "optional": true,
@@ -6438,7 +7163,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1943,
+            "line": 1950,
           },
           "name": "values",
           "optional": true,
@@ -6467,7 +7192,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1132,
+        "line": 1139,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -6483,7 +7208,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1138,
+            "line": 1145,
           },
           "name": "labelSelector",
           "optional": true,
@@ -6503,7 +7228,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1152,
+            "line": 1159,
           },
           "name": "namespaces",
           "optional": true,
@@ -6528,7 +7253,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1145,
+            "line": 1152,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -6548,7 +7273,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1159,
+            "line": 1166,
           },
           "name": "topologyKey",
           "optional": true,
@@ -6573,7 +7298,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1306,
+        "line": 1313,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "properties": Array [
@@ -6589,7 +7314,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1312,
+            "line": 1319,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -6614,7 +7339,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1319,
+            "line": 1326,
           },
           "name": "matchLabels",
           "optional": true,
@@ -6643,7 +7368,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1622,
+        "line": 1629,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "properties": Array [
@@ -6658,7 +7383,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1628,
+            "line": 1635,
           },
           "name": "key",
           "optional": true,
@@ -6678,7 +7403,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1635,
+            "line": 1642,
           },
           "name": "operator",
           "optional": true,
@@ -6698,7 +7423,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1642,
+            "line": 1649,
           },
           "name": "values",
           "optional": true,
@@ -6728,7 +7453,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1328,
+        "line": 1335,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
       "properties": Array [
@@ -6744,7 +7469,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1334,
+            "line": 1341,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -6769,7 +7494,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1341,
+            "line": 1348,
           },
           "name": "matchLabels",
           "optional": true,
@@ -6798,7 +7523,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1651,
+        "line": 1658,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -6813,7 +7538,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1657,
+            "line": 1664,
           },
           "name": "key",
           "optional": true,
@@ -6833,7 +7558,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1664,
+            "line": 1671,
           },
           "name": "operator",
           "optional": true,
@@ -6853,7 +7578,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1671,
+            "line": 1678,
           },
           "name": "values",
           "optional": true,
@@ -6882,7 +7607,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 996,
+        "line": 1003,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinity",
       "properties": Array [
@@ -6898,7 +7623,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1002,
+            "line": 1009,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -6923,7 +7648,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1009,
+            "line": 1016,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -6952,7 +7677,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1168,
+        "line": 1175,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -6967,7 +7692,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1174,
+            "line": 1181,
           },
           "name": "podAffinityTerm",
           "optional": true,
@@ -6986,7 +7711,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1181,
+            "line": 1188,
           },
           "name": "weight",
           "optional": true,
@@ -7010,7 +7735,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1350,
+        "line": 1357,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "properties": Array [
@@ -7026,7 +7751,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1377,
+            "line": 1384,
           },
           "name": "topologyKey",
           "type": Object {
@@ -7045,7 +7770,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1356,
+            "line": 1363,
           },
           "name": "labelSelector",
           "optional": true,
@@ -7065,7 +7790,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1370,
+            "line": 1377,
           },
           "name": "namespaces",
           "optional": true,
@@ -7090,7 +7815,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1363,
+            "line": 1370,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -7115,7 +7840,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1680,
+        "line": 1687,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "properties": Array [
@@ -7131,7 +7856,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1686,
+            "line": 1693,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -7156,7 +7881,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1693,
+            "line": 1700,
           },
           "name": "matchLabels",
           "optional": true,
@@ -7185,7 +7910,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1952,
+        "line": 1959,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "properties": Array [
@@ -7200,7 +7925,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1958,
+            "line": 1965,
           },
           "name": "key",
           "optional": true,
@@ -7220,7 +7945,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1965,
+            "line": 1972,
           },
           "name": "operator",
           "optional": true,
@@ -7240,7 +7965,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1972,
+            "line": 1979,
           },
           "name": "values",
           "optional": true,
@@ -7270,7 +7995,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1702,
+        "line": 1709,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
       "properties": Array [
@@ -7286,7 +8011,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1708,
+            "line": 1715,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -7311,7 +8036,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1715,
+            "line": 1722,
           },
           "name": "matchLabels",
           "optional": true,
@@ -7340,7 +8065,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1981,
+        "line": 1988,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -7355,7 +8080,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1987,
+            "line": 1994,
           },
           "name": "key",
           "optional": true,
@@ -7375,7 +8100,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1994,
+            "line": 2001,
           },
           "name": "operator",
           "optional": true,
@@ -7395,7 +8120,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2001,
+            "line": 2008,
           },
           "name": "values",
           "optional": true,
@@ -7424,7 +8149,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1190,
+        "line": 1197,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -7440,7 +8165,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1196,
+            "line": 1203,
           },
           "name": "labelSelector",
           "optional": true,
@@ -7460,7 +8185,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1210,
+            "line": 1217,
           },
           "name": "namespaces",
           "optional": true,
@@ -7485,7 +8210,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1203,
+            "line": 1210,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -7505,7 +8230,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1217,
+            "line": 1224,
           },
           "name": "topologyKey",
           "optional": true,
@@ -7530,7 +8255,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1386,
+        "line": 1393,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "properties": Array [
@@ -7546,7 +8271,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1392,
+            "line": 1399,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -7571,7 +8296,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1399,
+            "line": 1406,
           },
           "name": "matchLabels",
           "optional": true,
@@ -7600,7 +8325,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1724,
+        "line": 1731,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "properties": Array [
@@ -7615,7 +8340,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1730,
+            "line": 1737,
           },
           "name": "key",
           "optional": true,
@@ -7635,7 +8360,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1737,
+            "line": 1744,
           },
           "name": "operator",
           "optional": true,
@@ -7655,7 +8380,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1744,
+            "line": 1751,
           },
           "name": "values",
           "optional": true,
@@ -7685,7 +8410,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1408,
+        "line": 1415,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
       "properties": Array [
@@ -7701,7 +8426,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1414,
+            "line": 1421,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -7726,7 +8451,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1421,
+            "line": 1428,
           },
           "name": "matchLabels",
           "optional": true,
@@ -7755,7 +8480,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1753,
+        "line": 1760,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -7770,7 +8495,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1759,
+            "line": 1766,
           },
           "name": "key",
           "optional": true,
@@ -7790,7 +8515,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1766,
+            "line": 1773,
           },
           "name": "operator",
           "optional": true,
@@ -7810,7 +8535,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1773,
+            "line": 1780,
           },
           "name": "values",
           "optional": true,
@@ -7839,7 +8564,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 612,
+        "line": 619,
       },
       "name": "IoK8SApiCoreV1DaemonSetUpdateStrategy",
       "properties": Array [
@@ -7854,7 +8579,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 618,
+            "line": 625,
           },
           "name": "rollingUpdate",
           "optional": true,
@@ -7877,7 +8602,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 630,
+            "line": 637,
           },
           "name": "type",
           "optional": true,
@@ -7901,7 +8626,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1018,
+        "line": 1025,
       },
       "name": "IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
       "properties": Array [
@@ -7915,7 +8640,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1022,
+            "line": 1029,
           },
           "name": "maxSurge",
           "optional": true,
@@ -7933,7 +8658,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1027,
+            "line": 1034,
           },
           "name": "maxUnavailable",
           "optional": true,
@@ -7960,7 +8685,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1041,
+        "line": 1048,
       },
       "members": Array [
         Object {
@@ -7992,7 +8717,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 650,
+        "line": 657,
       },
       "name": "IoK8SApiCoreV1LocalObjectReference",
       "properties": Array [
@@ -8008,7 +8733,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 656,
+            "line": 663,
           },
           "name": "name",
           "optional": true,
@@ -8032,7 +8757,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 508,
+        "line": 515,
       },
       "name": "IoK8SApiCoreV1ResourceRequirements",
       "properties": Array [
@@ -8048,7 +8773,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 514,
+            "line": 521,
           },
           "name": "limits",
           "optional": true,
@@ -8073,7 +8798,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 521,
+            "line": 528,
           },
           "name": "requests",
           "optional": true,
@@ -8102,7 +8827,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 530,
+        "line": 537,
       },
       "name": "IoK8SApiCoreV1Toleration",
       "properties": Array [
@@ -8123,7 +8848,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 541,
+            "line": 548,
           },
           "name": "effect",
           "optional": true,
@@ -8143,7 +8868,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 548,
+            "line": 555,
           },
           "name": "key",
           "optional": true,
@@ -8168,7 +8893,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 560,
+            "line": 567,
           },
           "name": "operator",
           "optional": true,
@@ -8188,7 +8913,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 567,
+            "line": 574,
           },
           "name": "tolerationSeconds",
           "optional": true,
@@ -8208,7 +8933,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 574,
+            "line": 581,
           },
           "name": "value",
           "optional": true,
@@ -8237,7 +8962,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 921,
+        "line": 928,
       },
       "members": Array [
         Object {
@@ -8280,7 +9005,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 940,
+        "line": 947,
       },
       "members": Array [
         Object {
@@ -8311,7 +9036,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 235,
+        "line": 242,
       },
       "name": "LaceworkAgentCloudservice",
       "properties": Array [
@@ -8325,7 +9050,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 239,
+            "line": 246,
           },
           "name": "gke",
           "optional": true,
@@ -8348,7 +9073,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 637,
+        "line": 644,
       },
       "name": "LaceworkAgentCloudserviceGke",
       "properties": Array [
@@ -8362,7 +9087,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 641,
+            "line": 648,
           },
           "name": "autopilot",
           "optional": true,
@@ -8385,7 +9110,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 319,
+        "line": 326,
       },
       "name": "LaceworkAgentClusterAgent",
       "properties": Array [
@@ -8400,7 +9125,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 330,
+            "line": 337,
           },
           "name": "enable",
           "type": Object {
@@ -8417,7 +9142,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 323,
+            "line": 330,
           },
           "name": "image",
           "type": Object {
@@ -8435,7 +9160,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 365,
+            "line": 372,
           },
           "name": "additionalValues",
           "optional": true,
@@ -8459,7 +9184,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 344,
+            "line": 351,
           },
           "name": "clusterRegion",
           "optional": true,
@@ -8478,7 +9203,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 337,
+            "line": 344,
           },
           "name": "clusterType",
           "optional": true,
@@ -8497,7 +9222,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 351,
+            "line": 358,
           },
           "name": "scrapeInitialDelayMins",
           "optional": true,
@@ -8516,7 +9241,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 358,
+            "line": 365,
           },
           "name": "scrapeIntervalMins",
           "optional": true,
@@ -8539,7 +9264,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 733,
+        "line": 740,
       },
       "members": Array [
         Object {
@@ -8576,7 +9301,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 683,
+        "line": 690,
       },
       "name": "LaceworkAgentClusterAgentImage",
       "properties": Array [
@@ -8598,7 +9323,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 702,
+            "line": 709,
           },
           "name": "pullPolicy",
           "type": Object {
@@ -8615,7 +9340,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 707,
+            "line": 714,
           },
           "name": "registry",
           "type": Object {
@@ -8632,7 +9357,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 712,
+            "line": 719,
           },
           "name": "repository",
           "type": Object {
@@ -8649,7 +9374,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 717,
+            "line": 724,
           },
           "name": "tag",
           "type": Object {
@@ -8667,7 +9392,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 724,
+            "line": 731,
           },
           "name": "additionalValues",
           "optional": true,
@@ -8692,7 +9417,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 689,
+            "line": 696,
           },
           "name": "imagePullSecrets",
           "optional": true,
@@ -8727,7 +9452,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1059,
+        "line": 1066,
       },
       "members": Array [
         Object {
@@ -8764,7 +9489,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 153,
+        "line": 160,
       },
       "name": "LaceworkAgentDaemonset",
       "properties": Array [
@@ -8779,7 +9504,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 159,
+            "line": 166,
           },
           "name": "affinity",
           "type": Object {
@@ -8797,7 +9522,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 166,
+            "line": 173,
           },
           "name": "updateStrategy",
           "type": Object {
@@ -8819,7 +9544,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 246,
+        "line": 253,
       },
       "name": "LaceworkAgentDatacollector",
       "properties": Array [
@@ -8834,7 +9559,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 259,
+            "line": 266,
           },
           "name": "additionalValues",
           "optional": true,
@@ -8858,7 +9583,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 252,
+            "line": 259,
           },
           "name": "enable",
           "optional": true,
@@ -8881,7 +9606,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 173,
+        "line": 180,
       },
       "name": "LaceworkAgentDeployment",
       "properties": Array [
@@ -8896,7 +9621,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 179,
+            "line": 186,
           },
           "name": "affinity",
           "type": Object {
@@ -8914,7 +9639,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 186,
+            "line": 193,
           },
           "name": "updateStrategy",
           "type": Object {
@@ -8932,7 +9657,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 207,
+            "line": 214,
           },
           "name": "priorityClassCreate",
           "optional": true,
@@ -8952,7 +9677,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 200,
+            "line": 207,
           },
           "name": "priorityClassName",
           "optional": true,
@@ -8971,7 +9696,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 214,
+            "line": 221,
           },
           "name": "priorityClassPreemptionPolicy",
           "optional": true,
@@ -8990,7 +9715,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 221,
+            "line": 228,
           },
           "name": "priorityClassValue",
           "optional": true,
@@ -9010,7 +9735,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 193,
+            "line": 200,
           },
           "name": "resources",
           "optional": true,
@@ -9029,7 +9754,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 228,
+            "line": 235,
           },
           "name": "tolerations",
           "optional": true,
@@ -9057,7 +9782,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 266,
+        "line": 273,
       },
       "name": "LaceworkAgentImage",
       "properties": Array [
@@ -9079,7 +9804,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 285,
+            "line": 292,
           },
           "name": "pullPolicy",
           "type": Object {
@@ -9096,7 +9821,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 290,
+            "line": 297,
           },
           "name": "registry",
           "type": Object {
@@ -9113,7 +9838,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 295,
+            "line": 302,
           },
           "name": "repository",
           "type": Object {
@@ -9130,7 +9855,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 300,
+            "line": 307,
           },
           "name": "tag",
           "type": Object {
@@ -9148,7 +9873,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 312,
+            "line": 319,
           },
           "name": "additionalValues",
           "optional": true,
@@ -9173,7 +9898,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 272,
+            "line": 279,
           },
           "name": "imagePullSecrets",
           "optional": true,
@@ -9196,7 +9921,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 305,
+            "line": 312,
           },
           "name": "overrideValue",
           "optional": true,
@@ -9226,7 +9951,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 671,
+        "line": 678,
       },
       "members": Array [
         Object {
@@ -9263,7 +9988,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 372,
+        "line": 379,
       },
       "name": "LaceworkAgentLaceworkConfig",
       "properties": Array [
@@ -9277,7 +10002,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 376,
+            "line": 383,
           },
           "name": "accessToken",
           "type": Object {
@@ -9295,7 +10020,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 499,
+            "line": 506,
           },
           "name": "additionalValues",
           "optional": true,
@@ -9320,7 +10045,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 388,
+            "line": 395,
           },
           "name": "annotations",
           "optional": true,
@@ -9343,7 +10068,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 381,
+            "line": 388,
           },
           "name": "anonymizeIncoming",
           "optional": true,
@@ -9361,7 +10086,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 393,
+            "line": 400,
           },
           "name": "autoUpgrade",
           "optional": true,
@@ -9379,7 +10104,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 398,
+            "line": 405,
           },
           "name": "cmdlinefilter",
           "optional": true,
@@ -9397,7 +10122,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 403,
+            "line": 410,
           },
           "name": "codeaware",
           "optional": true,
@@ -9415,7 +10140,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 408,
+            "line": 415,
           },
           "name": "containerEngineEndpoint",
           "optional": true,
@@ -9433,7 +10158,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 413,
+            "line": 420,
           },
           "name": "containerRuntime",
           "optional": true,
@@ -9451,7 +10176,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 418,
+            "line": 425,
           },
           "name": "datacollector",
           "optional": true,
@@ -9469,7 +10194,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 447,
+            "line": 454,
           },
           "name": "env",
           "optional": true,
@@ -9487,7 +10212,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 452,
+            "line": 459,
           },
           "name": "fim",
           "optional": true,
@@ -9506,7 +10231,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 425,
+            "line": 432,
           },
           "name": "k8SNodeScrapeIntervalMins",
           "optional": true,
@@ -9524,7 +10249,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 430,
+            "line": 437,
           },
           "name": "kubernetesCluster",
           "optional": true,
@@ -9544,7 +10269,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 437,
+            "line": 444,
           },
           "name": "labels",
           "optional": true,
@@ -9567,7 +10292,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 442,
+            "line": 449,
           },
           "name": "metadataRequestInterval",
           "optional": true,
@@ -9585,7 +10310,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 457,
+            "line": 464,
           },
           "name": "packagescan",
           "optional": true,
@@ -9603,7 +10328,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 492,
+            "line": 499,
           },
           "name": "perfmode",
           "optional": true,
@@ -9621,7 +10346,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 462,
+            "line": 469,
           },
           "name": "procscan",
           "optional": true,
@@ -9639,7 +10364,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 467,
+            "line": 474,
           },
           "name": "proxyUrl",
           "optional": true,
@@ -9657,7 +10382,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 472,
+            "line": 479,
           },
           "name": "serverUrl",
           "optional": true,
@@ -9675,7 +10400,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 477,
+            "line": 484,
           },
           "name": "serviceAccountName",
           "optional": true,
@@ -9693,7 +10418,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 482,
+            "line": 489,
           },
           "name": "stdoutLogging",
           "optional": true,
@@ -9711,7 +10436,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 487,
+            "line": 494,
           },
           "name": "tags",
           "optional": true,
@@ -9739,7 +10464,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 745,
+        "line": 752,
       },
       "name": "LaceworkAgentLaceworkConfigAnonymizeIncoming",
       "properties": Array [
@@ -9754,7 +10479,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 756,
+            "line": 763,
           },
           "name": "additionalValues",
           "optional": true,
@@ -9777,7 +10502,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 749,
+            "line": 756,
           },
           "name": "netmask",
           "optional": true,
@@ -9799,7 +10524,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 763,
+        "line": 770,
       },
       "members": Array [
         Object {
@@ -9830,7 +10555,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 773,
+        "line": 780,
       },
       "name": "LaceworkAgentLaceworkConfigCmdlinefilter",
       "properties": Array [
@@ -9844,7 +10569,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 777,
+            "line": 784,
           },
           "name": "allow",
           "optional": true,
@@ -9862,7 +10587,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 782,
+            "line": 789,
           },
           "name": "disallow",
           "optional": true,
@@ -9885,7 +10610,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 789,
+        "line": 796,
       },
       "name": "LaceworkAgentLaceworkConfigCodeaware",
       "properties": Array [
@@ -9899,7 +10624,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 793,
+            "line": 800,
           },
           "name": "enable",
           "optional": true,
@@ -9921,7 +10646,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 800,
+        "line": 807,
       },
       "members": Array [
         Object {
@@ -9957,7 +10682,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 812,
+        "line": 819,
       },
       "members": Array [
         Object {
@@ -9988,7 +10713,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 822,
+        "line": 829,
       },
       "name": "LaceworkAgentLaceworkConfigFim",
       "properties": Array [
@@ -10002,7 +10727,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 836,
+            "line": 843,
           },
           "name": "enable",
           "type": Object {
@@ -10019,7 +10744,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 841,
+            "line": 848,
           },
           "name": "fileIgnore",
           "type": Object {
@@ -10041,7 +10766,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 846,
+            "line": 853,
           },
           "name": "filePath",
           "type": Object {
@@ -10064,7 +10789,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 863,
+            "line": 870,
           },
           "name": "additionalValues",
           "optional": true,
@@ -10087,7 +10812,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 826,
+            "line": 833,
           },
           "name": "coolingPeriod",
           "optional": true,
@@ -10105,7 +10830,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 831,
+            "line": 838,
           },
           "name": "crawlInterval",
           "optional": true,
@@ -10123,7 +10848,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 851,
+            "line": 858,
           },
           "name": "noAtime",
           "optional": true,
@@ -10141,7 +10866,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 856,
+            "line": 863,
           },
           "name": "runAt",
           "optional": true,
@@ -10164,7 +10889,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 870,
+        "line": 877,
       },
       "name": "LaceworkAgentLaceworkConfigPackagescan",
       "properties": Array [
@@ -10178,7 +10903,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 874,
+            "line": 881,
           },
           "name": "enable",
           "optional": true,
@@ -10196,7 +10921,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 879,
+            "line": 886,
           },
           "name": "interval",
           "optional": true,
@@ -10218,7 +10943,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 902,
+        "line": 909,
       },
       "members": Array [
         Object {
@@ -10255,7 +10980,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 886,
+        "line": 893,
       },
       "name": "LaceworkAgentLaceworkConfigProcscan",
       "properties": Array [
@@ -10269,7 +10994,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 890,
+            "line": 897,
           },
           "name": "enable",
           "optional": true,
@@ -10287,7 +11012,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 895,
+            "line": 902,
           },
           "name": "interval",
           "optional": true,
@@ -10431,7 +11156,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 58,
+        "line": 65,
       },
       "name": "LaceworkagentValues",
       "properties": Array [
@@ -10445,7 +11170,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 97,
+            "line": 104,
           },
           "name": "laceworkConfig",
           "type": Object {
@@ -10463,7 +11188,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 146,
+            "line": 153,
           },
           "name": "additionalValues",
           "optional": true,
@@ -10486,7 +11211,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 77,
+            "line": 84,
           },
           "name": "cloudservice",
           "optional": true,
@@ -10504,7 +11229,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 92,
+            "line": 99,
           },
           "name": "clusterAgent",
           "optional": true,
@@ -10522,7 +11247,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 67,
+            "line": 74,
           },
           "name": "daemonset",
           "optional": true,
@@ -10540,7 +11265,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 82,
+            "line": 89,
           },
           "name": "datacollector",
           "optional": true,
@@ -10558,7 +11283,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 72,
+            "line": 79,
           },
           "name": "deployment",
           "optional": true,
@@ -10576,7 +11301,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 62,
+            "line": 69,
           },
           "name": "global",
           "optional": true,
@@ -10599,7 +11324,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 87,
+            "line": 94,
           },
           "name": "image",
           "optional": true,
@@ -10618,7 +11343,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 118,
+            "line": 125,
           },
           "name": "priorityClassCreate",
           "optional": true,
@@ -10638,7 +11363,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 111,
+            "line": 118,
           },
           "name": "priorityClassName",
           "optional": true,
@@ -10657,7 +11382,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 125,
+            "line": 132,
           },
           "name": "priorityClassPreemptionPolicy",
           "optional": true,
@@ -10676,7 +11401,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 132,
+            "line": 139,
           },
           "name": "priorityClassValue",
           "optional": true,
@@ -10696,7 +11421,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 104,
+            "line": 111,
           },
           "name": "resources",
           "optional": true,
@@ -10715,7 +11440,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 139,
+            "line": 146,
           },
           "name": "tolerations",
           "optional": true,
@@ -16833,7 +17558,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 583,
+        "line": 590,
       },
       "name": "IoK8SApiCoreV1Affinity",
       "properties": Array [
@@ -16848,7 +17573,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 589,
+            "line": 596,
           },
           "name": "nodeAffinity",
           "optional": true,
@@ -16867,7 +17592,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 596,
+            "line": 603,
           },
           "name": "podAffinity",
           "optional": true,
@@ -16886,7 +17611,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 603,
+            "line": 610,
           },
           "name": "podAntiAffinity",
           "optional": true,
@@ -16910,7 +17635,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 952,
+        "line": 959,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinity",
       "properties": Array [
@@ -16926,7 +17651,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 958,
+            "line": 965,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -16951,7 +17676,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 965,
+            "line": 972,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -16975,7 +17700,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1073,
+        "line": 1080,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -16991,7 +17716,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1079,
+            "line": 1086,
           },
           "name": "preference",
           "optional": true,
@@ -17010,7 +17735,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1086,
+            "line": 1093,
           },
           "name": "weight",
           "optional": true,
@@ -17035,7 +17760,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1226,
+        "line": 1233,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
       "properties": Array [
@@ -17050,7 +17775,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1232,
+            "line": 1239,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -17074,7 +17799,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1239,
+            "line": 1246,
           },
           "name": "matchFields",
           "optional": true,
@@ -17103,7 +17828,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1430,
+        "line": 1437,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
       "properties": Array [
@@ -17118,7 +17843,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1436,
+            "line": 1443,
           },
           "name": "key",
           "optional": true,
@@ -17144,7 +17869,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1451,
+            "line": 1458,
           },
           "name": "operator",
           "optional": true,
@@ -17164,7 +17889,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1458,
+            "line": 1465,
           },
           "name": "values",
           "optional": true,
@@ -17199,7 +17924,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1790,
+        "line": 1797,
       },
       "members": Array [
         Object {
@@ -17255,7 +17980,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1467,
+        "line": 1474,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
       "properties": Array [
@@ -17270,7 +17995,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1473,
+            "line": 1480,
           },
           "name": "key",
           "optional": true,
@@ -17296,7 +18021,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1488,
+            "line": 1495,
           },
           "name": "operator",
           "optional": true,
@@ -17316,7 +18041,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1495,
+            "line": 1502,
           },
           "name": "values",
           "optional": true,
@@ -17351,7 +18076,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1818,
+        "line": 1825,
       },
       "members": Array [
         Object {
@@ -17408,7 +18133,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1095,
+        "line": 1102,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -17424,7 +18149,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1101,
+            "line": 1108,
           },
           "name": "nodeSelectorTerms",
           "optional": true,
@@ -17454,7 +18179,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1248,
+        "line": 1255,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
       "properties": Array [
@@ -17469,7 +18194,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1254,
+            "line": 1261,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -17493,7 +18218,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1261,
+            "line": 1268,
           },
           "name": "matchFields",
           "optional": true,
@@ -17522,7 +18247,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1504,
+        "line": 1511,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
       "properties": Array [
@@ -17537,7 +18262,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1510,
+            "line": 1517,
           },
           "name": "key",
           "optional": true,
@@ -17563,7 +18288,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1525,
+            "line": 1532,
           },
           "name": "operator",
           "optional": true,
@@ -17583,7 +18308,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1532,
+            "line": 1539,
           },
           "name": "values",
           "optional": true,
@@ -17618,7 +18343,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1846,
+        "line": 1853,
       },
       "members": Array [
         Object {
@@ -17674,7 +18399,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1541,
+        "line": 1548,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
       "properties": Array [
@@ -17689,7 +18414,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1547,
+            "line": 1554,
           },
           "name": "key",
           "optional": true,
@@ -17715,7 +18440,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1562,
+            "line": 1569,
           },
           "name": "operator",
           "optional": true,
@@ -17735,7 +18460,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1569,
+            "line": 1576,
           },
           "name": "values",
           "optional": true,
@@ -17770,7 +18495,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1874,
+        "line": 1881,
       },
       "members": Array [
         Object {
@@ -17826,7 +18551,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 974,
+        "line": 981,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinity",
       "properties": Array [
@@ -17842,7 +18567,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 980,
+            "line": 987,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -17867,7 +18592,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 987,
+            "line": 994,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -17896,7 +18621,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1110,
+        "line": 1117,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -17911,7 +18636,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1116,
+            "line": 1123,
           },
           "name": "podAffinityTerm",
           "optional": true,
@@ -17930,7 +18655,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1123,
+            "line": 1130,
           },
           "name": "weight",
           "optional": true,
@@ -17954,7 +18679,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1270,
+        "line": 1277,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "properties": Array [
@@ -17970,7 +18695,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1297,
+            "line": 1304,
           },
           "name": "topologyKey",
           "type": Object {
@@ -17989,7 +18714,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1276,
+            "line": 1283,
           },
           "name": "labelSelector",
           "optional": true,
@@ -18009,7 +18734,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1290,
+            "line": 1297,
           },
           "name": "namespaces",
           "optional": true,
@@ -18034,7 +18759,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1283,
+            "line": 1290,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -18059,7 +18784,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1578,
+        "line": 1585,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "properties": Array [
@@ -18075,7 +18800,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1584,
+            "line": 1591,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -18100,7 +18825,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1591,
+            "line": 1598,
           },
           "name": "matchLabels",
           "optional": true,
@@ -18129,7 +18854,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1894,
+        "line": 1901,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "properties": Array [
@@ -18144,7 +18869,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1900,
+            "line": 1907,
           },
           "name": "key",
           "optional": true,
@@ -18164,7 +18889,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1907,
+            "line": 1914,
           },
           "name": "operator",
           "optional": true,
@@ -18184,7 +18909,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1914,
+            "line": 1921,
           },
           "name": "values",
           "optional": true,
@@ -18214,7 +18939,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1600,
+        "line": 1607,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
       "properties": Array [
@@ -18230,7 +18955,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1606,
+            "line": 1613,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -18255,7 +18980,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1613,
+            "line": 1620,
           },
           "name": "matchLabels",
           "optional": true,
@@ -18284,7 +19009,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1923,
+        "line": 1930,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -18299,7 +19024,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1929,
+            "line": 1936,
           },
           "name": "key",
           "optional": true,
@@ -18319,7 +19044,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1936,
+            "line": 1943,
           },
           "name": "operator",
           "optional": true,
@@ -18339,7 +19064,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1943,
+            "line": 1950,
           },
           "name": "values",
           "optional": true,
@@ -18368,7 +19093,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1132,
+        "line": 1139,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -18384,7 +19109,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1138,
+            "line": 1145,
           },
           "name": "labelSelector",
           "optional": true,
@@ -18404,7 +19129,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1152,
+            "line": 1159,
           },
           "name": "namespaces",
           "optional": true,
@@ -18429,7 +19154,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1145,
+            "line": 1152,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -18449,7 +19174,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1159,
+            "line": 1166,
           },
           "name": "topologyKey",
           "optional": true,
@@ -18474,7 +19199,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1306,
+        "line": 1313,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "properties": Array [
@@ -18490,7 +19215,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1312,
+            "line": 1319,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -18515,7 +19240,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1319,
+            "line": 1326,
           },
           "name": "matchLabels",
           "optional": true,
@@ -18544,7 +19269,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1622,
+        "line": 1629,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "properties": Array [
@@ -18559,7 +19284,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1628,
+            "line": 1635,
           },
           "name": "key",
           "optional": true,
@@ -18579,7 +19304,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1635,
+            "line": 1642,
           },
           "name": "operator",
           "optional": true,
@@ -18599,7 +19324,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1642,
+            "line": 1649,
           },
           "name": "values",
           "optional": true,
@@ -18629,7 +19354,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1328,
+        "line": 1335,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
       "properties": Array [
@@ -18645,7 +19370,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1334,
+            "line": 1341,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -18670,7 +19395,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1341,
+            "line": 1348,
           },
           "name": "matchLabels",
           "optional": true,
@@ -18699,7 +19424,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1651,
+        "line": 1658,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -18714,7 +19439,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1657,
+            "line": 1664,
           },
           "name": "key",
           "optional": true,
@@ -18734,7 +19459,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1664,
+            "line": 1671,
           },
           "name": "operator",
           "optional": true,
@@ -18754,7 +19479,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1671,
+            "line": 1678,
           },
           "name": "values",
           "optional": true,
@@ -18783,7 +19508,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 996,
+        "line": 1003,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinity",
       "properties": Array [
@@ -18799,7 +19524,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1002,
+            "line": 1009,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -18824,7 +19549,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1009,
+            "line": 1016,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -18853,7 +19578,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1168,
+        "line": 1175,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -18868,7 +19593,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1174,
+            "line": 1181,
           },
           "name": "podAffinityTerm",
           "optional": true,
@@ -18887,7 +19612,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1181,
+            "line": 1188,
           },
           "name": "weight",
           "optional": true,
@@ -18911,7 +19636,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1350,
+        "line": 1357,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "properties": Array [
@@ -18927,7 +19652,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1377,
+            "line": 1384,
           },
           "name": "topologyKey",
           "type": Object {
@@ -18946,7 +19671,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1356,
+            "line": 1363,
           },
           "name": "labelSelector",
           "optional": true,
@@ -18966,7 +19691,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1370,
+            "line": 1377,
           },
           "name": "namespaces",
           "optional": true,
@@ -18991,7 +19716,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1363,
+            "line": 1370,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -19016,7 +19741,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1680,
+        "line": 1687,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "properties": Array [
@@ -19032,7 +19757,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1686,
+            "line": 1693,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -19057,7 +19782,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1693,
+            "line": 1700,
           },
           "name": "matchLabels",
           "optional": true,
@@ -19086,7 +19811,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1952,
+        "line": 1959,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "properties": Array [
@@ -19101,7 +19826,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1958,
+            "line": 1965,
           },
           "name": "key",
           "optional": true,
@@ -19121,7 +19846,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1965,
+            "line": 1972,
           },
           "name": "operator",
           "optional": true,
@@ -19141,7 +19866,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1972,
+            "line": 1979,
           },
           "name": "values",
           "optional": true,
@@ -19171,7 +19896,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1702,
+        "line": 1709,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
       "properties": Array [
@@ -19187,7 +19912,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1708,
+            "line": 1715,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -19212,7 +19937,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1715,
+            "line": 1722,
           },
           "name": "matchLabels",
           "optional": true,
@@ -19241,7 +19966,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1981,
+        "line": 1988,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -19256,7 +19981,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1987,
+            "line": 1994,
           },
           "name": "key",
           "optional": true,
@@ -19276,7 +20001,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1994,
+            "line": 2001,
           },
           "name": "operator",
           "optional": true,
@@ -19296,7 +20021,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2001,
+            "line": 2008,
           },
           "name": "values",
           "optional": true,
@@ -19325,7 +20050,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1190,
+        "line": 1197,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -19341,7 +20066,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1196,
+            "line": 1203,
           },
           "name": "labelSelector",
           "optional": true,
@@ -19361,7 +20086,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1210,
+            "line": 1217,
           },
           "name": "namespaces",
           "optional": true,
@@ -19386,7 +20111,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1203,
+            "line": 1210,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -19406,7 +20131,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1217,
+            "line": 1224,
           },
           "name": "topologyKey",
           "optional": true,
@@ -19431,7 +20156,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1386,
+        "line": 1393,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "properties": Array [
@@ -19447,7 +20172,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1392,
+            "line": 1399,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -19472,7 +20197,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1399,
+            "line": 1406,
           },
           "name": "matchLabels",
           "optional": true,
@@ -19501,7 +20226,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1724,
+        "line": 1731,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "properties": Array [
@@ -19516,7 +20241,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1730,
+            "line": 1737,
           },
           "name": "key",
           "optional": true,
@@ -19536,7 +20261,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1737,
+            "line": 1744,
           },
           "name": "operator",
           "optional": true,
@@ -19556,7 +20281,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1744,
+            "line": 1751,
           },
           "name": "values",
           "optional": true,
@@ -19586,7 +20311,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1408,
+        "line": 1415,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
       "properties": Array [
@@ -19602,7 +20327,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1414,
+            "line": 1421,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -19627,7 +20352,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1421,
+            "line": 1428,
           },
           "name": "matchLabels",
           "optional": true,
@@ -19656,7 +20381,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1753,
+        "line": 1760,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -19671,7 +20396,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1759,
+            "line": 1766,
           },
           "name": "key",
           "optional": true,
@@ -19691,7 +20416,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1766,
+            "line": 1773,
           },
           "name": "operator",
           "optional": true,
@@ -19711,7 +20436,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1773,
+            "line": 1780,
           },
           "name": "values",
           "optional": true,
@@ -19740,7 +20465,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 612,
+        "line": 619,
       },
       "name": "IoK8SApiCoreV1DaemonSetUpdateStrategy",
       "properties": Array [
@@ -19755,7 +20480,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 618,
+            "line": 625,
           },
           "name": "rollingUpdate",
           "optional": true,
@@ -19778,7 +20503,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 630,
+            "line": 637,
           },
           "name": "type",
           "optional": true,
@@ -19802,7 +20527,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1018,
+        "line": 1025,
       },
       "name": "IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
       "properties": Array [
@@ -19816,7 +20541,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1022,
+            "line": 1029,
           },
           "name": "maxSurge",
           "optional": true,
@@ -19834,7 +20559,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1027,
+            "line": 1034,
           },
           "name": "maxUnavailable",
           "optional": true,
@@ -19861,7 +20586,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1041,
+        "line": 1048,
       },
       "members": Array [
         Object {
@@ -19893,7 +20618,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 650,
+        "line": 657,
       },
       "name": "IoK8SApiCoreV1LocalObjectReference",
       "properties": Array [
@@ -19909,7 +20634,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 656,
+            "line": 663,
           },
           "name": "name",
           "optional": true,
@@ -19933,7 +20658,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 508,
+        "line": 515,
       },
       "name": "IoK8SApiCoreV1ResourceRequirements",
       "properties": Array [
@@ -19949,7 +20674,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 514,
+            "line": 521,
           },
           "name": "limits",
           "optional": true,
@@ -19974,7 +20699,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 521,
+            "line": 528,
           },
           "name": "requests",
           "optional": true,
@@ -20003,7 +20728,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 530,
+        "line": 537,
       },
       "name": "IoK8SApiCoreV1Toleration",
       "properties": Array [
@@ -20024,7 +20749,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 541,
+            "line": 548,
           },
           "name": "effect",
           "optional": true,
@@ -20044,7 +20769,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 548,
+            "line": 555,
           },
           "name": "key",
           "optional": true,
@@ -20069,7 +20794,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 560,
+            "line": 567,
           },
           "name": "operator",
           "optional": true,
@@ -20089,7 +20814,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 567,
+            "line": 574,
           },
           "name": "tolerationSeconds",
           "optional": true,
@@ -20109,7 +20834,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 574,
+            "line": 581,
           },
           "name": "value",
           "optional": true,
@@ -20138,7 +20863,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 921,
+        "line": 928,
       },
       "members": Array [
         Object {
@@ -20181,7 +20906,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 940,
+        "line": 947,
       },
       "members": Array [
         Object {
@@ -20212,7 +20937,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 235,
+        "line": 242,
       },
       "name": "LaceworkAgentCloudservice",
       "properties": Array [
@@ -20226,7 +20951,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 239,
+            "line": 246,
           },
           "name": "gke",
           "optional": true,
@@ -20249,7 +20974,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 637,
+        "line": 644,
       },
       "name": "LaceworkAgentCloudserviceGke",
       "properties": Array [
@@ -20263,7 +20988,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 641,
+            "line": 648,
           },
           "name": "autopilot",
           "optional": true,
@@ -20286,7 +21011,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 319,
+        "line": 326,
       },
       "name": "LaceworkAgentClusterAgent",
       "properties": Array [
@@ -20301,7 +21026,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 330,
+            "line": 337,
           },
           "name": "enable",
           "type": Object {
@@ -20318,7 +21043,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 323,
+            "line": 330,
           },
           "name": "image",
           "type": Object {
@@ -20336,7 +21061,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 365,
+            "line": 372,
           },
           "name": "additionalValues",
           "optional": true,
@@ -20360,7 +21085,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 344,
+            "line": 351,
           },
           "name": "clusterRegion",
           "optional": true,
@@ -20379,7 +21104,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 337,
+            "line": 344,
           },
           "name": "clusterType",
           "optional": true,
@@ -20398,7 +21123,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 351,
+            "line": 358,
           },
           "name": "scrapeInitialDelayMins",
           "optional": true,
@@ -20417,7 +21142,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 358,
+            "line": 365,
           },
           "name": "scrapeIntervalMins",
           "optional": true,
@@ -20440,7 +21165,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 733,
+        "line": 740,
       },
       "members": Array [
         Object {
@@ -20477,7 +21202,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 683,
+        "line": 690,
       },
       "name": "LaceworkAgentClusterAgentImage",
       "properties": Array [
@@ -20499,7 +21224,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 702,
+            "line": 709,
           },
           "name": "pullPolicy",
           "type": Object {
@@ -20516,7 +21241,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 707,
+            "line": 714,
           },
           "name": "registry",
           "type": Object {
@@ -20533,7 +21258,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 712,
+            "line": 719,
           },
           "name": "repository",
           "type": Object {
@@ -20550,7 +21275,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 717,
+            "line": 724,
           },
           "name": "tag",
           "type": Object {
@@ -20568,7 +21293,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 724,
+            "line": 731,
           },
           "name": "additionalValues",
           "optional": true,
@@ -20593,7 +21318,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 689,
+            "line": 696,
           },
           "name": "imagePullSecrets",
           "optional": true,
@@ -20628,7 +21353,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1059,
+        "line": 1066,
       },
       "members": Array [
         Object {
@@ -20665,7 +21390,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 153,
+        "line": 160,
       },
       "name": "LaceworkAgentDaemonset",
       "properties": Array [
@@ -20680,7 +21405,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 159,
+            "line": 166,
           },
           "name": "affinity",
           "type": Object {
@@ -20698,7 +21423,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 166,
+            "line": 173,
           },
           "name": "updateStrategy",
           "type": Object {
@@ -20720,7 +21445,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 246,
+        "line": 253,
       },
       "name": "LaceworkAgentDatacollector",
       "properties": Array [
@@ -20735,7 +21460,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 259,
+            "line": 266,
           },
           "name": "additionalValues",
           "optional": true,
@@ -20759,7 +21484,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 252,
+            "line": 259,
           },
           "name": "enable",
           "optional": true,
@@ -20782,7 +21507,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 173,
+        "line": 180,
       },
       "name": "LaceworkAgentDeployment",
       "properties": Array [
@@ -20797,7 +21522,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 179,
+            "line": 186,
           },
           "name": "affinity",
           "type": Object {
@@ -20815,7 +21540,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 186,
+            "line": 193,
           },
           "name": "updateStrategy",
           "type": Object {
@@ -20833,7 +21558,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 207,
+            "line": 214,
           },
           "name": "priorityClassCreate",
           "optional": true,
@@ -20853,7 +21578,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 200,
+            "line": 207,
           },
           "name": "priorityClassName",
           "optional": true,
@@ -20872,7 +21597,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 214,
+            "line": 221,
           },
           "name": "priorityClassPreemptionPolicy",
           "optional": true,
@@ -20891,7 +21616,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 221,
+            "line": 228,
           },
           "name": "priorityClassValue",
           "optional": true,
@@ -20911,7 +21636,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 193,
+            "line": 200,
           },
           "name": "resources",
           "optional": true,
@@ -20930,7 +21655,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 228,
+            "line": 235,
           },
           "name": "tolerations",
           "optional": true,
@@ -20958,7 +21683,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 266,
+        "line": 273,
       },
       "name": "LaceworkAgentImage",
       "properties": Array [
@@ -20980,7 +21705,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 285,
+            "line": 292,
           },
           "name": "pullPolicy",
           "type": Object {
@@ -20997,7 +21722,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 290,
+            "line": 297,
           },
           "name": "registry",
           "type": Object {
@@ -21014,7 +21739,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 295,
+            "line": 302,
           },
           "name": "repository",
           "type": Object {
@@ -21031,7 +21756,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 300,
+            "line": 307,
           },
           "name": "tag",
           "type": Object {
@@ -21049,7 +21774,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 312,
+            "line": 319,
           },
           "name": "additionalValues",
           "optional": true,
@@ -21074,7 +21799,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 272,
+            "line": 279,
           },
           "name": "imagePullSecrets",
           "optional": true,
@@ -21097,7 +21822,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 305,
+            "line": 312,
           },
           "name": "overrideValue",
           "optional": true,
@@ -21127,7 +21852,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 671,
+        "line": 678,
       },
       "members": Array [
         Object {
@@ -21164,7 +21889,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 372,
+        "line": 379,
       },
       "name": "LaceworkAgentLaceworkConfig",
       "properties": Array [
@@ -21178,7 +21903,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 376,
+            "line": 383,
           },
           "name": "accessToken",
           "type": Object {
@@ -21196,7 +21921,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 499,
+            "line": 506,
           },
           "name": "additionalValues",
           "optional": true,
@@ -21221,7 +21946,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 388,
+            "line": 395,
           },
           "name": "annotations",
           "optional": true,
@@ -21244,7 +21969,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 381,
+            "line": 388,
           },
           "name": "anonymizeIncoming",
           "optional": true,
@@ -21262,7 +21987,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 393,
+            "line": 400,
           },
           "name": "autoUpgrade",
           "optional": true,
@@ -21280,7 +22005,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 398,
+            "line": 405,
           },
           "name": "cmdlinefilter",
           "optional": true,
@@ -21298,7 +22023,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 403,
+            "line": 410,
           },
           "name": "codeaware",
           "optional": true,
@@ -21316,7 +22041,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 408,
+            "line": 415,
           },
           "name": "containerEngineEndpoint",
           "optional": true,
@@ -21334,7 +22059,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 413,
+            "line": 420,
           },
           "name": "containerRuntime",
           "optional": true,
@@ -21352,7 +22077,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 418,
+            "line": 425,
           },
           "name": "datacollector",
           "optional": true,
@@ -21370,7 +22095,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 447,
+            "line": 454,
           },
           "name": "env",
           "optional": true,
@@ -21388,7 +22113,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 452,
+            "line": 459,
           },
           "name": "fim",
           "optional": true,
@@ -21407,7 +22132,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 425,
+            "line": 432,
           },
           "name": "k8SNodeScrapeIntervalMins",
           "optional": true,
@@ -21425,7 +22150,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 430,
+            "line": 437,
           },
           "name": "kubernetesCluster",
           "optional": true,
@@ -21445,7 +22170,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 437,
+            "line": 444,
           },
           "name": "labels",
           "optional": true,
@@ -21468,7 +22193,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 442,
+            "line": 449,
           },
           "name": "metadataRequestInterval",
           "optional": true,
@@ -21486,7 +22211,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 457,
+            "line": 464,
           },
           "name": "packagescan",
           "optional": true,
@@ -21504,7 +22229,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 492,
+            "line": 499,
           },
           "name": "perfmode",
           "optional": true,
@@ -21522,7 +22247,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 462,
+            "line": 469,
           },
           "name": "procscan",
           "optional": true,
@@ -21540,7 +22265,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 467,
+            "line": 474,
           },
           "name": "proxyUrl",
           "optional": true,
@@ -21558,7 +22283,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 472,
+            "line": 479,
           },
           "name": "serverUrl",
           "optional": true,
@@ -21576,7 +22301,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 477,
+            "line": 484,
           },
           "name": "serviceAccountName",
           "optional": true,
@@ -21594,7 +22319,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 482,
+            "line": 489,
           },
           "name": "stdoutLogging",
           "optional": true,
@@ -21612,7 +22337,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 487,
+            "line": 494,
           },
           "name": "tags",
           "optional": true,
@@ -21640,7 +22365,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 745,
+        "line": 752,
       },
       "name": "LaceworkAgentLaceworkConfigAnonymizeIncoming",
       "properties": Array [
@@ -21655,7 +22380,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 756,
+            "line": 763,
           },
           "name": "additionalValues",
           "optional": true,
@@ -21678,7 +22403,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 749,
+            "line": 756,
           },
           "name": "netmask",
           "optional": true,
@@ -21700,7 +22425,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 763,
+        "line": 770,
       },
       "members": Array [
         Object {
@@ -21731,7 +22456,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 773,
+        "line": 780,
       },
       "name": "LaceworkAgentLaceworkConfigCmdlinefilter",
       "properties": Array [
@@ -21745,7 +22470,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 777,
+            "line": 784,
           },
           "name": "allow",
           "optional": true,
@@ -21763,7 +22488,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 782,
+            "line": 789,
           },
           "name": "disallow",
           "optional": true,
@@ -21786,7 +22511,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 789,
+        "line": 796,
       },
       "name": "LaceworkAgentLaceworkConfigCodeaware",
       "properties": Array [
@@ -21800,7 +22525,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 793,
+            "line": 800,
           },
           "name": "enable",
           "optional": true,
@@ -21822,7 +22547,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 800,
+        "line": 807,
       },
       "members": Array [
         Object {
@@ -21858,7 +22583,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 812,
+        "line": 819,
       },
       "members": Array [
         Object {
@@ -21889,7 +22614,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 822,
+        "line": 829,
       },
       "name": "LaceworkAgentLaceworkConfigFim",
       "properties": Array [
@@ -21903,7 +22628,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 836,
+            "line": 843,
           },
           "name": "enable",
           "type": Object {
@@ -21920,7 +22645,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 841,
+            "line": 848,
           },
           "name": "fileIgnore",
           "type": Object {
@@ -21942,7 +22667,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 846,
+            "line": 853,
           },
           "name": "filePath",
           "type": Object {
@@ -21965,7 +22690,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 863,
+            "line": 870,
           },
           "name": "additionalValues",
           "optional": true,
@@ -21988,7 +22713,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 826,
+            "line": 833,
           },
           "name": "coolingPeriod",
           "optional": true,
@@ -22006,7 +22731,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 831,
+            "line": 838,
           },
           "name": "crawlInterval",
           "optional": true,
@@ -22024,7 +22749,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 851,
+            "line": 858,
           },
           "name": "noAtime",
           "optional": true,
@@ -22042,7 +22767,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 856,
+            "line": 863,
           },
           "name": "runAt",
           "optional": true,
@@ -22065,7 +22790,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 870,
+        "line": 877,
       },
       "name": "LaceworkAgentLaceworkConfigPackagescan",
       "properties": Array [
@@ -22079,7 +22804,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 874,
+            "line": 881,
           },
           "name": "enable",
           "optional": true,
@@ -22097,7 +22822,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 879,
+            "line": 886,
           },
           "name": "interval",
           "optional": true,
@@ -22119,7 +22844,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 902,
+        "line": 909,
       },
       "members": Array [
         Object {
@@ -22156,7 +22881,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 886,
+        "line": 893,
       },
       "name": "LaceworkAgentLaceworkConfigProcscan",
       "properties": Array [
@@ -22170,7 +22895,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 890,
+            "line": 897,
           },
           "name": "enable",
           "optional": true,
@@ -22188,7 +22913,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 895,
+            "line": 902,
           },
           "name": "interval",
           "optional": true,
@@ -22332,7 +23057,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 58,
+        "line": 65,
       },
       "name": "LaceworkagentValues",
       "properties": Array [
@@ -22346,7 +23071,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 97,
+            "line": 104,
           },
           "name": "laceworkConfig",
           "type": Object {
@@ -22364,7 +23089,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 146,
+            "line": 153,
           },
           "name": "additionalValues",
           "optional": true,
@@ -22387,7 +23112,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 77,
+            "line": 84,
           },
           "name": "cloudservice",
           "optional": true,
@@ -22405,7 +23130,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 92,
+            "line": 99,
           },
           "name": "clusterAgent",
           "optional": true,
@@ -22423,7 +23148,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 67,
+            "line": 74,
           },
           "name": "daemonset",
           "optional": true,
@@ -22441,7 +23166,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 82,
+            "line": 89,
           },
           "name": "datacollector",
           "optional": true,
@@ -22459,7 +23184,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 72,
+            "line": 79,
           },
           "name": "deployment",
           "optional": true,
@@ -22477,7 +23202,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 62,
+            "line": 69,
           },
           "name": "global",
           "optional": true,
@@ -22500,7 +23225,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 87,
+            "line": 94,
           },
           "name": "image",
           "optional": true,
@@ -22519,7 +23244,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 118,
+            "line": 125,
           },
           "name": "priorityClassCreate",
           "optional": true,
@@ -22539,7 +23264,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 111,
+            "line": 118,
           },
           "name": "priorityClassName",
           "optional": true,
@@ -22558,7 +23283,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 125,
+            "line": 132,
           },
           "name": "priorityClassPreemptionPolicy",
           "optional": true,
@@ -22577,7 +23302,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 132,
+            "line": 139,
           },
           "name": "priorityClassValue",
           "optional": true,
@@ -22597,7 +23322,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 104,
+            "line": 111,
           },
           "name": "resources",
           "optional": true,
@@ -22616,7 +23341,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 139,
+            "line": 146,
           },
           "name": "tolerations",
           "optional": true,
@@ -22674,243 +23399,636 @@ export class Laceworkagent extends Construct {
       ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
     };
 
-    new Helm(scope, 'Helm', finalProps)
+    new Helm(scope, \`Helm\${id}\`, finalProps)
   }
 
   private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
     for (let prop in props) {
-      if (typeof(props[prop]) === 'object' && prop !== 'additionalValues') {
-        props[prop] = this.flattenAdditionalValues(props[prop]);
+      if (Array.isArray(props[prop])) {
+        props[prop].map((item: any) => {
+          if (typeof(item) === 'object' && prop !== 'additionalValues') {
+            return this.flattenAdditionalValues(item);
+          }
+          return item;
+        });
+        } else if (typeof(props[prop]) === 'object' && prop !== 'additionalValues') {
+          props[prop] = this.flattenAdditionalValues(props[prop]);
+        }
       }
+
+      const { additionalValues, ...valuesWithoutAdditionalValues } = props;
+
+      return {
+        ...valuesWithoutAdditionalValues,
+        ...additionalValues,
+      };
     }
-
-    const { additionalValues, ...valuesWithoutAdditionalValues } = props;
-
-    return {
-      ...valuesWithoutAdditionalValues,
-      ...additionalValues,
-    };
   }
-}
 
-/**
- * @schema lacework-agent
- */
-export interface LaceworkagentValues {
   /**
-   * @schema lacework-agent#global
+   * @schema lacework-agent
    */
-  readonly global?: { [key: string]: any };
+  export interface LaceworkagentValues {
+    /**
+     * @schema lacework-agent#global
+     */
+    readonly global?: { [key: string]: any };
+
+    /**
+     * @schema lacework-agent#daemonset
+     */
+    readonly daemonset?: LaceworkAgentDaemonset;
+
+    /**
+     * @schema lacework-agent#deployment
+     */
+    readonly deployment?: LaceworkAgentDeployment;
+
+    /**
+     * @schema lacework-agent#cloudservice
+     */
+    readonly cloudservice?: LaceworkAgentCloudservice;
+
+    /**
+     * @schema lacework-agent#datacollector
+     */
+    readonly datacollector?: LaceworkAgentDatacollector;
+
+    /**
+     * @schema lacework-agent#image
+     */
+    readonly image?: LaceworkAgentImage;
+
+    /**
+     * @schema lacework-agent#clusterAgent
+     */
+    readonly clusterAgent?: LaceworkAgentClusterAgent;
+
+    /**
+     * @schema lacework-agent#laceworkConfig
+     */
+    readonly laceworkConfig: LaceworkAgentLaceworkConfig;
+
+    /**
+     * Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+     *
+     * @schema lacework-agent#resources
+     */
+    readonly resources?: IoK8SApiCoreV1ResourceRequirements;
+
+    /**
+     * If specified, indicates the pod's priority. \\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+     *
+     * @schema lacework-agent#priorityClassName
+     */
+    readonly priorityClassName?: string;
+
+    /**
+     * If specified, a priority class is created and used to deploy agent
+     *
+     * @schema lacework-agent#priorityClassCreate
+     */
+    readonly priorityClassCreate?: boolean;
+
+    /**
+     * If specified, it determines if agent pod can preempt a pod with a lower a priority
+     *
+     * @schema lacework-agent#priorityClassPreemptionPolicy
+     */
+    readonly priorityClassPreemptionPolicy?: string;
+
+    /**
+     * If specified, it represents the priority class value to use
+     *
+     * @schema lacework-agent#priorityClassValue
+     */
+    readonly priorityClassValue?: number;
+
+    /**
+     * If specified, the pod's tolerations.
+     *
+     * @schema lacework-agent#tolerations
+     */
+    readonly tolerations?: IoK8SApiCoreV1Toleration[];
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema lacework-agent#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
 
   /**
-   * @schema lacework-agent#daemonset
+   * @schema LaceworkAgentDaemonset
    */
-  readonly daemonset?: LaceworkAgentDaemonset;
+  export interface LaceworkAgentDaemonset {
+    /**
+     * If specified, the pod's scheduling constraints
+     *
+     * @schema LaceworkAgentDaemonset#affinity
+     */
+    readonly affinity: IoK8SApiCoreV1Affinity;
+
+    /**
+     * An update strategy to replace existing DaemonSet pods with new pods.
+     *
+     * @schema LaceworkAgentDaemonset#updateStrategy
+     */
+    readonly updateStrategy: IoK8SApiCoreV1DaemonSetUpdateStrategy;
+
+  }
 
   /**
-   * @schema lacework-agent#deployment
+   * @schema LaceworkAgentDeployment
    */
-  readonly deployment?: LaceworkAgentDeployment;
+  export interface LaceworkAgentDeployment {
+    /**
+     * If specified, the pod's scheduling constraints
+     *
+     * @schema LaceworkAgentDeployment#affinity
+     */
+    readonly affinity: IoK8SApiCoreV1Affinity;
+
+    /**
+     * An update strategy to replace existing DaemonSet pods with new pods.
+     *
+     * @schema LaceworkAgentDeployment#updateStrategy
+     */
+    readonly updateStrategy: IoK8SApiCoreV1DaemonSetUpdateStrategy;
+
+    /**
+     * Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+     *
+     * @schema LaceworkAgentDeployment#resources
+     */
+    readonly resources?: IoK8SApiCoreV1ResourceRequirements;
+
+    /**
+     * If specified, indicates the pod's priority. \\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+     *
+     * @schema LaceworkAgentDeployment#priorityClassName
+     */
+    readonly priorityClassName?: string;
+
+    /**
+     * If specified, a priority class is created and used to deploy agent
+     *
+     * @schema LaceworkAgentDeployment#priorityClassCreate
+     */
+    readonly priorityClassCreate?: boolean;
+
+    /**
+     * If specified, it determines if agent pod can preempt a pod with a lower a priority
+     *
+     * @schema LaceworkAgentDeployment#priorityClassPreemptionPolicy
+     */
+    readonly priorityClassPreemptionPolicy?: string;
+
+    /**
+     * If specified, it represents the priority class value to use
+     *
+     * @schema LaceworkAgentDeployment#priorityClassValue
+     */
+    readonly priorityClassValue?: number;
+
+    /**
+     * If specified, the pod's tolerations.
+     *
+     * @schema LaceworkAgentDeployment#tolerations
+     */
+    readonly tolerations?: IoK8SApiCoreV1Toleration[];
+
+  }
 
   /**
-   * @schema lacework-agent#cloudservice
+   * @schema LaceworkAgentCloudservice
    */
-  readonly cloudservice?: LaceworkAgentCloudservice;
+  export interface LaceworkAgentCloudservice {
+    /**
+     * @schema LaceworkAgentCloudservice#gke
+     */
+    readonly gke?: LaceworkAgentCloudserviceGke;
+
+  }
 
   /**
-   * @schema lacework-agent#datacollector
+   * @schema LaceworkAgentDatacollector
    */
-  readonly datacollector?: LaceworkAgentDatacollector;
+  export interface LaceworkAgentDatacollector {
+    /**
+     * Enable lacework datacollector
+     *
+     * @schema LaceworkAgentDatacollector#enable
+     */
+    readonly enable?: boolean;
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema LaceworkAgentDatacollector#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
 
   /**
-   * @schema lacework-agent#image
+   * @schema LaceworkAgentImage
    */
-  readonly image?: LaceworkAgentImage;
+  export interface LaceworkAgentImage {
+    /**
+     * ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+     *
+     * @schema LaceworkAgentImage#imagePullSecrets
+     */
+    readonly imagePullSecrets?: IoK8SApiCoreV1LocalObjectReference[];
+
+    /**
+     * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+     *
+     * Possible enum values:
+     * - \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+     * - \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+     * - \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+     *
+     * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+     * @schema LaceworkAgentImage#pullPolicy
+     */
+    readonly pullPolicy: LaceworkAgentImagePullPolicy;
+
+    /**
+     * @schema LaceworkAgentImage#registry
+     */
+    readonly registry: string;
+
+    /**
+     * @schema LaceworkAgentImage#repository
+     */
+    readonly repository: string;
+
+    /**
+     * @schema LaceworkAgentImage#tag
+     */
+    readonly tag: string;
+
+    /**
+     * @schema LaceworkAgentImage#overrideValue
+     */
+    readonly overrideValue?: string;
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema LaceworkAgentImage#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
 
   /**
-   * @schema lacework-agent#clusterAgent
+   * @schema LaceworkAgentClusterAgent
    */
-  readonly clusterAgent?: LaceworkAgentClusterAgent;
+  export interface LaceworkAgentClusterAgent {
+    /**
+     * @schema LaceworkAgentClusterAgent#image
+     */
+    readonly image: LaceworkAgentClusterAgentImage;
+
+    /**
+     * Enable cluster agent
+     *
+     * @schema LaceworkAgentClusterAgent#enable
+     */
+    readonly enable: boolean;
+
+    /**
+     * Kubernetes cluster type
+     *
+     * @schema LaceworkAgentClusterAgent#clusterType
+     */
+    readonly clusterType?: LaceworkAgentClusterAgentClusterType;
+
+    /**
+     * Kubernetes cluster cloud region
+     *
+     * @schema LaceworkAgentClusterAgent#clusterRegion
+     */
+    readonly clusterRegion?: string;
+
+    /**
+     * Cluster mode agent's initial delay of cluster scraping after startup in minutes
+     *
+     * @schema LaceworkAgentClusterAgent#scrapeInitialDelayMins
+     */
+    readonly scrapeInitialDelayMins?: number;
+
+    /**
+     * Cluster mode agent's scrape interval in minutes
+     *
+     * @schema LaceworkAgentClusterAgent#scrapeIntervalMins
+     */
+    readonly scrapeIntervalMins?: number;
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema LaceworkAgentClusterAgent#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
 
   /**
-   * @schema lacework-agent#laceworkConfig
+   * @schema LaceworkAgentLaceworkConfig
    */
-  readonly laceworkConfig: LaceworkAgentLaceworkConfig;
+  export interface LaceworkAgentLaceworkConfig {
+    /**
+     * @schema LaceworkAgentLaceworkConfig#accessToken
+     */
+    readonly accessToken: any;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#anonymizeIncoming
+     */
+    readonly anonymizeIncoming?: LaceworkAgentLaceworkConfigAnonymizeIncoming;
+
+    /**
+     * Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations
+     *
+     * @schema LaceworkAgentLaceworkConfig#annotations
+     */
+    readonly annotations?: { [key: string]: string };
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#autoUpgrade
+     */
+    readonly autoUpgrade?: LaceworkAgentLaceworkConfigAutoUpgrade;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#cmdlinefilter
+     */
+    readonly cmdlinefilter?: LaceworkAgentLaceworkConfigCmdlinefilter;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#codeaware
+     */
+    readonly codeaware?: LaceworkAgentLaceworkConfigCodeaware;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#containerEngineEndpoint
+     */
+    readonly containerEngineEndpoint?: string;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#containerRuntime
+     */
+    readonly containerRuntime?: LaceworkAgentLaceworkConfigContainerRuntime;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#datacollector
+     */
+    readonly datacollector?: LaceworkAgentLaceworkConfigDatacollector;
+
+    /**
+     * Kubernetes node's scrape interval in minutes
+     *
+     * @schema LaceworkAgentLaceworkConfig#k8sNodeScrapeIntervalMins
+     */
+    readonly k8SNodeScrapeIntervalMins?: number;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#kubernetesCluster
+     */
+    readonly kubernetesCluster?: string;
+
+    /**
+     * Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
+     *
+     * @schema LaceworkAgentLaceworkConfig#labels
+     */
+    readonly labels?: { [key: string]: string };
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#metadataRequestInterval
+     */
+    readonly metadataRequestInterval?: string;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#env
+     */
+    readonly env?: string;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#fim
+     */
+    readonly fim?: LaceworkAgentLaceworkConfigFim;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#packagescan
+     */
+    readonly packagescan?: LaceworkAgentLaceworkConfigPackagescan;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#procscan
+     */
+    readonly procscan?: LaceworkAgentLaceworkConfigProcscan;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#proxyUrl
+     */
+    readonly proxyUrl?: string;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#serverUrl
+     */
+    readonly serverUrl?: string;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#serviceAccountName
+     */
+    readonly serviceAccountName?: string;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#stdoutLogging
+     */
+    readonly stdoutLogging?: boolean;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#tags
+     */
+    readonly tags?: { [key: string]: string };
+
+    /**
+     * @schema LaceworkAgentLaceworkConfig#perfmode
+     */
+    readonly perfmode?: LaceworkAgentLaceworkConfigPerfmode;
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema LaceworkAgentLaceworkConfig#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
 
   /**
-   * Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+   * ResourceRequirements describes the compute resource requirements.
    *
-   * @schema lacework-agent#resources
+   * @schema io.k8s.api.core.v1.ResourceRequirements
    */
-  readonly resources?: IoK8SApiCoreV1ResourceRequirements;
+  export interface IoK8SApiCoreV1ResourceRequirements {
+    /**
+     * Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+     *
+     * @schema io.k8s.api.core.v1.ResourceRequirements#limits
+     */
+    readonly limits?: { [key: string]: any };
+
+    /**
+     * Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+     *
+     * @schema io.k8s.api.core.v1.ResourceRequirements#requests
+     */
+    readonly requests?: { [key: string]: any };
+
+  }
 
   /**
-   * If specified, indicates the pod's priority. \\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+   * The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
    *
-   * @schema lacework-agent#priorityClassName
+   * @schema io.k8s.api.core.v1.Toleration
    */
-  readonly priorityClassName?: string;
+  export interface IoK8SApiCoreV1Toleration {
+    /**
+     * Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+     *
+     * Possible enum values:
+     * - \`\\"NoExecute\\"\` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+     * - \`\\"NoSchedule\\"\` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+     * - \`\\"PreferNoSchedule\\"\` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+     *
+     * @schema io.k8s.api.core.v1.Toleration#effect
+     */
+    readonly effect?: IoK8SApiCoreV1TolerationEffect;
+
+    /**
+     * Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+     *
+     * @schema io.k8s.api.core.v1.Toleration#key
+     */
+    readonly key?: string;
+
+    /**
+     * Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+     *
+     * Possible enum values:
+     * - \`\\"Equal\\"\`
+     * - \`\\"Exists\\"\`
+     *
+     * @default Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+     * @schema io.k8s.api.core.v1.Toleration#operator
+     */
+    readonly operator?: IoK8SApiCoreV1TolerationOperator;
+
+    /**
+     * TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+     *
+     * @schema io.k8s.api.core.v1.Toleration#tolerationSeconds
+     */
+    readonly tolerationSeconds?: number;
+
+    /**
+     * Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+     *
+     * @schema io.k8s.api.core.v1.Toleration#value
+     */
+    readonly value?: string;
+
+  }
 
   /**
-   * If specified, a priority class is created and used to deploy agent
+   * Affinity is a group of affinity scheduling rules.
    *
-   * @schema lacework-agent#priorityClassCreate
+   * @schema io.k8s.api.core.v1.Affinity
    */
-  readonly priorityClassCreate?: boolean;
+  export interface IoK8SApiCoreV1Affinity {
+    /**
+     * Node affinity is a group of node affinity scheduling rules.
+     *
+     * @schema io.k8s.api.core.v1.Affinity#nodeAffinity
+     */
+    readonly nodeAffinity?: IoK8SApiCoreV1AffinityNodeAffinity;
+
+    /**
+     * Pod affinity is a group of inter pod affinity scheduling rules.
+     *
+     * @schema io.k8s.api.core.v1.Affinity#podAffinity
+     */
+    readonly podAffinity?: IoK8SApiCoreV1AffinityPodAffinity;
+
+    /**
+     * Pod anti affinity is a group of inter pod anti affinity scheduling rules.
+     *
+     * @schema io.k8s.api.core.v1.Affinity#podAntiAffinity
+     */
+    readonly podAntiAffinity?: IoK8SApiCoreV1AffinityPodAntiAffinity;
+
+  }
 
   /**
-   * If specified, it determines if agent pod can preempt a pod with a lower a priority
+   * DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.
    *
-   * @schema lacework-agent#priorityClassPreemptionPolicy
+   * @schema io.k8s.api.core.v1.DaemonSetUpdateStrategy
    */
-  readonly priorityClassPreemptionPolicy?: string;
+  export interface IoK8SApiCoreV1DaemonSetUpdateStrategy {
+    /**
+     * Spec to control the desired behavior of daemon set rolling update.
+     *
+     * @schema io.k8s.api.core.v1.DaemonSetUpdateStrategy#rollingUpdate
+     */
+    readonly rollingUpdate?: IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate;
+
+    /**
+     * Type of daemon set update. Can be \\"RollingUpdate\\" or \\"OnDelete\\". Default is RollingUpdate.
+     *
+     * Possible enum values:
+     * - \`\\"OnDelete\\"\` Replace the old daemons only when it's killed
+     * - \`\\"RollingUpdate\\"\` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.
+     *
+     * @default RollingUpdate.
+     * @schema io.k8s.api.core.v1.DaemonSetUpdateStrategy#type
+     */
+    readonly type?: IoK8SApiCoreV1DaemonSetUpdateStrategyType;
+
+  }
 
   /**
-   * If specified, it represents the priority class value to use
+   * @schema LaceworkAgentCloudserviceGke
+   */
+  export interface LaceworkAgentCloudserviceGke {
+    /**
+     * @schema LaceworkAgentCloudserviceGke#autopilot
+     */
+    readonly autopilot?: boolean;
+
+  }
+
+  /**
+   * LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
    *
-   * @schema lacework-agent#priorityClassValue
+   * @schema io.k8s.api.core.v1.LocalObjectReference
    */
-  readonly priorityClassValue?: number;
+  export interface IoK8SApiCoreV1LocalObjectReference {
+    /**
+     * Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+     *
+     * @schema io.k8s.api.core.v1.LocalObjectReference#name
+     */
+    readonly name?: string;
 
-  /**
-   * If specified, the pod's tolerations.
-   *
-   * @schema lacework-agent#tolerations
-   */
-  readonly tolerations?: IoK8SApiCoreV1Toleration[];
-
-  /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema lacework-agent#additionalValues
-   */
-  readonly additionalValues?: { [key: string]: any };
-
-}
-
-/**
- * @schema LaceworkAgentDaemonset
- */
-export interface LaceworkAgentDaemonset {
-  /**
-   * If specified, the pod's scheduling constraints
-   *
-   * @schema LaceworkAgentDaemonset#affinity
-   */
-  readonly affinity: IoK8SApiCoreV1Affinity;
-
-  /**
-   * An update strategy to replace existing DaemonSet pods with new pods.
-   *
-   * @schema LaceworkAgentDaemonset#updateStrategy
-   */
-  readonly updateStrategy: IoK8SApiCoreV1DaemonSetUpdateStrategy;
-
-}
-
-/**
- * @schema LaceworkAgentDeployment
- */
-export interface LaceworkAgentDeployment {
-  /**
-   * If specified, the pod's scheduling constraints
-   *
-   * @schema LaceworkAgentDeployment#affinity
-   */
-  readonly affinity: IoK8SApiCoreV1Affinity;
-
-  /**
-   * An update strategy to replace existing DaemonSet pods with new pods.
-   *
-   * @schema LaceworkAgentDeployment#updateStrategy
-   */
-  readonly updateStrategy: IoK8SApiCoreV1DaemonSetUpdateStrategy;
-
-  /**
-   * Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-   *
-   * @schema LaceworkAgentDeployment#resources
-   */
-  readonly resources?: IoK8SApiCoreV1ResourceRequirements;
-
-  /**
-   * If specified, indicates the pod's priority. \\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
-   *
-   * @schema LaceworkAgentDeployment#priorityClassName
-   */
-  readonly priorityClassName?: string;
-
-  /**
-   * If specified, a priority class is created and used to deploy agent
-   *
-   * @schema LaceworkAgentDeployment#priorityClassCreate
-   */
-  readonly priorityClassCreate?: boolean;
-
-  /**
-   * If specified, it determines if agent pod can preempt a pod with a lower a priority
-   *
-   * @schema LaceworkAgentDeployment#priorityClassPreemptionPolicy
-   */
-  readonly priorityClassPreemptionPolicy?: string;
-
-  /**
-   * If specified, it represents the priority class value to use
-   *
-   * @schema LaceworkAgentDeployment#priorityClassValue
-   */
-  readonly priorityClassValue?: number;
-
-  /**
-   * If specified, the pod's tolerations.
-   *
-   * @schema LaceworkAgentDeployment#tolerations
-   */
-  readonly tolerations?: IoK8SApiCoreV1Toleration[];
-
-}
-
-/**
- * @schema LaceworkAgentCloudservice
- */
-export interface LaceworkAgentCloudservice {
-  /**
-   * @schema LaceworkAgentCloudservice#gke
-   */
-  readonly gke?: LaceworkAgentCloudserviceGke;
-
-}
-
-/**
- * @schema LaceworkAgentDatacollector
- */
-export interface LaceworkAgentDatacollector {
-  /**
-   * Enable lacework datacollector
-   *
-   * @schema LaceworkAgentDatacollector#enable
-   */
-  readonly enable?: boolean;
-
-  /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema LaceworkAgentDatacollector#additionalValues
-   */
-  readonly additionalValues?: { [key: string]: any };
-
-}
-
-/**
- * @schema LaceworkAgentImage
- */
-export interface LaceworkAgentImage {
-  /**
-   * ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
-   *
-   * @schema LaceworkAgentImage#imagePullSecrets
-   */
-  readonly imagePullSecrets?: IoK8SApiCoreV1LocalObjectReference[];
+  }
 
   /**
    * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
@@ -22921,254 +24039,248 @@ export interface LaceworkAgentImage {
    * - \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
    *
    * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
-   * @schema LaceworkAgentImage#pullPolicy
+   * @schema LaceworkAgentImagePullPolicy
    */
-  readonly pullPolicy: LaceworkAgentImagePullPolicy;
+  export enum LaceworkAgentImagePullPolicy {
+    /** Always */
+    ALWAYS = \\"Always\\",
+    /** IfNotPresent */
+    IF_NOT_PRESENT = \\"IfNotPresent\\",
+    /** Never */
+    NEVER = \\"Never\\",
+  }
 
   /**
-   * @schema LaceworkAgentImage#registry
+   * @schema LaceworkAgentClusterAgentImage
    */
-  readonly registry: string;
+  export interface LaceworkAgentClusterAgentImage {
+    /**
+     * ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+     *
+     * @schema LaceworkAgentClusterAgentImage#imagePullSecrets
+     */
+    readonly imagePullSecrets?: IoK8SApiCoreV1LocalObjectReference[];
 
-  /**
-   * @schema LaceworkAgentImage#repository
-   */
-  readonly repository: string;
+    /**
+     * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+     *
+     * Possible enum values:
+     * - \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+     * - \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+     * - \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+     *
+     * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+     * @schema LaceworkAgentClusterAgentImage#pullPolicy
+     */
+    readonly pullPolicy: LaceworkAgentClusterAgentImagePullPolicy;
 
-  /**
-   * @schema LaceworkAgentImage#tag
-   */
-  readonly tag: string;
+    /**
+     * @schema LaceworkAgentClusterAgentImage#registry
+     */
+    readonly registry: string;
 
-  /**
-   * @schema LaceworkAgentImage#overrideValue
-   */
-  readonly overrideValue?: string;
+    /**
+     * @schema LaceworkAgentClusterAgentImage#repository
+     */
+    readonly repository: string;
 
-  /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema LaceworkAgentImage#additionalValues
-   */
-  readonly additionalValues?: { [key: string]: any };
+    /**
+     * @schema LaceworkAgentClusterAgentImage#tag
+     */
+    readonly tag: string;
 
-}
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema LaceworkAgentClusterAgentImage#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
 
-/**
- * @schema LaceworkAgentClusterAgent
- */
-export interface LaceworkAgentClusterAgent {
-  /**
-   * @schema LaceworkAgentClusterAgent#image
-   */
-  readonly image: LaceworkAgentClusterAgentImage;
-
-  /**
-   * Enable cluster agent
-   *
-   * @schema LaceworkAgentClusterAgent#enable
-   */
-  readonly enable: boolean;
+  }
 
   /**
    * Kubernetes cluster type
    *
-   * @schema LaceworkAgentClusterAgent#clusterType
+   * @schema LaceworkAgentClusterAgentClusterType
    */
-  readonly clusterType?: LaceworkAgentClusterAgentClusterType;
+  export enum LaceworkAgentClusterAgentClusterType {
+    /** eks */
+    EKS = \\"eks\\",
+    /** gke */
+    GKE = \\"gke\\",
+    /** unknown */
+    UNKNOWN = \\"unknown\\",
+  }
 
   /**
-   * Kubernetes cluster cloud region
-   *
-   * @schema LaceworkAgentClusterAgent#clusterRegion
+   * @schema LaceworkAgentLaceworkConfigAnonymizeIncoming
    */
-  readonly clusterRegion?: string;
+  export interface LaceworkAgentLaceworkConfigAnonymizeIncoming {
+    /**
+     * @schema LaceworkAgentLaceworkConfigAnonymizeIncoming#netmask
+     */
+    readonly netmask?: string;
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema LaceworkAgentLaceworkConfigAnonymizeIncoming#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
 
   /**
-   * Cluster mode agent's initial delay of cluster scraping after startup in minutes
-   *
-   * @schema LaceworkAgentClusterAgent#scrapeInitialDelayMins
+   * @schema LaceworkAgentLaceworkConfigAutoUpgrade
    */
-  readonly scrapeInitialDelayMins?: number;
+  export enum LaceworkAgentLaceworkConfigAutoUpgrade {
+    /** disable */
+    DISABLE = \\"disable\\",
+    /** enable */
+    ENABLE = \\"enable\\",
+  }
 
   /**
-   * Cluster mode agent's scrape interval in minutes
-   *
-   * @schema LaceworkAgentClusterAgent#scrapeIntervalMins
+   * @schema LaceworkAgentLaceworkConfigCmdlinefilter
    */
-  readonly scrapeIntervalMins?: number;
+  export interface LaceworkAgentLaceworkConfigCmdlinefilter {
+    /**
+     * @schema LaceworkAgentLaceworkConfigCmdlinefilter#allow
+     */
+    readonly allow?: string;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfigCmdlinefilter#disallow
+     */
+    readonly disallow?: string;
+
+  }
 
   /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema LaceworkAgentClusterAgent#additionalValues
+   * @schema LaceworkAgentLaceworkConfigCodeaware
    */
-  readonly additionalValues?: { [key: string]: any };
+  export interface LaceworkAgentLaceworkConfigCodeaware {
+    /**
+     * @schema LaceworkAgentLaceworkConfigCodeaware#enable
+     */
+    readonly enable?: boolean;
 
-}
-
-/**
- * @schema LaceworkAgentLaceworkConfig
- */
-export interface LaceworkAgentLaceworkConfig {
-  /**
-   * @schema LaceworkAgentLaceworkConfig#accessToken
-   */
-  readonly accessToken: any;
+  }
 
   /**
-   * @schema LaceworkAgentLaceworkConfig#anonymizeIncoming
+   * @schema LaceworkAgentLaceworkConfigContainerRuntime
    */
-  readonly anonymizeIncoming?: LaceworkAgentLaceworkConfigAnonymizeIncoming;
+  export enum LaceworkAgentLaceworkConfigContainerRuntime {
+    /** containerd */
+    CONTAINERD = \\"containerd\\",
+    /** cri-o */
+    CRI_O = \\"cri-o\\",
+    /** docker */
+    DOCKER = \\"docker\\",
+  }
 
   /**
-   * Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations
-   *
-   * @schema LaceworkAgentLaceworkConfig#annotations
+   * @schema LaceworkAgentLaceworkConfigDatacollector
    */
-  readonly annotations?: { [key: string]: string };
+  export enum LaceworkAgentLaceworkConfigDatacollector {
+    /** disable */
+    DISABLE = \\"disable\\",
+    /** enable */
+    ENABLE = \\"enable\\",
+  }
 
   /**
-   * @schema LaceworkAgentLaceworkConfig#autoUpgrade
+   * @schema LaceworkAgentLaceworkConfigFim
    */
-  readonly autoUpgrade?: LaceworkAgentLaceworkConfigAutoUpgrade;
+  export interface LaceworkAgentLaceworkConfigFim {
+    /**
+     * @schema LaceworkAgentLaceworkConfigFim#coolingPeriod
+     */
+    readonly coolingPeriod?: number;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfigFim#crawlInterval
+     */
+    readonly crawlInterval?: number;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfigFim#enable
+     */
+    readonly enable: boolean;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfigFim#fileIgnore
+     */
+    readonly fileIgnore: string[];
+
+    /**
+     * @schema LaceworkAgentLaceworkConfigFim#filePath
+     */
+    readonly filePath: string[];
+
+    /**
+     * @schema LaceworkAgentLaceworkConfigFim#noAtime
+     */
+    readonly noAtime?: boolean;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfigFim#runAt
+     */
+    readonly runAt?: any;
+
+    /**
+     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+     *
+     * @schema LaceworkAgentLaceworkConfigFim#additionalValues
+     */
+    readonly additionalValues?: { [key: string]: any };
+
+  }
 
   /**
-   * @schema LaceworkAgentLaceworkConfig#cmdlinefilter
+   * @schema LaceworkAgentLaceworkConfigPackagescan
    */
-  readonly cmdlinefilter?: LaceworkAgentLaceworkConfigCmdlinefilter;
+  export interface LaceworkAgentLaceworkConfigPackagescan {
+    /**
+     * @schema LaceworkAgentLaceworkConfigPackagescan#enable
+     */
+    readonly enable?: boolean;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfigPackagescan#interval
+     */
+    readonly interval?: number;
+
+  }
 
   /**
-   * @schema LaceworkAgentLaceworkConfig#codeaware
+   * @schema LaceworkAgentLaceworkConfigProcscan
    */
-  readonly codeaware?: LaceworkAgentLaceworkConfigCodeaware;
+  export interface LaceworkAgentLaceworkConfigProcscan {
+    /**
+     * @schema LaceworkAgentLaceworkConfigProcscan#enable
+     */
+    readonly enable?: boolean;
+
+    /**
+     * @schema LaceworkAgentLaceworkConfigProcscan#interval
+     */
+    readonly interval?: number;
+
+  }
 
   /**
-   * @schema LaceworkAgentLaceworkConfig#containerEngineEndpoint
+   * @schema LaceworkAgentLaceworkConfigPerfmode
    */
-  readonly containerEngineEndpoint?: string;
+  export enum LaceworkAgentLaceworkConfigPerfmode {
+    /** lite */
+    LITE = \\"lite\\",
+    /** scan */
+    SCAN = \\"scan\\",
+    /** ebpflite */
+    EBPFLITE = \\"ebpflite\\",
+  }
 
-  /**
-   * @schema LaceworkAgentLaceworkConfig#containerRuntime
-   */
-  readonly containerRuntime?: LaceworkAgentLaceworkConfigContainerRuntime;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfig#datacollector
-   */
-  readonly datacollector?: LaceworkAgentLaceworkConfigDatacollector;
-
-  /**
-   * Kubernetes node's scrape interval in minutes
-   *
-   * @schema LaceworkAgentLaceworkConfig#k8sNodeScrapeIntervalMins
-   */
-  readonly k8SNodeScrapeIntervalMins?: number;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfig#kubernetesCluster
-   */
-  readonly kubernetesCluster?: string;
-
-  /**
-   * Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
-   *
-   * @schema LaceworkAgentLaceworkConfig#labels
-   */
-  readonly labels?: { [key: string]: string };
-
-  /**
-   * @schema LaceworkAgentLaceworkConfig#metadataRequestInterval
-   */
-  readonly metadataRequestInterval?: string;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfig#env
-   */
-  readonly env?: string;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfig#fim
-   */
-  readonly fim?: LaceworkAgentLaceworkConfigFim;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfig#packagescan
-   */
-  readonly packagescan?: LaceworkAgentLaceworkConfigPackagescan;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfig#procscan
-   */
-  readonly procscan?: LaceworkAgentLaceworkConfigProcscan;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfig#proxyUrl
-   */
-  readonly proxyUrl?: string;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfig#serverUrl
-   */
-  readonly serverUrl?: string;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfig#serviceAccountName
-   */
-  readonly serviceAccountName?: string;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfig#stdoutLogging
-   */
-  readonly stdoutLogging?: boolean;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfig#tags
-   */
-  readonly tags?: { [key: string]: string };
-
-  /**
-   * @schema LaceworkAgentLaceworkConfig#perfmode
-   */
-  readonly perfmode?: LaceworkAgentLaceworkConfigPerfmode;
-
-  /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema LaceworkAgentLaceworkConfig#additionalValues
-   */
-  readonly additionalValues?: { [key: string]: any };
-
-}
-
-/**
- * ResourceRequirements describes the compute resource requirements.
- *
- * @schema io.k8s.api.core.v1.ResourceRequirements
- */
-export interface IoK8SApiCoreV1ResourceRequirements {
-  /**
-   * Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-   *
-   * @schema io.k8s.api.core.v1.ResourceRequirements#limits
-   */
-  readonly limits?: { [key: string]: any };
-
-  /**
-   * Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-   *
-   * @schema io.k8s.api.core.v1.ResourceRequirements#requests
-   */
-  readonly requests?: { [key: string]: any };
-
-}
-
-/**
- * The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
- *
- * @schema io.k8s.api.core.v1.Toleration
- */
-export interface IoK8SApiCoreV1Toleration {
   /**
    * Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
    *
@@ -23177,16 +24289,16 @@ export interface IoK8SApiCoreV1Toleration {
    * - \`\\"NoSchedule\\"\` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
    * - \`\\"PreferNoSchedule\\"\` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
    *
-   * @schema io.k8s.api.core.v1.Toleration#effect
+   * @schema IoK8SApiCoreV1TolerationEffect
    */
-  readonly effect?: IoK8SApiCoreV1TolerationEffect;
-
-  /**
-   * Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-   *
-   * @schema io.k8s.api.core.v1.Toleration#key
-   */
-  readonly key?: string;
+  export enum IoK8SApiCoreV1TolerationEffect {
+    /** NoExecute */
+    NO_EXECUTE = \\"NoExecute\\",
+    /** NoSchedule */
+    NO_SCHEDULE = \\"NoSchedule\\",
+    /** PreferNoSchedule */
+    PREFER_NO_SCHEDULE = \\"PreferNoSchedule\\",
+  }
 
   /**
    * Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
@@ -23196,67 +24308,98 @@ export interface IoK8SApiCoreV1Toleration {
    * - \`\\"Exists\\"\`
    *
    * @default Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
-   * @schema io.k8s.api.core.v1.Toleration#operator
+   * @schema IoK8SApiCoreV1TolerationOperator
    */
-  readonly operator?: IoK8SApiCoreV1TolerationOperator;
+  export enum IoK8SApiCoreV1TolerationOperator {
+    /** Equal */
+    EQUAL = \\"Equal\\",
+    /** Exists */
+    EXISTS = \\"Exists\\",
+  }
 
-  /**
-   * TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
-   *
-   * @schema io.k8s.api.core.v1.Toleration#tolerationSeconds
-   */
-  readonly tolerationSeconds?: number;
-
-  /**
-   * Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
-   *
-   * @schema io.k8s.api.core.v1.Toleration#value
-   */
-  readonly value?: string;
-
-}
-
-/**
- * Affinity is a group of affinity scheduling rules.
- *
- * @schema io.k8s.api.core.v1.Affinity
- */
-export interface IoK8SApiCoreV1Affinity {
   /**
    * Node affinity is a group of node affinity scheduling rules.
    *
-   * @schema io.k8s.api.core.v1.Affinity#nodeAffinity
+   * @schema IoK8SApiCoreV1AffinityNodeAffinity
    */
-  readonly nodeAffinity?: IoK8SApiCoreV1AffinityNodeAffinity;
+  export interface IoK8SApiCoreV1AffinityNodeAffinity {
+    /**
+     * The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinity#preferredDuringSchedulingIgnoredDuringExecution
+     */
+    readonly preferredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution[];
+
+    /**
+     * A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinity#requiredDuringSchedulingIgnoredDuringExecution
+     */
+    readonly requiredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution;
+
+  }
 
   /**
    * Pod affinity is a group of inter pod affinity scheduling rules.
    *
-   * @schema io.k8s.api.core.v1.Affinity#podAffinity
+   * @schema IoK8SApiCoreV1AffinityPodAffinity
    */
-  readonly podAffinity?: IoK8SApiCoreV1AffinityPodAffinity;
+  export interface IoK8SApiCoreV1AffinityPodAffinity {
+    /**
+     * The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinity#preferredDuringSchedulingIgnoredDuringExecution
+     */
+    readonly preferredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution[];
+
+    /**
+     * If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinity#requiredDuringSchedulingIgnoredDuringExecution
+     */
+    readonly requiredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution[];
+
+  }
 
   /**
    * Pod anti affinity is a group of inter pod anti affinity scheduling rules.
    *
-   * @schema io.k8s.api.core.v1.Affinity#podAntiAffinity
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinity
    */
-  readonly podAntiAffinity?: IoK8SApiCoreV1AffinityPodAntiAffinity;
+  export interface IoK8SApiCoreV1AffinityPodAntiAffinity {
+    /**
+     * The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinity#preferredDuringSchedulingIgnoredDuringExecution
+     */
+    readonly preferredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution[];
 
-}
+    /**
+     * If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinity#requiredDuringSchedulingIgnoredDuringExecution
+     */
+    readonly requiredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution[];
 
-/**
- * DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.
- *
- * @schema io.k8s.api.core.v1.DaemonSetUpdateStrategy
- */
-export interface IoK8SApiCoreV1DaemonSetUpdateStrategy {
+  }
+
   /**
    * Spec to control the desired behavior of daemon set rolling update.
    *
-   * @schema io.k8s.api.core.v1.DaemonSetUpdateStrategy#rollingUpdate
+   * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate
    */
-  readonly rollingUpdate?: IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate;
+  export interface IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate {
+    /**
+     * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate#maxSurge
+     */
+    readonly maxSurge?: any;
+
+    /**
+     * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate#maxUnavailable
+     */
+    readonly maxUnavailable?: any;
+
+  }
 
   /**
    * Type of daemon set update. Can be \\"RollingUpdate\\" or \\"OnDelete\\". Default is RollingUpdate.
@@ -23266,68 +24409,14 @@ export interface IoK8SApiCoreV1DaemonSetUpdateStrategy {
    * - \`\\"RollingUpdate\\"\` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.
    *
    * @default RollingUpdate.
-   * @schema io.k8s.api.core.v1.DaemonSetUpdateStrategy#type
+   * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyType
    */
-  readonly type?: IoK8SApiCoreV1DaemonSetUpdateStrategyType;
-
-}
-
-/**
- * @schema LaceworkAgentCloudserviceGke
- */
-export interface LaceworkAgentCloudserviceGke {
-  /**
-   * @schema LaceworkAgentCloudserviceGke#autopilot
-   */
-  readonly autopilot?: boolean;
-
-}
-
-/**
- * LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
- *
- * @schema io.k8s.api.core.v1.LocalObjectReference
- */
-export interface IoK8SApiCoreV1LocalObjectReference {
-  /**
-   * Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-   *
-   * @schema io.k8s.api.core.v1.LocalObjectReference#name
-   */
-  readonly name?: string;
-
-}
-
-/**
- * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
- *
- * Possible enum values:
- * - \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
- * - \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
- * - \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
- *
- * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
- * @schema LaceworkAgentImagePullPolicy
- */
-export enum LaceworkAgentImagePullPolicy {
-  /** Always */
-  ALWAYS = \\"Always\\",
-  /** IfNotPresent */
-  IF_NOT_PRESENT = \\"IfNotPresent\\",
-  /** Never */
-  NEVER = \\"Never\\",
-}
-
-/**
- * @schema LaceworkAgentClusterAgentImage
- */
-export interface LaceworkAgentClusterAgentImage {
-  /**
-   * ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
-   *
-   * @schema LaceworkAgentClusterAgentImage#imagePullSecrets
-   */
-  readonly imagePullSecrets?: IoK8SApiCoreV1LocalObjectReference[];
+  export enum IoK8SApiCoreV1DaemonSetUpdateStrategyType {
+    /** OnDelete */
+    ON_DELETE = \\"OnDelete\\",
+    /** RollingUpdate */
+    ROLLING_UPDATE = \\"RollingUpdate\\",
+  }
 
   /**
    * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
@@ -23338,743 +24427,725 @@ export interface LaceworkAgentClusterAgentImage {
    * - \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
    *
    * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
-   * @schema LaceworkAgentClusterAgentImage#pullPolicy
+   * @schema LaceworkAgentClusterAgentImagePullPolicy
    */
-  readonly pullPolicy: LaceworkAgentClusterAgentImagePullPolicy;
+  export enum LaceworkAgentClusterAgentImagePullPolicy {
+    /** Always */
+    ALWAYS = \\"Always\\",
+    /** IfNotPresent */
+    IF_NOT_PRESENT = \\"IfNotPresent\\",
+    /** Never */
+    NEVER = \\"Never\\",
+  }
 
   /**
-   * @schema LaceworkAgentClusterAgentImage#registry
-   */
-  readonly registry: string;
-
-  /**
-   * @schema LaceworkAgentClusterAgentImage#repository
-   */
-  readonly repository: string;
-
-  /**
-   * @schema LaceworkAgentClusterAgentImage#tag
-   */
-  readonly tag: string;
-
-  /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   * An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
    *
-   * @schema LaceworkAgentClusterAgentImage#additionalValues
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution
    */
-  readonly additionalValues?: { [key: string]: any };
+  export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution {
+    /**
+     * A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution#preference
+     */
+    readonly preference?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference;
 
-}
+    /**
+     * Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
+     */
+    readonly weight?: number;
 
-/**
- * Kubernetes cluster type
- *
- * @schema LaceworkAgentClusterAgentClusterType
- */
-export enum LaceworkAgentClusterAgentClusterType {
-  /** eks */
-  EKS = \\"eks\\",
-  /** gke */
-  GKE = \\"gke\\",
-  /** unknown */
-  UNKNOWN = \\"unknown\\",
-}
-
-/**
- * @schema LaceworkAgentLaceworkConfigAnonymizeIncoming
- */
-export interface LaceworkAgentLaceworkConfigAnonymizeIncoming {
-  /**
-   * @schema LaceworkAgentLaceworkConfigAnonymizeIncoming#netmask
-   */
-  readonly netmask?: string;
-
-  /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema LaceworkAgentLaceworkConfigAnonymizeIncoming#additionalValues
-   */
-  readonly additionalValues?: { [key: string]: any };
-
-}
-
-/**
- * @schema LaceworkAgentLaceworkConfigAutoUpgrade
- */
-export enum LaceworkAgentLaceworkConfigAutoUpgrade {
-  /** disable */
-  DISABLE = \\"disable\\",
-  /** enable */
-  ENABLE = \\"enable\\",
-}
-
-/**
- * @schema LaceworkAgentLaceworkConfigCmdlinefilter
- */
-export interface LaceworkAgentLaceworkConfigCmdlinefilter {
-  /**
-   * @schema LaceworkAgentLaceworkConfigCmdlinefilter#allow
-   */
-  readonly allow?: string;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfigCmdlinefilter#disallow
-   */
-  readonly disallow?: string;
-
-}
-
-/**
- * @schema LaceworkAgentLaceworkConfigCodeaware
- */
-export interface LaceworkAgentLaceworkConfigCodeaware {
-  /**
-   * @schema LaceworkAgentLaceworkConfigCodeaware#enable
-   */
-  readonly enable?: boolean;
-
-}
-
-/**
- * @schema LaceworkAgentLaceworkConfigContainerRuntime
- */
-export enum LaceworkAgentLaceworkConfigContainerRuntime {
-  /** containerd */
-  CONTAINERD = \\"containerd\\",
-  /** cri-o */
-  CRI_O = \\"cri-o\\",
-  /** docker */
-  DOCKER = \\"docker\\",
-}
-
-/**
- * @schema LaceworkAgentLaceworkConfigDatacollector
- */
-export enum LaceworkAgentLaceworkConfigDatacollector {
-  /** disable */
-  DISABLE = \\"disable\\",
-  /** enable */
-  ENABLE = \\"enable\\",
-}
-
-/**
- * @schema LaceworkAgentLaceworkConfigFim
- */
-export interface LaceworkAgentLaceworkConfigFim {
-  /**
-   * @schema LaceworkAgentLaceworkConfigFim#coolingPeriod
-   */
-  readonly coolingPeriod?: number;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfigFim#crawlInterval
-   */
-  readonly crawlInterval?: number;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfigFim#enable
-   */
-  readonly enable: boolean;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfigFim#fileIgnore
-   */
-  readonly fileIgnore: string[];
-
-  /**
-   * @schema LaceworkAgentLaceworkConfigFim#filePath
-   */
-  readonly filePath: string[];
-
-  /**
-   * @schema LaceworkAgentLaceworkConfigFim#noAtime
-   */
-  readonly noAtime?: boolean;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfigFim#runAt
-   */
-  readonly runAt?: any;
-
-  /**
-   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-   *
-   * @schema LaceworkAgentLaceworkConfigFim#additionalValues
-   */
-  readonly additionalValues?: { [key: string]: any };
-
-}
-
-/**
- * @schema LaceworkAgentLaceworkConfigPackagescan
- */
-export interface LaceworkAgentLaceworkConfigPackagescan {
-  /**
-   * @schema LaceworkAgentLaceworkConfigPackagescan#enable
-   */
-  readonly enable?: boolean;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfigPackagescan#interval
-   */
-  readonly interval?: number;
-
-}
-
-/**
- * @schema LaceworkAgentLaceworkConfigProcscan
- */
-export interface LaceworkAgentLaceworkConfigProcscan {
-  /**
-   * @schema LaceworkAgentLaceworkConfigProcscan#enable
-   */
-  readonly enable?: boolean;
-
-  /**
-   * @schema LaceworkAgentLaceworkConfigProcscan#interval
-   */
-  readonly interval?: number;
-
-}
-
-/**
- * @schema LaceworkAgentLaceworkConfigPerfmode
- */
-export enum LaceworkAgentLaceworkConfigPerfmode {
-  /** lite */
-  LITE = \\"lite\\",
-  /** scan */
-  SCAN = \\"scan\\",
-  /** ebpflite */
-  EBPFLITE = \\"ebpflite\\",
-}
-
-/**
- * Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
- *
- * Possible enum values:
- * - \`\\"NoExecute\\"\` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
- * - \`\\"NoSchedule\\"\` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
- * - \`\\"PreferNoSchedule\\"\` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
- *
- * @schema IoK8SApiCoreV1TolerationEffect
- */
-export enum IoK8SApiCoreV1TolerationEffect {
-  /** NoExecute */
-  NO_EXECUTE = \\"NoExecute\\",
-  /** NoSchedule */
-  NO_SCHEDULE = \\"NoSchedule\\",
-  /** PreferNoSchedule */
-  PREFER_NO_SCHEDULE = \\"PreferNoSchedule\\",
-}
-
-/**
- * Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
- *
- * Possible enum values:
- * - \`\\"Equal\\"\`
- * - \`\\"Exists\\"\`
- *
- * @default Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
- * @schema IoK8SApiCoreV1TolerationOperator
- */
-export enum IoK8SApiCoreV1TolerationOperator {
-  /** Equal */
-  EQUAL = \\"Equal\\",
-  /** Exists */
-  EXISTS = \\"Exists\\",
-}
-
-/**
- * Node affinity is a group of node affinity scheduling rules.
- *
- * @schema IoK8SApiCoreV1AffinityNodeAffinity
- */
-export interface IoK8SApiCoreV1AffinityNodeAffinity {
-  /**
-   * The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
-   *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinity#preferredDuringSchedulingIgnoredDuringExecution
-   */
-  readonly preferredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution[];
+  }
 
   /**
    * A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinity#requiredDuringSchedulingIgnoredDuringExecution
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution
    */
-  readonly requiredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution;
+  export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution {
+    /**
+     * Required. A list of node selector terms. The terms are ORed.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution#nodeSelectorTerms
+     */
+    readonly nodeSelectorTerms?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms[];
 
-}
+  }
 
-/**
- * Pod affinity is a group of inter pod affinity scheduling rules.
- *
- * @schema IoK8SApiCoreV1AffinityPodAffinity
- */
-export interface IoK8SApiCoreV1AffinityPodAffinity {
   /**
-   * The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+   * The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinity#preferredDuringSchedulingIgnoredDuringExecution
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution
    */
-  readonly preferredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution[];
+  export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution {
+    /**
+     * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution#podAffinityTerm
+     */
+    readonly podAffinityTerm?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm;
+
+    /**
+     * weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
+     */
+    readonly weight?: number;
+
+  }
 
   /**
-   * If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+   * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinity#requiredDuringSchedulingIgnoredDuringExecution
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution
    */
-  readonly requiredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution[];
+  export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution {
+    /**
+     * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#labelSelector
+     */
+    readonly labelSelector?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector;
 
-}
+    /**
+     * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaceSelector
+     */
+    readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector;
 
-/**
- * Pod anti affinity is a group of inter pod anti affinity scheduling rules.
- *
- * @schema IoK8SApiCoreV1AffinityPodAntiAffinity
- */
-export interface IoK8SApiCoreV1AffinityPodAntiAffinity {
+    /**
+     * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaces
+     */
+    readonly namespaces?: string[];
+
+    /**
+     * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#topologyKey
+     */
+    readonly topologyKey?: string;
+
+  }
+
   /**
-   * The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+   * The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
    *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinity#preferredDuringSchedulingIgnoredDuringExecution
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution
    */
-  readonly preferredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution[];
+  export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution {
+    /**
+     * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution#podAffinityTerm
+     */
+    readonly podAffinityTerm?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm;
+
+    /**
+     * weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
+     */
+    readonly weight?: number;
+
+  }
 
   /**
-   * If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+   * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
    *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinity#requiredDuringSchedulingIgnoredDuringExecution
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution
    */
-  readonly requiredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution[];
+  export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution {
+    /**
+     * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#labelSelector
+     */
+    readonly labelSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector;
 
-}
+    /**
+     * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaceSelector
+     */
+    readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector;
 
-/**
- * Spec to control the desired behavior of daemon set rolling update.
- *
- * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate
- */
-export interface IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate {
-  /**
-   * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate#maxSurge
-   */
-  readonly maxSurge?: any;
+    /**
+     * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaces
+     */
+    readonly namespaces?: string[];
 
-  /**
-   * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate#maxUnavailable
-   */
-  readonly maxUnavailable?: any;
+    /**
+     * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#topologyKey
+     */
+    readonly topologyKey?: string;
 
-}
+  }
 
-/**
- * Type of daemon set update. Can be \\"RollingUpdate\\" or \\"OnDelete\\". Default is RollingUpdate.
- *
- * Possible enum values:
- * - \`\\"OnDelete\\"\` Replace the old daemons only when it's killed
- * - \`\\"RollingUpdate\\"\` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.
- *
- * @default RollingUpdate.
- * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyType
- */
-export enum IoK8SApiCoreV1DaemonSetUpdateStrategyType {
-  /** OnDelete */
-  ON_DELETE = \\"OnDelete\\",
-  /** RollingUpdate */
-  ROLLING_UPDATE = \\"RollingUpdate\\",
-}
-
-/**
- * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
- *
- * Possible enum values:
- * - \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
- * - \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
- * - \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
- *
- * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
- * @schema LaceworkAgentClusterAgentImagePullPolicy
- */
-export enum LaceworkAgentClusterAgentImagePullPolicy {
-  /** Always */
-  ALWAYS = \\"Always\\",
-  /** IfNotPresent */
-  IF_NOT_PRESENT = \\"IfNotPresent\\",
-  /** Never */
-  NEVER = \\"Never\\",
-}
-
-/**
- * An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
- *
- * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution
- */
-export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution {
   /**
    * A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution#preference
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference
    */
-  readonly preference?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference;
+  export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference {
+    /**
+     * A list of node selector requirements by node's labels.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference#matchExpressions
+     */
+    readonly matchExpressions?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions[];
+
+    /**
+     * A list of node selector requirements by node's fields.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference#matchFields
+     */
+    readonly matchFields?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields[];
+
+  }
 
   /**
-   * Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+   * A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms
    */
-  readonly weight?: number;
+  export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms {
+    /**
+     * A list of node selector requirements by node's labels.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms#matchExpressions
+     */
+    readonly matchExpressions?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions[];
 
-}
+    /**
+     * A list of node selector requirements by node's fields.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms#matchFields
+     */
+    readonly matchFields?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields[];
 
-/**
- * A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.
- *
- * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution
- */
-export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution {
-  /**
-   * Required. A list of node selector terms. The terms are ORed.
-   *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution#nodeSelectorTerms
-   */
-  readonly nodeSelectorTerms?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms[];
+  }
 
-}
-
-/**
- * The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
- *
- * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution
- */
-export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution {
   /**
    * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution#podAffinityTerm
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm
    */
-  readonly podAffinityTerm?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm;
+  export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm {
+    /**
+     * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#labelSelector
+     */
+    readonly labelSelector?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector;
 
-  /**
-   * weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
-   */
-  readonly weight?: number;
+    /**
+     * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaceSelector
+     */
+    readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector;
 
-}
+    /**
+     * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaces
+     */
+    readonly namespaces?: string[];
 
-/**
- * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
- *
- * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution
- */
-export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution {
+    /**
+     * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#topologyKey
+     */
+    readonly topologyKey: string;
+
+  }
+
   /**
    * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#labelSelector
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector
    */
-  readonly labelSelector?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector;
+  export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector {
+    /**
+     * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchExpressions
+     */
+    readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions[];
+
+    /**
+     * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchLabels
+     */
+    readonly matchLabels?: { [key: string]: string };
+
+  }
 
   /**
    * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaceSelector
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector
    */
-  readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector;
+  export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector {
+    /**
+     * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchExpressions
+     */
+    readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions[];
 
-  /**
-   * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaces
-   */
-  readonly namespaces?: string[];
+    /**
+     * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchLabels
+     */
+    readonly matchLabels?: { [key: string]: string };
 
-  /**
-   * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#topologyKey
-   */
-  readonly topologyKey?: string;
+  }
 
-}
-
-/**
- * The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
- *
- * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution
- */
-export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution {
   /**
    * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
    *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution#podAffinityTerm
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm
    */
-  readonly podAffinityTerm?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm;
+  export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm {
+    /**
+     * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#labelSelector
+     */
+    readonly labelSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector;
 
-  /**
-   * weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
-   */
-  readonly weight?: number;
+    /**
+     * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaceSelector
+     */
+    readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector;
 
-}
+    /**
+     * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaces
+     */
+    readonly namespaces?: string[];
 
-/**
- * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
- *
- * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution
- */
-export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution {
-  /**
-   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#labelSelector
-   */
-  readonly labelSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector;
+    /**
+     * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#topologyKey
+     */
+    readonly topologyKey: string;
 
-  /**
-   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaceSelector
-   */
-  readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector;
-
-  /**
-   * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaces
-   */
-  readonly namespaces?: string[];
-
-  /**
-   * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#topologyKey
-   */
-  readonly topologyKey?: string;
-
-}
-
-/**
- * A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
- *
- * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference
- */
-export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference {
-  /**
-   * A list of node selector requirements by node's labels.
-   *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference#matchExpressions
-   */
-  readonly matchExpressions?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions[];
-
-  /**
-   * A list of node selector requirements by node's fields.
-   *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference#matchFields
-   */
-  readonly matchFields?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields[];
-
-}
-
-/**
- * A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
- *
- * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms
- */
-export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms {
-  /**
-   * A list of node selector requirements by node's labels.
-   *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms#matchExpressions
-   */
-  readonly matchExpressions?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions[];
-
-  /**
-   * A list of node selector requirements by node's fields.
-   *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms#matchFields
-   */
-  readonly matchFields?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields[];
-
-}
-
-/**
- * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
- *
- * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm
- */
-export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm {
-  /**
-   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#labelSelector
-   */
-  readonly labelSelector?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector;
+  }
 
   /**
    * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaceSelector
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector
    */
-  readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector;
+  export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector {
+    /**
+     * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchExpressions
+     */
+    readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions[];
 
-  /**
-   * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaces
-   */
-  readonly namespaces?: string[];
+    /**
+     * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchLabels
+     */
+    readonly matchLabels?: { [key: string]: string };
 
-  /**
-   * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#topologyKey
-   */
-  readonly topologyKey: string;
-
-}
-
-/**
- * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
- *
- * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector
- */
-export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector {
-  /**
-   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchExpressions
-   */
-  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions[];
-
-  /**
-   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchLabels
-   */
-  readonly matchLabels?: { [key: string]: string };
-
-}
-
-/**
- * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
- *
- * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector
- */
-export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector {
-  /**
-   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchExpressions
-   */
-  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions[];
-
-  /**
-   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchLabels
-   */
-  readonly matchLabels?: { [key: string]: string };
-
-}
-
-/**
- * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
- *
- * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm
- */
-export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm {
-  /**
-   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#labelSelector
-   */
-  readonly labelSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector;
+  }
 
   /**
    * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaceSelector
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector
    */
-  readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector;
+  export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector {
+    /**
+     * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchExpressions
+     */
+    readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions[];
+
+    /**
+     * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchLabels
+     */
+    readonly matchLabels?: { [key: string]: string };
+
+  }
 
   /**
-   * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+   * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaces
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions
    */
-  readonly namespaces?: string[];
+  export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions {
+    /**
+     * The label key that the selector applies to.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#key
+     */
+    readonly key?: string;
+
+    /**
+     * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+     *
+     * Possible enum values:
+     * - \`\\"DoesNotExist\\"\`
+     * - \`\\"Exists\\"\`
+     * - \`\\"Gt\\"\`
+     * - \`\\"In\\"\`
+     * - \`\\"Lt\\"\`
+     * - \`\\"NotIn\\"\`
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#operator
+     */
+    readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator;
+
+    /**
+     * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#values
+     */
+    readonly values?: string[];
+
+  }
 
   /**
-   * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+   * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#topologyKey
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields
    */
-  readonly topologyKey: string;
+  export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields {
+    /**
+     * The label key that the selector applies to.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#key
+     */
+    readonly key?: string;
 
-}
+    /**
+     * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+     *
+     * Possible enum values:
+     * - \`\\"DoesNotExist\\"\`
+     * - \`\\"Exists\\"\`
+     * - \`\\"Gt\\"\`
+     * - \`\\"In\\"\`
+     * - \`\\"Lt\\"\`
+     * - \`\\"NotIn\\"\`
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#operator
+     */
+    readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator;
 
-/**
- * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
- *
- * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector
- */
-export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector {
-  /**
-   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchExpressions
-   */
-  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions[];
+    /**
+     * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#values
+     */
+    readonly values?: string[];
 
-  /**
-   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchLabels
-   */
-  readonly matchLabels?: { [key: string]: string };
-
-}
-
-/**
- * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
- *
- * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector
- */
-export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector {
-  /**
-   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchExpressions
-   */
-  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions[];
+  }
 
   /**
-   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+   * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchLabels
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions
    */
-  readonly matchLabels?: { [key: string]: string };
+  export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions {
+    /**
+     * The label key that the selector applies to.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#key
+     */
+    readonly key?: string;
 
-}
+    /**
+     * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+     *
+     * Possible enum values:
+     * - \`\\"DoesNotExist\\"\`
+     * - \`\\"Exists\\"\`
+     * - \`\\"Gt\\"\`
+     * - \`\\"In\\"\`
+     * - \`\\"Lt\\"\`
+     * - \`\\"NotIn\\"\`
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#operator
+     */
+    readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator;
 
-/**
- * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
- *
- * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions
- */
-export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions {
+    /**
+     * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#values
+     */
+    readonly values?: string[];
+
+  }
+
   /**
-   * The label key that the selector applies to.
+   * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#key
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields
    */
-  readonly key?: string;
+  export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields {
+    /**
+     * The label key that the selector applies to.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#key
+     */
+    readonly key?: string;
+
+    /**
+     * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+     *
+     * Possible enum values:
+     * - \`\\"DoesNotExist\\"\`
+     * - \`\\"Exists\\"\`
+     * - \`\\"Gt\\"\`
+     * - \`\\"In\\"\`
+     * - \`\\"Lt\\"\`
+     * - \`\\"NotIn\\"\`
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#operator
+     */
+    readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator;
+
+    /**
+     * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+     *
+     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#values
+     */
+    readonly values?: string[];
+
+  }
+
+  /**
+   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector
+   */
+  export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector {
+    /**
+     * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchExpressions
+     */
+    readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions[];
+
+    /**
+     * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchLabels
+     */
+    readonly matchLabels?: { [key: string]: string };
+
+  }
+
+  /**
+   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector
+   */
+  export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector {
+    /**
+     * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchExpressions
+     */
+    readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions[];
+
+    /**
+     * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchLabels
+     */
+    readonly matchLabels?: { [key: string]: string };
+
+  }
+
+  /**
+   * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions
+   */
+  export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions {
+    /**
+     * key is the label key that the selector applies to.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#key
+     */
+    readonly key?: string;
+
+    /**
+     * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#operator
+     */
+    readonly operator?: string;
+
+    /**
+     * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#values
+     */
+    readonly values?: string[];
+
+  }
+
+  /**
+   * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions
+   */
+  export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions {
+    /**
+     * key is the label key that the selector applies to.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#key
+     */
+    readonly key?: string;
+
+    /**
+     * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#operator
+     */
+    readonly operator?: string;
+
+    /**
+     * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#values
+     */
+    readonly values?: string[];
+
+  }
+
+  /**
+   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector
+   */
+  export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector {
+    /**
+     * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchExpressions
+     */
+    readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions[];
+
+    /**
+     * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchLabels
+     */
+    readonly matchLabels?: { [key: string]: string };
+
+  }
+
+  /**
+   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector
+   */
+  export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector {
+    /**
+     * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchExpressions
+     */
+    readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions[];
+
+    /**
+     * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchLabels
+     */
+    readonly matchLabels?: { [key: string]: string };
+
+  }
+
+  /**
+   * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions
+   */
+  export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions {
+    /**
+     * key is the label key that the selector applies to.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#key
+     */
+    readonly key?: string;
+
+    /**
+     * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#operator
+     */
+    readonly operator?: string;
+
+    /**
+     * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#values
+     */
+    readonly values?: string[];
+
+  }
+
+  /**
+   * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions
+   */
+  export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions {
+    /**
+     * key is the label key that the selector applies to.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#key
+     */
+    readonly key?: string;
+
+    /**
+     * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#operator
+     */
+    readonly operator?: string;
+
+    /**
+     * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#values
+     */
+    readonly values?: string[];
+
+  }
 
   /**
    * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
@@ -24087,31 +25158,22 @@ export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgno
    * - \`\\"Lt\\"\`
    * - \`\\"NotIn\\"\`
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#operator
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator
    */
-  readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator;
-
-  /**
-   * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-   *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#values
-   */
-  readonly values?: string[];
-
-}
-
-/**
- * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
- *
- * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields
- */
-export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields {
-  /**
-   * The label key that the selector applies to.
-   *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#key
-   */
-  readonly key?: string;
+  export enum IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator {
+    /** DoesNotExist */
+    DOES_NOT_EXIST = \\"DoesNotExist\\",
+    /** Exists */
+    EXISTS = \\"Exists\\",
+    /** Gt */
+    GT = \\"Gt\\",
+    /** In */
+    IN = \\"In\\",
+    /** Lt */
+    LT = \\"Lt\\",
+    /** NotIn */
+    NOT_IN = \\"NotIn\\",
+  }
 
   /**
    * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
@@ -24124,31 +25186,22 @@ export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgno
    * - \`\\"Lt\\"\`
    * - \`\\"NotIn\\"\`
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#operator
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator
    */
-  readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator;
-
-  /**
-   * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-   *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#values
-   */
-  readonly values?: string[];
-
-}
-
-/**
- * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
- *
- * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions
- */
-export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions {
-  /**
-   * The label key that the selector applies to.
-   *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#key
-   */
-  readonly key?: string;
+  export enum IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator {
+    /** DoesNotExist */
+    DOES_NOT_EXIST = \\"DoesNotExist\\",
+    /** Exists */
+    EXISTS = \\"Exists\\",
+    /** Gt */
+    GT = \\"Gt\\",
+    /** In */
+    IN = \\"In\\",
+    /** Lt */
+    LT = \\"Lt\\",
+    /** NotIn */
+    NOT_IN = \\"NotIn\\",
+  }
 
   /**
    * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
@@ -24161,31 +25214,22 @@ export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnor
    * - \`\\"Lt\\"\`
    * - \`\\"NotIn\\"\`
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#operator
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator
    */
-  readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator;
-
-  /**
-   * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-   *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#values
-   */
-  readonly values?: string[];
-
-}
-
-/**
- * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
- *
- * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields
- */
-export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields {
-  /**
-   * The label key that the selector applies to.
-   *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#key
-   */
-  readonly key?: string;
+  export enum IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator {
+    /** DoesNotExist */
+    DOES_NOT_EXIST = \\"DoesNotExist\\",
+    /** Exists */
+    EXISTS = \\"Exists\\",
+    /** Gt */
+    GT = \\"Gt\\",
+    /** In */
+    IN = \\"In\\",
+    /** Lt */
+    LT = \\"Lt\\",
+    /** NotIn */
+    NOT_IN = \\"NotIn\\",
+  }
 
   /**
    * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
@@ -24198,450 +25242,849 @@ export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnor
    * - \`\\"Lt\\"\`
    * - \`\\"NotIn\\"\`
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#operator
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator
    */
-  readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator;
+  export enum IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator {
+    /** DoesNotExist */
+    DOES_NOT_EXIST = \\"DoesNotExist\\",
+    /** Exists */
+    EXISTS = \\"Exists\\",
+    /** Gt */
+    GT = \\"Gt\\",
+    /** In */
+    IN = \\"In\\",
+    /** Lt */
+    LT = \\"Lt\\",
+    /** NotIn */
+    NOT_IN = \\"NotIn\\",
+  }
 
   /**
-   * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+   * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#values
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions
    */
-  readonly values?: string[];
+  export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions {
+    /**
+     * key is the label key that the selector applies to.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#key
+     */
+    readonly key?: string;
 
+    /**
+     * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#operator
+     */
+    readonly operator?: string;
+
+    /**
+     * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#values
+     */
+    readonly values?: string[];
+
+  }
+
+  /**
+   * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions
+   */
+  export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions {
+    /**
+     * key is the label key that the selector applies to.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#key
+     */
+    readonly key?: string;
+
+    /**
+     * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#operator
+     */
+    readonly operator?: string;
+
+    /**
+     * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#values
+     */
+    readonly values?: string[];
+
+  }
+
+  /**
+   * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions
+   */
+  export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions {
+    /**
+     * key is the label key that the selector applies to.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#key
+     */
+    readonly key?: string;
+
+    /**
+     * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#operator
+     */
+    readonly operator?: string;
+
+    /**
+     * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#values
+     */
+    readonly values?: string[];
+
+  }
+
+  /**
+   * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions
+   */
+  export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions {
+    /**
+     * key is the label key that the selector applies to.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#key
+     */
+    readonly key?: string;
+
+    /**
+     * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#operator
+     */
+    readonly operator?: string;
+
+    /**
+     * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+     *
+     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#values
+     */
+    readonly values?: string[];
+
+  }
+
+",
+}
+`;
+
+exports[`importing helm chart minio:=helm:https://operator.min.io/operator@5.0.9 with python lanugage 1`] = `
+Object {
+  "author": Object {
+    "name": "generated@generated.com",
+    "roles": Array [
+      "author",
+    ],
+  },
+  "dependencies": "__omitted__",
+  "dependencyClosure": Object {
+    "cdk8s": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Org.Cdk8s",
+          "packageId": "Org.Cdk8s",
+        },
+        "go": Object {
+          "moduleName": "github.com/cdk8s-team/cdk8s-core-go",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "cdk8s",
+            "groupId": "org.cdk8s",
+          },
+          "package": "org.cdk8s",
+        },
+        "js": Object {
+          "npm": "cdk8s",
+        },
+        "python": Object {
+          "distName": "cdk8s",
+          "module": "cdk8s",
+        },
+      },
+    },
+    "constructs": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Constructs",
+          "packageId": "Constructs",
+        },
+        "go": Object {
+          "moduleName": "github.com/aws/constructs-go",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "constructs",
+            "groupId": "software.constructs",
+          },
+          "package": "software.constructs",
+        },
+        "js": Object {
+          "npm": "constructs",
+        },
+        "python": Object {
+          "distName": "constructs",
+          "module": "constructs",
+        },
+      },
+    },
+  },
+  "description": "operator",
+  "fingerprint": "<fingerprint>",
+  "homepage": "http://generated",
+  "jsiiVersion": "__omitted__",
+  "license": "UNLICENSED",
+  "metadata": Object {
+    "jsii": Object {
+      "pacmak": Object {
+        "hasDefaultInterfaces": true,
+      },
+    },
+  },
+  "name": "operator",
+  "repository": Object {
+    "type": "git",
+    "url": "http://generated",
+  },
+  "schema": "jsii/0.10.0",
+  "targets": Object {
+    "js": Object {
+      "npm": "operator",
+    },
+    "python": Object {
+      "distName": "generated",
+      "module": "operator",
+    },
+  },
+  "types": Object {
+    "operator.Operator": Object {
+      "assembly": "operator",
+      "base": "constructs.Construct",
+      "fqn": "operator.Operator",
+      "initializer": Object {
+        "locationInModule": Object {
+          "filename": "operator.ts",
+          "line": 14,
+        },
+        "parameters": Array [
+          Object {
+            "name": "scope",
+            "type": Object {
+              "fqn": "constructs.Construct",
+            },
+          },
+          Object {
+            "name": "id",
+            "type": Object {
+              "primitive": "string",
+            },
+          },
+          Object {
+            "name": "props",
+            "optional": true,
+            "type": Object {
+              "fqn": "operator.OperatorProps",
+            },
+          },
+        ],
+      },
+      "kind": "class",
+      "locationInModule": Object {
+        "filename": "operator.ts",
+        "line": 13,
+      },
+      "name": "Operator",
+      "symbolId": "operator:Operator",
+    },
+    "operator.OperatorProps": Object {
+      "assembly": "operator",
+      "datatype": true,
+      "fqn": "operator.OperatorProps",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "operator.ts",
+        "line": 5,
+      },
+      "name": "OperatorProps",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "operator.ts",
+            "line": 8,
+          },
+          "name": "helmExecutable",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "operator.ts",
+            "line": 9,
+          },
+          "name": "helmFlags",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "operator.ts",
+            "line": 6,
+          },
+          "name": "namespace",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "operator.ts",
+            "line": 7,
+          },
+          "name": "releaseName",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "operator.ts",
+            "line": 10,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "operator:OperatorProps",
+    },
+  },
+  "version": "0.0.0",
+}
+`;
+
+exports[`importing helm chart minio:=helm:https://operator.min.io/operator@5.0.9 with python lanugage 2`] = `
+Object {
+  "operator/__init__.py": "import abc
+import builtins
+import datetime
+import enum
+import typing
+
+import jsii
+import publication
+import typing_extensions
+
+from typeguard import check_type
+
+from ._jsii import *
+
+import constructs as _constructs_77d1e7e8
+
+
+class Operator(
+    _constructs_77d1e7e8.Construct,
+    metaclass=jsii.JSIIMeta,
+    jsii_type=\\"operator.Operator\\",
+):
+    def __init__(
+        self,
+        scope: _constructs_77d1e7e8.Construct,
+        id: builtins.str,
+        *,
+        helm_executable: typing.Optional[builtins.str] = None,
+        helm_flags: typing.Optional[typing.Sequence[builtins.str]] = None,
+        namespace: typing.Optional[builtins.str] = None,
+        release_name: typing.Optional[builtins.str] = None,
+        values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    ) -> None:
+        '''
+        :param scope: -
+        :param id: -
+        :param helm_executable: -
+        :param helm_flags: -
+        :param namespace: -
+        :param release_name: -
+        :param values: -
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__11493dc2fc191cbb73ceb199e0facf7edcc58bf9f85942664ecc4614b277a2ba)
+            check_type(argname=\\"argument scope\\", value=scope, expected_type=type_hints[\\"scope\\"])
+            check_type(argname=\\"argument id\\", value=id, expected_type=type_hints[\\"id\\"])
+        props = OperatorProps(
+            helm_executable=helm_executable,
+            helm_flags=helm_flags,
+            namespace=namespace,
+            release_name=release_name,
+            values=values,
+        )
+
+        jsii.create(self.__class__, self, [scope, id, props])
+
+
+@jsii.data_type(
+    jsii_type=\\"operator.OperatorProps\\",
+    jsii_struct_bases=[],
+    name_mapping={
+        \\"helm_executable\\": \\"helmExecutable\\",
+        \\"helm_flags\\": \\"helmFlags\\",
+        \\"namespace\\": \\"namespace\\",
+        \\"release_name\\": \\"releaseName\\",
+        \\"values\\": \\"values\\",
+    },
+)
+class OperatorProps:
+    def __init__(
+        self,
+        *,
+        helm_executable: typing.Optional[builtins.str] = None,
+        helm_flags: typing.Optional[typing.Sequence[builtins.str]] = None,
+        namespace: typing.Optional[builtins.str] = None,
+        release_name: typing.Optional[builtins.str] = None,
+        values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+    ) -> None:
+        '''
+        :param helm_executable: -
+        :param helm_flags: -
+        :param namespace: -
+        :param release_name: -
+        :param values: -
+        '''
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__1ba6cfa05344ec1eb73016e5b58b05d2a9a2e22bf82546647dd2d6dac88cf487)
+            check_type(argname=\\"argument helm_executable\\", value=helm_executable, expected_type=type_hints[\\"helm_executable\\"])
+            check_type(argname=\\"argument helm_flags\\", value=helm_flags, expected_type=type_hints[\\"helm_flags\\"])
+            check_type(argname=\\"argument namespace\\", value=namespace, expected_type=type_hints[\\"namespace\\"])
+            check_type(argname=\\"argument release_name\\", value=release_name, expected_type=type_hints[\\"release_name\\"])
+            check_type(argname=\\"argument values\\", value=values, expected_type=type_hints[\\"values\\"])
+        self._values: typing.Dict[builtins.str, typing.Any] = {}
+        if helm_executable is not None:
+            self._values[\\"helm_executable\\"] = helm_executable
+        if helm_flags is not None:
+            self._values[\\"helm_flags\\"] = helm_flags
+        if namespace is not None:
+            self._values[\\"namespace\\"] = namespace
+        if release_name is not None:
+            self._values[\\"release_name\\"] = release_name
+        if values is not None:
+            self._values[\\"values\\"] = values
+
+    @builtins.property
+    def helm_executable(self) -> typing.Optional[builtins.str]:
+        result = self._values.get(\\"helm_executable\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def helm_flags(self) -> typing.Optional[typing.List[builtins.str]]:
+        result = self._values.get(\\"helm_flags\\")
+        return typing.cast(typing.Optional[typing.List[builtins.str]], result)
+
+    @builtins.property
+    def namespace(self) -> typing.Optional[builtins.str]:
+        result = self._values.get(\\"namespace\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def release_name(self) -> typing.Optional[builtins.str]:
+        result = self._values.get(\\"release_name\\")
+        return typing.cast(typing.Optional[builtins.str], result)
+
+    @builtins.property
+    def values(self) -> typing.Optional[typing.Mapping[builtins.str, typing.Any]]:
+        result = self._values.get(\\"values\\")
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, typing.Any]], result)
+
+    def __eq__(self, rhs: typing.Any) -> builtins.bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs: typing.Any) -> builtins.bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return \\"OperatorProps(%s)\\" % \\", \\".join(
+            k + \\"=\\" + repr(v) for k, v in self._values.items()
+        )
+
+
+__all__ = [
+    \\"Operator\\",
+    \\"OperatorProps\\",
+]
+
+publication.publish()
+
+def _typecheckingstub__11493dc2fc191cbb73ceb199e0facf7edcc58bf9f85942664ecc4614b277a2ba(
+    scope: _constructs_77d1e7e8.Construct,
+    id: builtins.str,
+    *,
+    helm_executable: typing.Optional[builtins.str] = None,
+    helm_flags: typing.Optional[typing.Sequence[builtins.str]] = None,
+    namespace: typing.Optional[builtins.str] = None,
+    release_name: typing.Optional[builtins.str] = None,
+    values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__1ba6cfa05344ec1eb73016e5b58b05d2a9a2e22bf82546647dd2d6dac88cf487(
+    *,
+    helm_executable: typing.Optional[builtins.str] = None,
+    helm_flags: typing.Optional[typing.Sequence[builtins.str]] = None,
+    namespace: typing.Optional[builtins.str] = None,
+    release_name: typing.Optional[builtins.str] = None,
+    values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+",
+  "operator/_jsii/__init__.py": "import abc
+import builtins
+import datetime
+import enum
+import typing
+
+import jsii
+import publication
+import typing_extensions
+
+from typeguard import check_type
+
+import cdk8s._jsii
+import constructs._jsii
+
+__jsii_assembly__ = jsii.JSIIAssembly.load(
+    \\"operator\\", \\"0.0.0\\", __name__[0:-6], \\"operator@0.0.0.jsii.tgz\\"
+)
+
+__all__ = [
+    \\"__jsii_assembly__\\",
+]
+
+publication.publish()
+",
+  "operator/py.typed": "
+",
+}
+`;
+
+exports[`importing helm chart minio:=helm:https://operator.min.io/operator@5.0.9 with typescript lanugage 1`] = `
+Object {
+  "author": Object {
+    "name": "generated@generated.com",
+    "roles": Array [
+      "author",
+    ],
+  },
+  "dependencies": "__omitted__",
+  "dependencyClosure": Object {
+    "cdk8s": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Org.Cdk8s",
+          "packageId": "Org.Cdk8s",
+        },
+        "go": Object {
+          "moduleName": "github.com/cdk8s-team/cdk8s-core-go",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "cdk8s",
+            "groupId": "org.cdk8s",
+          },
+          "package": "org.cdk8s",
+        },
+        "js": Object {
+          "npm": "cdk8s",
+        },
+        "python": Object {
+          "distName": "cdk8s",
+          "module": "cdk8s",
+        },
+      },
+    },
+    "constructs": Object {
+      "targets": Object {
+        "dotnet": Object {
+          "namespace": "Constructs",
+          "packageId": "Constructs",
+        },
+        "go": Object {
+          "moduleName": "github.com/aws/constructs-go",
+        },
+        "java": Object {
+          "maven": Object {
+            "artifactId": "constructs",
+            "groupId": "software.constructs",
+          },
+          "package": "software.constructs",
+        },
+        "js": Object {
+          "npm": "constructs",
+        },
+        "python": Object {
+          "distName": "constructs",
+          "module": "constructs",
+        },
+      },
+    },
+  },
+  "description": "operator",
+  "fingerprint": "<fingerprint>",
+  "homepage": "http://generated",
+  "jsiiVersion": "__omitted__",
+  "license": "UNLICENSED",
+  "metadata": Object {
+    "jsii": Object {
+      "pacmak": Object {
+        "hasDefaultInterfaces": true,
+      },
+    },
+  },
+  "name": "operator",
+  "repository": Object {
+    "type": "git",
+    "url": "http://generated",
+  },
+  "schema": "jsii/0.10.0",
+  "targets": Object {
+    "js": Object {
+      "npm": "operator",
+    },
+  },
+  "types": Object {
+    "operator.Operator": Object {
+      "assembly": "operator",
+      "base": "constructs.Construct",
+      "fqn": "operator.Operator",
+      "initializer": Object {
+        "locationInModule": Object {
+          "filename": "operator.ts",
+          "line": 14,
+        },
+        "parameters": Array [
+          Object {
+            "name": "scope",
+            "type": Object {
+              "fqn": "constructs.Construct",
+            },
+          },
+          Object {
+            "name": "id",
+            "type": Object {
+              "primitive": "string",
+            },
+          },
+          Object {
+            "name": "props",
+            "optional": true,
+            "type": Object {
+              "fqn": "operator.OperatorProps",
+            },
+          },
+        ],
+      },
+      "kind": "class",
+      "locationInModule": Object {
+        "filename": "operator.ts",
+        "line": 13,
+      },
+      "name": "Operator",
+      "symbolId": "operator:Operator",
+    },
+    "operator.OperatorProps": Object {
+      "assembly": "operator",
+      "datatype": true,
+      "fqn": "operator.OperatorProps",
+      "kind": "interface",
+      "locationInModule": Object {
+        "filename": "operator.ts",
+        "line": 5,
+      },
+      "name": "OperatorProps",
+      "properties": Array [
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "operator.ts",
+            "line": 8,
+          },
+          "name": "helmExecutable",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "operator.ts",
+            "line": 9,
+          },
+          "name": "helmFlags",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "string",
+              },
+              "kind": "array",
+            },
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "operator.ts",
+            "line": 6,
+          },
+          "name": "namespace",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "operator.ts",
+            "line": 7,
+          },
+          "name": "releaseName",
+          "optional": true,
+          "type": Object {
+            "primitive": "string",
+          },
+        },
+        Object {
+          "abstract": true,
+          "immutable": true,
+          "locationInModule": Object {
+            "filename": "operator.ts",
+            "line": 10,
+          },
+          "name": "values",
+          "optional": true,
+          "type": Object {
+            "collection": Object {
+              "elementtype": Object {
+                "primitive": "any",
+              },
+              "kind": "map",
+            },
+          },
+        },
+      ],
+      "symbolId": "operator:OperatorProps",
+    },
+  },
+  "version": "0.0.0",
+}
+`;
+
+exports[`importing helm chart minio:=helm:https://operator.min.io/operator@5.0.9 with typescript lanugage 2`] = `
+Object {
+  "operator.ts": "// generated by cdk8s
+import { Helm, HelmProps } from 'cdk8s';
+import { Construct } from 'constructs';
+
+export interface OperatorProps {
+  readonly namespace?: string;
+  readonly releaseName?: string;
+  readonly helmExecutable?: string;
+  readonly helmFlags?: string[];
+  readonly values?: { [key: string]: any };
 }
 
-/**
- * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
- *
- * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector
- */
-export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector {
-  /**
-   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchExpressions
-   */
-  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions[];
+export class Operator extends Construct {
+  public constructor(scope: Construct, id: string, props: OperatorProps = {}) {
+    super(scope, id)
+    let updatedProps = {};
 
-  /**
-   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchLabels
-   */
-  readonly matchLabels?: { [key: string]: string };
+    if (props.values) {
+      const { additionalValues, ...valuesWithoutAdditionalValues } = props.values;
+      updatedProps = {
+        ...props,
+        values: {
+          ...this.flattenAdditionalValues(valuesWithoutAdditionalValues),
+          ...additionalValues,
+        }
+      };
+    }
 
-}
+    const finalProps: HelmProps = {
+      chart: 'operator',
+      repo: 'https://operator.min.io',
+      version: '5.0.9',
+      ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
+    };
 
-/**
- * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
- *
- * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector
- */
-export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector {
-  /**
-   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchExpressions
-   */
-  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions[];
+    new Helm(scope, \`Helm\${id}\`, finalProps)
+  }
 
-  /**
-   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchLabels
-   */
-  readonly matchLabels?: { [key: string]: string };
+  private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
+    for (let prop in props) {
+      if (Array.isArray(props[prop])) {
+        props[prop].map((item: any) => {
+          if (typeof(item) === 'object' && prop !== 'additionalValues') {
+            return this.flattenAdditionalValues(item);
+          }
+          return item;
+        });
+        } else if (typeof(props[prop]) === 'object' && prop !== 'additionalValues') {
+          props[prop] = this.flattenAdditionalValues(props[prop]);
+        }
+      }
 
-}
+      const { additionalValues, ...valuesWithoutAdditionalValues } = props;
 
-/**
- * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
- *
- * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions
- */
-export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions {
-  /**
-   * key is the label key that the selector applies to.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#key
-   */
-  readonly key?: string;
-
-  /**
-   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#operator
-   */
-  readonly operator?: string;
-
-  /**
-   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#values
-   */
-  readonly values?: string[];
-
-}
-
-/**
- * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
- *
- * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions
- */
-export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions {
-  /**
-   * key is the label key that the selector applies to.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#key
-   */
-  readonly key?: string;
-
-  /**
-   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#operator
-   */
-  readonly operator?: string;
-
-  /**
-   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#values
-   */
-  readonly values?: string[];
-
-}
-
-/**
- * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
- *
- * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector
- */
-export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector {
-  /**
-   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchExpressions
-   */
-  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions[];
-
-  /**
-   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchLabels
-   */
-  readonly matchLabels?: { [key: string]: string };
-
-}
-
-/**
- * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
- *
- * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector
- */
-export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector {
-  /**
-   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchExpressions
-   */
-  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions[];
-
-  /**
-   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchLabels
-   */
-  readonly matchLabels?: { [key: string]: string };
-
-}
-
-/**
- * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
- *
- * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions
- */
-export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions {
-  /**
-   * key is the label key that the selector applies to.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#key
-   */
-  readonly key?: string;
-
-  /**
-   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#operator
-   */
-  readonly operator?: string;
-
-  /**
-   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#values
-   */
-  readonly values?: string[];
-
-}
-
-/**
- * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
- *
- * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions
- */
-export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions {
-  /**
-   * key is the label key that the selector applies to.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#key
-   */
-  readonly key?: string;
-
-  /**
-   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#operator
-   */
-  readonly operator?: string;
-
-  /**
-   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#values
-   */
-  readonly values?: string[];
-
-}
-
-/**
- * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
- *
- * Possible enum values:
- * - \`\\"DoesNotExist\\"\`
- * - \`\\"Exists\\"\`
- * - \`\\"Gt\\"\`
- * - \`\\"In\\"\`
- * - \`\\"Lt\\"\`
- * - \`\\"NotIn\\"\`
- *
- * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator
- */
-export enum IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator {
-  /** DoesNotExist */
-  DOES_NOT_EXIST = \\"DoesNotExist\\",
-  /** Exists */
-  EXISTS = \\"Exists\\",
-  /** Gt */
-  GT = \\"Gt\\",
-  /** In */
-  IN = \\"In\\",
-  /** Lt */
-  LT = \\"Lt\\",
-  /** NotIn */
-  NOT_IN = \\"NotIn\\",
-}
-
-/**
- * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
- *
- * Possible enum values:
- * - \`\\"DoesNotExist\\"\`
- * - \`\\"Exists\\"\`
- * - \`\\"Gt\\"\`
- * - \`\\"In\\"\`
- * - \`\\"Lt\\"\`
- * - \`\\"NotIn\\"\`
- *
- * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator
- */
-export enum IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator {
-  /** DoesNotExist */
-  DOES_NOT_EXIST = \\"DoesNotExist\\",
-  /** Exists */
-  EXISTS = \\"Exists\\",
-  /** Gt */
-  GT = \\"Gt\\",
-  /** In */
-  IN = \\"In\\",
-  /** Lt */
-  LT = \\"Lt\\",
-  /** NotIn */
-  NOT_IN = \\"NotIn\\",
-}
-
-/**
- * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
- *
- * Possible enum values:
- * - \`\\"DoesNotExist\\"\`
- * - \`\\"Exists\\"\`
- * - \`\\"Gt\\"\`
- * - \`\\"In\\"\`
- * - \`\\"Lt\\"\`
- * - \`\\"NotIn\\"\`
- *
- * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator
- */
-export enum IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator {
-  /** DoesNotExist */
-  DOES_NOT_EXIST = \\"DoesNotExist\\",
-  /** Exists */
-  EXISTS = \\"Exists\\",
-  /** Gt */
-  GT = \\"Gt\\",
-  /** In */
-  IN = \\"In\\",
-  /** Lt */
-  LT = \\"Lt\\",
-  /** NotIn */
-  NOT_IN = \\"NotIn\\",
-}
-
-/**
- * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
- *
- * Possible enum values:
- * - \`\\"DoesNotExist\\"\`
- * - \`\\"Exists\\"\`
- * - \`\\"Gt\\"\`
- * - \`\\"In\\"\`
- * - \`\\"Lt\\"\`
- * - \`\\"NotIn\\"\`
- *
- * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator
- */
-export enum IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator {
-  /** DoesNotExist */
-  DOES_NOT_EXIST = \\"DoesNotExist\\",
-  /** Exists */
-  EXISTS = \\"Exists\\",
-  /** Gt */
-  GT = \\"Gt\\",
-  /** In */
-  IN = \\"In\\",
-  /** Lt */
-  LT = \\"Lt\\",
-  /** NotIn */
-  NOT_IN = \\"NotIn\\",
-}
-
-/**
- * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
- *
- * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions
- */
-export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions {
-  /**
-   * key is the label key that the selector applies to.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#key
-   */
-  readonly key?: string;
-
-  /**
-   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#operator
-   */
-  readonly operator?: string;
-
-  /**
-   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#values
-   */
-  readonly values?: string[];
-
-}
-
-/**
- * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
- *
- * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions
- */
-export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions {
-  /**
-   * key is the label key that the selector applies to.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#key
-   */
-  readonly key?: string;
-
-  /**
-   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#operator
-   */
-  readonly operator?: string;
-
-  /**
-   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#values
-   */
-  readonly values?: string[];
-
-}
-
-/**
- * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
- *
- * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions
- */
-export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions {
-  /**
-   * key is the label key that the selector applies to.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#key
-   */
-  readonly key?: string;
-
-  /**
-   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#operator
-   */
-  readonly operator?: string;
-
-  /**
-   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#values
-   */
-  readonly values?: string[];
-
-}
-
-/**
- * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
- *
- * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions
- */
-export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions {
-  /**
-   * key is the label key that the selector applies to.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#key
-   */
-  readonly key?: string;
-
-  /**
-   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#operator
-   */
-  readonly operator?: string;
-
-  /**
-   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#values
-   */
-  readonly values?: string[];
-
-}
+      return {
+        ...valuesWithoutAdditionalValues,
+        ...additionalValues,
+      };
+    }
+  }
 
 ",
 }

--- a/test/import/__snapshots__/import-helm.test.ts.snap
+++ b/test/import/__snapshots__/import-helm.test.ts.snap
@@ -140,7 +140,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 112,
+        "line": 113,
       },
       "members": Array [
         Object {
@@ -171,7 +171,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 122,
+        "line": 123,
       },
       "name": "MysqlAuth",
       "properties": Array [
@@ -185,7 +185,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 144,
+            "line": 145,
           },
           "name": "password",
           "type": Object {
@@ -202,7 +202,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 139,
+            "line": 140,
           },
           "name": "username",
           "type": Object {
@@ -220,7 +220,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 166,
+            "line": 167,
           },
           "name": "additionalValues",
           "optional": true,
@@ -243,7 +243,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 159,
+            "line": 160,
           },
           "name": "createDatabase",
           "optional": true,
@@ -261,7 +261,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 134,
+            "line": 135,
           },
           "name": "database",
           "optional": true,
@@ -279,7 +279,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 154,
+            "line": 155,
           },
           "name": "replicationPassword",
           "optional": true,
@@ -297,7 +297,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 149,
+            "line": 150,
           },
           "name": "replicationUser",
           "optional": true,
@@ -317,7 +317,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 129,
+            "line": 130,
           },
           "name": "rootPassword",
           "optional": true,
@@ -340,7 +340,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 173,
+        "line": 174,
       },
       "name": "MysqlPrimary",
       "properties": Array [
@@ -355,7 +355,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 194,
+            "line": 195,
           },
           "name": "additionalValues",
           "optional": true,
@@ -378,7 +378,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 182,
+            "line": 183,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -396,7 +396,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 187,
+            "line": 188,
           },
           "name": "persistence",
           "optional": true,
@@ -414,7 +414,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 177,
+            "line": 178,
           },
           "name": "podSecurityContext",
           "optional": true,
@@ -437,7 +437,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 252,
+        "line": 253,
       },
       "name": "MysqlPrimaryContainerSecurityContext",
       "properties": Array [
@@ -452,7 +452,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 268,
+            "line": 269,
           },
           "name": "additionalValues",
           "optional": true,
@@ -475,7 +475,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 256,
+            "line": 257,
           },
           "name": "enabled",
           "optional": true,
@@ -493,7 +493,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 261,
+            "line": 262,
           },
           "name": "runAsUser",
           "optional": true,
@@ -516,7 +516,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 275,
+        "line": 276,
       },
       "name": "MysqlPrimaryPersistence",
       "properties": Array [
@@ -531,7 +531,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 291,
+            "line": 292,
           },
           "name": "additionalValues",
           "optional": true,
@@ -554,7 +554,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 279,
+            "line": 280,
           },
           "name": "enabled",
           "optional": true,
@@ -572,7 +572,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 284,
+            "line": 285,
           },
           "name": "size",
           "optional": true,
@@ -595,7 +595,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 229,
+        "line": 230,
       },
       "name": "MysqlPrimaryPodSecurityContext",
       "properties": Array [
@@ -610,7 +610,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 245,
+            "line": 246,
           },
           "name": "additionalValues",
           "optional": true,
@@ -633,7 +633,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 233,
+            "line": 234,
           },
           "name": "enabled",
           "optional": true,
@@ -651,7 +651,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 238,
+            "line": 239,
           },
           "name": "fsGroup",
           "optional": true,
@@ -758,7 +758,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 201,
+        "line": 202,
       },
       "name": "MysqlSecondary",
       "properties": Array [
@@ -773,7 +773,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 222,
+            "line": 223,
           },
           "name": "additionalValues",
           "optional": true,
@@ -796,7 +796,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 210,
+            "line": 211,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -814,7 +814,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 215,
+            "line": 216,
           },
           "name": "persistence",
           "optional": true,
@@ -832,7 +832,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 205,
+            "line": 206,
           },
           "name": "podSecurityContext",
           "optional": true,
@@ -855,7 +855,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 321,
+        "line": 322,
       },
       "name": "MysqlSecondaryContainerSecurityContext",
       "properties": Array [
@@ -870,7 +870,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 337,
+            "line": 338,
           },
           "name": "additionalValues",
           "optional": true,
@@ -893,7 +893,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 325,
+            "line": 326,
           },
           "name": "enabled",
           "optional": true,
@@ -911,7 +911,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 330,
+            "line": 331,
           },
           "name": "runAsUser",
           "optional": true,
@@ -934,7 +934,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 344,
+        "line": 345,
       },
       "name": "MysqlSecondaryPersistence",
       "properties": Array [
@@ -949,7 +949,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 360,
+            "line": 361,
           },
           "name": "additionalValues",
           "optional": true,
@@ -972,7 +972,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 348,
+            "line": 349,
           },
           "name": "enabled",
           "optional": true,
@@ -990,7 +990,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 353,
+            "line": 354,
           },
           "name": "size",
           "optional": true,
@@ -1013,7 +1013,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 298,
+        "line": 299,
       },
       "name": "MysqlSecondaryPodSecurityContext",
       "properties": Array [
@@ -1028,7 +1028,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 314,
+            "line": 315,
           },
           "name": "additionalValues",
           "optional": true,
@@ -1051,7 +1051,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 302,
+            "line": 303,
           },
           "name": "enabled",
           "optional": true,
@@ -1069,7 +1069,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 307,
+            "line": 308,
           },
           "name": "fsGroup",
           "optional": true,
@@ -1092,7 +1092,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 65,
+        "line": 66,
       },
       "name": "MysqlValues",
       "properties": Array [
@@ -1107,7 +1107,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 103,
+            "line": 104,
           },
           "name": "additionalValues",
           "optional": true,
@@ -1131,7 +1131,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 71,
+            "line": 72,
           },
           "name": "architecture",
           "optional": true,
@@ -1149,7 +1149,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 76,
+            "line": 77,
           },
           "name": "auth",
           "optional": true,
@@ -1167,7 +1167,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 91,
+            "line": 92,
           },
           "name": "common",
           "optional": true,
@@ -1190,7 +1190,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 96,
+            "line": 97,
           },
           "name": "global",
           "optional": true,
@@ -1213,7 +1213,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 81,
+            "line": 82,
           },
           "name": "primary",
           "optional": true,
@@ -1231,7 +1231,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 86,
+            "line": 87,
           },
           "name": "secondary",
           "optional": true,
@@ -2657,7 +2657,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 112,
+        "line": 113,
       },
       "members": Array [
         Object {
@@ -2688,7 +2688,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 122,
+        "line": 123,
       },
       "name": "MysqlAuth",
       "properties": Array [
@@ -2702,7 +2702,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 144,
+            "line": 145,
           },
           "name": "password",
           "type": Object {
@@ -2719,7 +2719,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 139,
+            "line": 140,
           },
           "name": "username",
           "type": Object {
@@ -2737,7 +2737,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 166,
+            "line": 167,
           },
           "name": "additionalValues",
           "optional": true,
@@ -2760,7 +2760,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 159,
+            "line": 160,
           },
           "name": "createDatabase",
           "optional": true,
@@ -2778,7 +2778,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 134,
+            "line": 135,
           },
           "name": "database",
           "optional": true,
@@ -2796,7 +2796,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 154,
+            "line": 155,
           },
           "name": "replicationPassword",
           "optional": true,
@@ -2814,7 +2814,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 149,
+            "line": 150,
           },
           "name": "replicationUser",
           "optional": true,
@@ -2834,7 +2834,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 129,
+            "line": 130,
           },
           "name": "rootPassword",
           "optional": true,
@@ -2857,7 +2857,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 173,
+        "line": 174,
       },
       "name": "MysqlPrimary",
       "properties": Array [
@@ -2872,7 +2872,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 194,
+            "line": 195,
           },
           "name": "additionalValues",
           "optional": true,
@@ -2895,7 +2895,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 182,
+            "line": 183,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -2913,7 +2913,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 187,
+            "line": 188,
           },
           "name": "persistence",
           "optional": true,
@@ -2931,7 +2931,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 177,
+            "line": 178,
           },
           "name": "podSecurityContext",
           "optional": true,
@@ -2954,7 +2954,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 252,
+        "line": 253,
       },
       "name": "MysqlPrimaryContainerSecurityContext",
       "properties": Array [
@@ -2969,7 +2969,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 268,
+            "line": 269,
           },
           "name": "additionalValues",
           "optional": true,
@@ -2992,7 +2992,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 256,
+            "line": 257,
           },
           "name": "enabled",
           "optional": true,
@@ -3010,7 +3010,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 261,
+            "line": 262,
           },
           "name": "runAsUser",
           "optional": true,
@@ -3033,7 +3033,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 275,
+        "line": 276,
       },
       "name": "MysqlPrimaryPersistence",
       "properties": Array [
@@ -3048,7 +3048,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 291,
+            "line": 292,
           },
           "name": "additionalValues",
           "optional": true,
@@ -3071,7 +3071,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 279,
+            "line": 280,
           },
           "name": "enabled",
           "optional": true,
@@ -3089,7 +3089,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 284,
+            "line": 285,
           },
           "name": "size",
           "optional": true,
@@ -3112,7 +3112,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 229,
+        "line": 230,
       },
       "name": "MysqlPrimaryPodSecurityContext",
       "properties": Array [
@@ -3127,7 +3127,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 245,
+            "line": 246,
           },
           "name": "additionalValues",
           "optional": true,
@@ -3150,7 +3150,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 233,
+            "line": 234,
           },
           "name": "enabled",
           "optional": true,
@@ -3168,7 +3168,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 238,
+            "line": 239,
           },
           "name": "fsGroup",
           "optional": true,
@@ -3275,7 +3275,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 201,
+        "line": 202,
       },
       "name": "MysqlSecondary",
       "properties": Array [
@@ -3290,7 +3290,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 222,
+            "line": 223,
           },
           "name": "additionalValues",
           "optional": true,
@@ -3313,7 +3313,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 210,
+            "line": 211,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -3331,7 +3331,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 215,
+            "line": 216,
           },
           "name": "persistence",
           "optional": true,
@@ -3349,7 +3349,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 205,
+            "line": 206,
           },
           "name": "podSecurityContext",
           "optional": true,
@@ -3372,7 +3372,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 321,
+        "line": 322,
       },
       "name": "MysqlSecondaryContainerSecurityContext",
       "properties": Array [
@@ -3387,7 +3387,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 337,
+            "line": 338,
           },
           "name": "additionalValues",
           "optional": true,
@@ -3410,7 +3410,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 325,
+            "line": 326,
           },
           "name": "enabled",
           "optional": true,
@@ -3428,7 +3428,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 330,
+            "line": 331,
           },
           "name": "runAsUser",
           "optional": true,
@@ -3451,7 +3451,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 344,
+        "line": 345,
       },
       "name": "MysqlSecondaryPersistence",
       "properties": Array [
@@ -3466,7 +3466,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 360,
+            "line": 361,
           },
           "name": "additionalValues",
           "optional": true,
@@ -3489,7 +3489,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 348,
+            "line": 349,
           },
           "name": "enabled",
           "optional": true,
@@ -3507,7 +3507,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 353,
+            "line": 354,
           },
           "name": "size",
           "optional": true,
@@ -3530,7 +3530,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 298,
+        "line": 299,
       },
       "name": "MysqlSecondaryPodSecurityContext",
       "properties": Array [
@@ -3545,7 +3545,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 314,
+            "line": 315,
           },
           "name": "additionalValues",
           "optional": true,
@@ -3568,7 +3568,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 302,
+            "line": 303,
           },
           "name": "enabled",
           "optional": true,
@@ -3586,7 +3586,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 307,
+            "line": 308,
           },
           "name": "fsGroup",
           "optional": true,
@@ -3609,7 +3609,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 65,
+        "line": 66,
       },
       "name": "MysqlValues",
       "properties": Array [
@@ -3624,7 +3624,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 103,
+            "line": 104,
           },
           "name": "additionalValues",
           "optional": true,
@@ -3648,7 +3648,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 71,
+            "line": 72,
           },
           "name": "architecture",
           "optional": true,
@@ -3666,7 +3666,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 76,
+            "line": 77,
           },
           "name": "auth",
           "optional": true,
@@ -3684,7 +3684,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 91,
+            "line": 92,
           },
           "name": "common",
           "optional": true,
@@ -3707,7 +3707,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 96,
+            "line": 97,
           },
           "name": "global",
           "optional": true,
@@ -3730,7 +3730,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 81,
+            "line": 82,
           },
           "name": "primary",
           "optional": true,
@@ -3748,7 +3748,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 86,
+            "line": 87,
           },
           "name": "secondary",
           "optional": true,
@@ -3780,7 +3780,7 @@ export interface MysqlProps {
 
 export class Mysql extends Construct {
   public constructor(scope: Construct, id: string, props: MysqlProps = {}) {
-    super(scope, id)
+    super(scope, id);
     let updatedProps = {};
 
     if (props.values) {
@@ -3790,7 +3790,7 @@ export class Mysql extends Construct {
         values: {
           ...this.flattenAdditionalValues(valuesWithoutAdditionalValues),
           ...additionalValues,
-        }
+        },
       };
     }
 
@@ -3801,333 +3801,334 @@ export class Mysql extends Construct {
       ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
     };
 
-    new Helm(scope, \`Helm\${id}\`, finalProps)
+    new Helm(this, 'Helm', finalProps);
   }
 
   private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
     for (let prop in props) {
       if (Array.isArray(props[prop])) {
         props[prop].map((item: any) => {
-          if (typeof(item) === 'object' && prop !== 'additionalValues') {
+          if (typeof item === 'object' && prop !== 'additionalValues') {
             return this.flattenAdditionalValues(item);
           }
           return item;
         });
-        } else if (typeof(props[prop]) === 'object' && prop !== 'additionalValues') {
-          props[prop] = this.flattenAdditionalValues(props[prop]);
-        }
       }
-
-      const { additionalValues, ...valuesWithoutAdditionalValues } = props;
-
-      return {
-        ...valuesWithoutAdditionalValues,
-        ...additionalValues,
-      };
+      else if (typeof props[prop] === 'object' && prop !== 'additionalValues') {
+        props[prop] = this.flattenAdditionalValues(props[prop]);
+      }
     }
+
+    const { additionalValues, ...valuesWithoutAdditionalValues } = props;
+
+    return {
+      ...valuesWithoutAdditionalValues,
+      ...additionalValues,
+    };
   }
+}
 
-  /**
-   * @schema mysql
-   */
-  export interface MysqlValues {
-    /**
-     * Allowed values: \`standalone\` or \`replication\`
-     *
-     * @schema mysql#architecture
-     */
-    readonly architecture?: MysqlArchitecture;
-
-    /**
-     * @schema mysql#auth
-     */
-    readonly auth?: MysqlAuth;
-
-    /**
-     * @schema mysql#primary
-     */
-    readonly primary?: MysqlPrimary;
-
-    /**
-     * @schema mysql#secondary
-     */
-    readonly secondary?: MysqlSecondary;
-
-    /**
-     * @schema mysql#common
-     */
-    readonly common?: { [key: string]: any };
-
-    /**
-     * @schema mysql#global
-     */
-    readonly global?: { [key: string]: any };
-
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema mysql#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
-
-  }
-
+/**
+ * @schema mysql
+ */
+export interface MysqlValues {
   /**
    * Allowed values: \`standalone\` or \`replication\`
    *
-   * @schema MysqlArchitecture
+   * @schema mysql#architecture
    */
-  export enum MysqlArchitecture {
-    /** standalone */
-    STANDALONE = \\"standalone\\",
-    /** replication */
-    REPLICATION = \\"replication\\",
-  }
+  readonly architecture?: MysqlArchitecture;
 
   /**
-   * @schema MysqlAuth
+   * @schema mysql#auth
    */
-  export interface MysqlAuth {
-    /**
-     * Defaults to a random 10-character alphanumeric string if not set
-     *
-     * @default a random 10-character alphanumeric string if not set
-     * @schema MysqlAuth#rootPassword
-     */
-    readonly rootPassword?: string;
-
-    /**
-     * @schema MysqlAuth#database
-     */
-    readonly database?: string;
-
-    /**
-     * @schema MysqlAuth#username
-     */
-    readonly username: string;
-
-    /**
-     * @schema MysqlAuth#password
-     */
-    readonly password: string;
-
-    /**
-     * @schema MysqlAuth#replicationUser
-     */
-    readonly replicationUser?: string;
-
-    /**
-     * @schema MysqlAuth#replicationPassword
-     */
-    readonly replicationPassword?: string;
-
-    /**
-     * @schema MysqlAuth#createDatabase
-     */
-    readonly createDatabase?: boolean;
-
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema MysqlAuth#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
-
-  }
+  readonly auth?: MysqlAuth;
 
   /**
-   * @schema MysqlPrimary
+   * @schema mysql#primary
    */
-  export interface MysqlPrimary {
-    /**
-     * @schema MysqlPrimary#podSecurityContext
-     */
-    readonly podSecurityContext?: MysqlPrimaryPodSecurityContext;
-
-    /**
-     * @schema MysqlPrimary#containerSecurityContext
-     */
-    readonly containerSecurityContext?: MysqlPrimaryContainerSecurityContext;
-
-    /**
-     * @schema MysqlPrimary#persistence
-     */
-    readonly persistence?: MysqlPrimaryPersistence;
-
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema MysqlPrimary#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
-
-  }
+  readonly primary?: MysqlPrimary;
 
   /**
-   * @schema MysqlSecondary
+   * @schema mysql#secondary
    */
-  export interface MysqlSecondary {
-    /**
-     * @schema MysqlSecondary#podSecurityContext
-     */
-    readonly podSecurityContext?: MysqlSecondaryPodSecurityContext;
-
-    /**
-     * @schema MysqlSecondary#containerSecurityContext
-     */
-    readonly containerSecurityContext?: MysqlSecondaryContainerSecurityContext;
-
-    /**
-     * @schema MysqlSecondary#persistence
-     */
-    readonly persistence?: MysqlSecondaryPersistence;
-
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema MysqlSecondary#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
-
-  }
+  readonly secondary?: MysqlSecondary;
 
   /**
-   * @schema MysqlPrimaryPodSecurityContext
+   * @schema mysql#common
    */
-  export interface MysqlPrimaryPodSecurityContext {
-    /**
-     * @schema MysqlPrimaryPodSecurityContext#enabled
-     */
-    readonly enabled?: boolean;
-
-    /**
-     * @schema MysqlPrimaryPodSecurityContext#fsGroup
-     */
-    readonly fsGroup?: number;
-
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema MysqlPrimaryPodSecurityContext#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
-
-  }
+  readonly common?: { [key: string]: any };
 
   /**
-   * @schema MysqlPrimaryContainerSecurityContext
+   * @schema mysql#global
    */
-  export interface MysqlPrimaryContainerSecurityContext {
-    /**
-     * @schema MysqlPrimaryContainerSecurityContext#enabled
-     */
-    readonly enabled?: boolean;
-
-    /**
-     * @schema MysqlPrimaryContainerSecurityContext#runAsUser
-     */
-    readonly runAsUser?: number;
-
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema MysqlPrimaryContainerSecurityContext#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
-
-  }
+  readonly global?: { [key: string]: any };
 
   /**
-   * @schema MysqlPrimaryPersistence
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema mysql#additionalValues
    */
-  export interface MysqlPrimaryPersistence {
-    /**
-     * @schema MysqlPrimaryPersistence#enabled
-     */
-    readonly enabled?: boolean;
+  readonly additionalValues?: { [key: string]: any };
 
-    /**
-     * @schema MysqlPrimaryPersistence#size
-     */
-    readonly size?: string;
+}
 
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema MysqlPrimaryPersistence#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
+/**
+ * Allowed values: \`standalone\` or \`replication\`
+ *
+ * @schema MysqlArchitecture
+ */
+export enum MysqlArchitecture {
+  /** standalone */
+  STANDALONE = \\"standalone\\",
+  /** replication */
+  REPLICATION = \\"replication\\",
+}
 
-  }
+/**
+ * @schema MysqlAuth
+ */
+export interface MysqlAuth {
+  /**
+   * Defaults to a random 10-character alphanumeric string if not set
+   *
+   * @default a random 10-character alphanumeric string if not set
+   * @schema MysqlAuth#rootPassword
+   */
+  readonly rootPassword?: string;
 
   /**
-   * @schema MysqlSecondaryPodSecurityContext
+   * @schema MysqlAuth#database
    */
-  export interface MysqlSecondaryPodSecurityContext {
-    /**
-     * @schema MysqlSecondaryPodSecurityContext#enabled
-     */
-    readonly enabled?: boolean;
-
-    /**
-     * @schema MysqlSecondaryPodSecurityContext#fsGroup
-     */
-    readonly fsGroup?: number;
-
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema MysqlSecondaryPodSecurityContext#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
-
-  }
+  readonly database?: string;
 
   /**
-   * @schema MysqlSecondaryContainerSecurityContext
+   * @schema MysqlAuth#username
    */
-  export interface MysqlSecondaryContainerSecurityContext {
-    /**
-     * @schema MysqlSecondaryContainerSecurityContext#enabled
-     */
-    readonly enabled?: boolean;
-
-    /**
-     * @schema MysqlSecondaryContainerSecurityContext#runAsUser
-     */
-    readonly runAsUser?: number;
-
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema MysqlSecondaryContainerSecurityContext#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
-
-  }
+  readonly username: string;
 
   /**
-   * @schema MysqlSecondaryPersistence
+   * @schema MysqlAuth#password
    */
-  export interface MysqlSecondaryPersistence {
-    /**
-     * @schema MysqlSecondaryPersistence#enabled
-     */
-    readonly enabled?: boolean;
+  readonly password: string;
 
-    /**
-     * @schema MysqlSecondaryPersistence#size
-     */
-    readonly size?: string;
+  /**
+   * @schema MysqlAuth#replicationUser
+   */
+  readonly replicationUser?: string;
 
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema MysqlSecondaryPersistence#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
+  /**
+   * @schema MysqlAuth#replicationPassword
+   */
+  readonly replicationPassword?: string;
 
-  }
+  /**
+   * @schema MysqlAuth#createDatabase
+   */
+  readonly createDatabase?: boolean;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlAuth#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema MysqlPrimary
+ */
+export interface MysqlPrimary {
+  /**
+   * @schema MysqlPrimary#podSecurityContext
+   */
+  readonly podSecurityContext?: MysqlPrimaryPodSecurityContext;
+
+  /**
+   * @schema MysqlPrimary#containerSecurityContext
+   */
+  readonly containerSecurityContext?: MysqlPrimaryContainerSecurityContext;
+
+  /**
+   * @schema MysqlPrimary#persistence
+   */
+  readonly persistence?: MysqlPrimaryPersistence;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlPrimary#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema MysqlSecondary
+ */
+export interface MysqlSecondary {
+  /**
+   * @schema MysqlSecondary#podSecurityContext
+   */
+  readonly podSecurityContext?: MysqlSecondaryPodSecurityContext;
+
+  /**
+   * @schema MysqlSecondary#containerSecurityContext
+   */
+  readonly containerSecurityContext?: MysqlSecondaryContainerSecurityContext;
+
+  /**
+   * @schema MysqlSecondary#persistence
+   */
+  readonly persistence?: MysqlSecondaryPersistence;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlSecondary#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema MysqlPrimaryPodSecurityContext
+ */
+export interface MysqlPrimaryPodSecurityContext {
+  /**
+   * @schema MysqlPrimaryPodSecurityContext#enabled
+   */
+  readonly enabled?: boolean;
+
+  /**
+   * @schema MysqlPrimaryPodSecurityContext#fsGroup
+   */
+  readonly fsGroup?: number;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlPrimaryPodSecurityContext#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema MysqlPrimaryContainerSecurityContext
+ */
+export interface MysqlPrimaryContainerSecurityContext {
+  /**
+   * @schema MysqlPrimaryContainerSecurityContext#enabled
+   */
+  readonly enabled?: boolean;
+
+  /**
+   * @schema MysqlPrimaryContainerSecurityContext#runAsUser
+   */
+  readonly runAsUser?: number;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlPrimaryContainerSecurityContext#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema MysqlPrimaryPersistence
+ */
+export interface MysqlPrimaryPersistence {
+  /**
+   * @schema MysqlPrimaryPersistence#enabled
+   */
+  readonly enabled?: boolean;
+
+  /**
+   * @schema MysqlPrimaryPersistence#size
+   */
+  readonly size?: string;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlPrimaryPersistence#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema MysqlSecondaryPodSecurityContext
+ */
+export interface MysqlSecondaryPodSecurityContext {
+  /**
+   * @schema MysqlSecondaryPodSecurityContext#enabled
+   */
+  readonly enabled?: boolean;
+
+  /**
+   * @schema MysqlSecondaryPodSecurityContext#fsGroup
+   */
+  readonly fsGroup?: number;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlSecondaryPodSecurityContext#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema MysqlSecondaryContainerSecurityContext
+ */
+export interface MysqlSecondaryContainerSecurityContext {
+  /**
+   * @schema MysqlSecondaryContainerSecurityContext#enabled
+   */
+  readonly enabled?: boolean;
+
+  /**
+   * @schema MysqlSecondaryContainerSecurityContext#runAsUser
+   */
+  readonly runAsUser?: number;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlSecondaryContainerSecurityContext#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema MysqlSecondaryPersistence
+ */
+export interface MysqlSecondaryPersistence {
+  /**
+   * @schema MysqlSecondaryPersistence#enabled
+   */
+  readonly enabled?: boolean;
+
+  /**
+   * @schema MysqlSecondaryPersistence#size
+   */
+  readonly size?: string;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema MysqlSecondaryPersistence#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
 
 ",
 }
@@ -4793,7 +4794,7 @@ export interface LokiProps {
 
 export class Loki extends Construct {
   public constructor(scope: Construct, id: string, props: LokiProps = {}) {
-    super(scope, id)
+    super(scope, id);
     let updatedProps = {};
 
     if (props.values) {
@@ -4803,7 +4804,7 @@ export class Loki extends Construct {
         values: {
           ...this.flattenAdditionalValues(valuesWithoutAdditionalValues),
           ...additionalValues,
-        }
+        },
       };
     }
 
@@ -4814,31 +4815,32 @@ export class Loki extends Construct {
       ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
     };
 
-    new Helm(scope, \`Helm\${id}\`, finalProps)
+    new Helm(this, 'Helm', finalProps);
   }
 
   private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
     for (let prop in props) {
       if (Array.isArray(props[prop])) {
         props[prop].map((item: any) => {
-          if (typeof(item) === 'object' && prop !== 'additionalValues') {
+          if (typeof item === 'object' && prop !== 'additionalValues') {
             return this.flattenAdditionalValues(item);
           }
           return item;
         });
-        } else if (typeof(props[prop]) === 'object' && prop !== 'additionalValues') {
-          props[prop] = this.flattenAdditionalValues(props[prop]);
-        }
       }
-
-      const { additionalValues, ...valuesWithoutAdditionalValues } = props;
-
-      return {
-        ...valuesWithoutAdditionalValues,
-        ...additionalValues,
-      };
+      else if (typeof props[prop] === 'object' && prop !== 'additionalValues') {
+        props[prop] = this.flattenAdditionalValues(props[prop]);
+      }
     }
+
+    const { additionalValues, ...valuesWithoutAdditionalValues } = props;
+
+    return {
+      ...valuesWithoutAdditionalValues,
+      ...additionalValues,
+    };
   }
+}
 
 ",
 }
@@ -5504,7 +5506,7 @@ export interface IngressnginxProps {
 
 export class Ingressnginx extends Construct {
   public constructor(scope: Construct, id: string, props: IngressnginxProps = {}) {
-    super(scope, id)
+    super(scope, id);
     let updatedProps = {};
 
     if (props.values) {
@@ -5514,7 +5516,7 @@ export class Ingressnginx extends Construct {
         values: {
           ...this.flattenAdditionalValues(valuesWithoutAdditionalValues),
           ...additionalValues,
-        }
+        },
       };
     }
 
@@ -5525,31 +5527,32 @@ export class Ingressnginx extends Construct {
       ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
     };
 
-    new Helm(scope, \`Helm\${id}\`, finalProps)
+    new Helm(this, 'Helm', finalProps);
   }
 
   private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
     for (let prop in props) {
       if (Array.isArray(props[prop])) {
         props[prop].map((item: any) => {
-          if (typeof(item) === 'object' && prop !== 'additionalValues') {
+          if (typeof item === 'object' && prop !== 'additionalValues') {
             return this.flattenAdditionalValues(item);
           }
           return item;
         });
-        } else if (typeof(props[prop]) === 'object' && prop !== 'additionalValues') {
-          props[prop] = this.flattenAdditionalValues(props[prop]);
-        }
       }
-
-      const { additionalValues, ...valuesWithoutAdditionalValues } = props;
-
-      return {
-        ...valuesWithoutAdditionalValues,
-        ...additionalValues,
-      };
+      else if (typeof props[prop] === 'object' && prop !== 'additionalValues') {
+        props[prop] = this.flattenAdditionalValues(props[prop]);
+      }
     }
+
+    const { additionalValues, ...valuesWithoutAdditionalValues } = props;
+
+    return {
+      ...valuesWithoutAdditionalValues,
+      ...additionalValues,
+    };
   }
+}
 
 ",
 }
@@ -5657,7 +5660,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 590,
+        "line": 591,
       },
       "name": "IoK8SApiCoreV1Affinity",
       "properties": Array [
@@ -5672,7 +5675,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 596,
+            "line": 597,
           },
           "name": "nodeAffinity",
           "optional": true,
@@ -5691,7 +5694,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 603,
+            "line": 604,
           },
           "name": "podAffinity",
           "optional": true,
@@ -5710,7 +5713,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 610,
+            "line": 611,
           },
           "name": "podAntiAffinity",
           "optional": true,
@@ -5734,7 +5737,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 959,
+        "line": 960,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinity",
       "properties": Array [
@@ -5750,7 +5753,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 965,
+            "line": 966,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -5775,7 +5778,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 972,
+            "line": 973,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -5799,7 +5802,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1080,
+        "line": 1081,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -5815,7 +5818,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1086,
+            "line": 1087,
           },
           "name": "preference",
           "optional": true,
@@ -5834,7 +5837,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1093,
+            "line": 1094,
           },
           "name": "weight",
           "optional": true,
@@ -5859,7 +5862,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1233,
+        "line": 1234,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
       "properties": Array [
@@ -5874,7 +5877,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1239,
+            "line": 1240,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -5898,7 +5901,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1246,
+            "line": 1247,
           },
           "name": "matchFields",
           "optional": true,
@@ -5927,7 +5930,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1437,
+        "line": 1438,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
       "properties": Array [
@@ -5942,7 +5945,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1443,
+            "line": 1444,
           },
           "name": "key",
           "optional": true,
@@ -5968,7 +5971,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1458,
+            "line": 1459,
           },
           "name": "operator",
           "optional": true,
@@ -5988,7 +5991,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1465,
+            "line": 1466,
           },
           "name": "values",
           "optional": true,
@@ -6023,7 +6026,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1797,
+        "line": 1798,
       },
       "members": Array [
         Object {
@@ -6079,7 +6082,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1474,
+        "line": 1475,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
       "properties": Array [
@@ -6094,7 +6097,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1480,
+            "line": 1481,
           },
           "name": "key",
           "optional": true,
@@ -6120,7 +6123,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1495,
+            "line": 1496,
           },
           "name": "operator",
           "optional": true,
@@ -6140,7 +6143,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1502,
+            "line": 1503,
           },
           "name": "values",
           "optional": true,
@@ -6175,7 +6178,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1825,
+        "line": 1826,
       },
       "members": Array [
         Object {
@@ -6232,7 +6235,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1102,
+        "line": 1103,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -6248,7 +6251,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1108,
+            "line": 1109,
           },
           "name": "nodeSelectorTerms",
           "optional": true,
@@ -6278,7 +6281,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1255,
+        "line": 1256,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
       "properties": Array [
@@ -6293,7 +6296,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1261,
+            "line": 1262,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -6317,7 +6320,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1268,
+            "line": 1269,
           },
           "name": "matchFields",
           "optional": true,
@@ -6346,7 +6349,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1511,
+        "line": 1512,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
       "properties": Array [
@@ -6361,7 +6364,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1517,
+            "line": 1518,
           },
           "name": "key",
           "optional": true,
@@ -6387,7 +6390,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1532,
+            "line": 1533,
           },
           "name": "operator",
           "optional": true,
@@ -6407,7 +6410,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1539,
+            "line": 1540,
           },
           "name": "values",
           "optional": true,
@@ -6442,7 +6445,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1853,
+        "line": 1854,
       },
       "members": Array [
         Object {
@@ -6498,7 +6501,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1548,
+        "line": 1549,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
       "properties": Array [
@@ -6513,7 +6516,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1554,
+            "line": 1555,
           },
           "name": "key",
           "optional": true,
@@ -6539,7 +6542,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1569,
+            "line": 1570,
           },
           "name": "operator",
           "optional": true,
@@ -6559,7 +6562,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1576,
+            "line": 1577,
           },
           "name": "values",
           "optional": true,
@@ -6594,7 +6597,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1881,
+        "line": 1882,
       },
       "members": Array [
         Object {
@@ -6650,7 +6653,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 981,
+        "line": 982,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinity",
       "properties": Array [
@@ -6666,7 +6669,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 987,
+            "line": 988,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -6691,7 +6694,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 994,
+            "line": 995,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -6720,7 +6723,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1117,
+        "line": 1118,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -6735,7 +6738,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1123,
+            "line": 1124,
           },
           "name": "podAffinityTerm",
           "optional": true,
@@ -6754,7 +6757,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1130,
+            "line": 1131,
           },
           "name": "weight",
           "optional": true,
@@ -6778,7 +6781,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1277,
+        "line": 1278,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "properties": Array [
@@ -6794,7 +6797,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1304,
+            "line": 1305,
           },
           "name": "topologyKey",
           "type": Object {
@@ -6813,7 +6816,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1283,
+            "line": 1284,
           },
           "name": "labelSelector",
           "optional": true,
@@ -6833,7 +6836,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1297,
+            "line": 1298,
           },
           "name": "namespaces",
           "optional": true,
@@ -6858,7 +6861,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1290,
+            "line": 1291,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -6883,7 +6886,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1585,
+        "line": 1586,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "properties": Array [
@@ -6899,7 +6902,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1591,
+            "line": 1592,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -6924,7 +6927,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1598,
+            "line": 1599,
           },
           "name": "matchLabels",
           "optional": true,
@@ -6953,7 +6956,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1901,
+        "line": 1902,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "properties": Array [
@@ -6968,7 +6971,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1907,
+            "line": 1908,
           },
           "name": "key",
           "optional": true,
@@ -6988,7 +6991,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1914,
+            "line": 1915,
           },
           "name": "operator",
           "optional": true,
@@ -7008,7 +7011,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1921,
+            "line": 1922,
           },
           "name": "values",
           "optional": true,
@@ -7038,7 +7041,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1607,
+        "line": 1608,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
       "properties": Array [
@@ -7054,7 +7057,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1613,
+            "line": 1614,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -7079,7 +7082,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1620,
+            "line": 1621,
           },
           "name": "matchLabels",
           "optional": true,
@@ -7108,7 +7111,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1930,
+        "line": 1931,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -7123,7 +7126,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1936,
+            "line": 1937,
           },
           "name": "key",
           "optional": true,
@@ -7143,7 +7146,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1943,
+            "line": 1944,
           },
           "name": "operator",
           "optional": true,
@@ -7163,7 +7166,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1950,
+            "line": 1951,
           },
           "name": "values",
           "optional": true,
@@ -7192,7 +7195,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1139,
+        "line": 1140,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -7208,7 +7211,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1145,
+            "line": 1146,
           },
           "name": "labelSelector",
           "optional": true,
@@ -7228,7 +7231,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1159,
+            "line": 1160,
           },
           "name": "namespaces",
           "optional": true,
@@ -7253,7 +7256,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1152,
+            "line": 1153,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -7273,7 +7276,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1166,
+            "line": 1167,
           },
           "name": "topologyKey",
           "optional": true,
@@ -7298,7 +7301,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1313,
+        "line": 1314,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "properties": Array [
@@ -7314,7 +7317,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1319,
+            "line": 1320,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -7339,7 +7342,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1326,
+            "line": 1327,
           },
           "name": "matchLabels",
           "optional": true,
@@ -7368,7 +7371,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1629,
+        "line": 1630,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "properties": Array [
@@ -7383,7 +7386,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1635,
+            "line": 1636,
           },
           "name": "key",
           "optional": true,
@@ -7403,7 +7406,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1642,
+            "line": 1643,
           },
           "name": "operator",
           "optional": true,
@@ -7423,7 +7426,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1649,
+            "line": 1650,
           },
           "name": "values",
           "optional": true,
@@ -7453,7 +7456,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1335,
+        "line": 1336,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
       "properties": Array [
@@ -7469,7 +7472,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1341,
+            "line": 1342,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -7494,7 +7497,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1348,
+            "line": 1349,
           },
           "name": "matchLabels",
           "optional": true,
@@ -7523,7 +7526,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1658,
+        "line": 1659,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -7538,7 +7541,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1664,
+            "line": 1665,
           },
           "name": "key",
           "optional": true,
@@ -7558,7 +7561,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1671,
+            "line": 1672,
           },
           "name": "operator",
           "optional": true,
@@ -7578,7 +7581,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1678,
+            "line": 1679,
           },
           "name": "values",
           "optional": true,
@@ -7607,7 +7610,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1003,
+        "line": 1004,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinity",
       "properties": Array [
@@ -7623,7 +7626,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1009,
+            "line": 1010,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -7648,7 +7651,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1016,
+            "line": 1017,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -7677,7 +7680,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1175,
+        "line": 1176,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -7692,7 +7695,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1181,
+            "line": 1182,
           },
           "name": "podAffinityTerm",
           "optional": true,
@@ -7711,7 +7714,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1188,
+            "line": 1189,
           },
           "name": "weight",
           "optional": true,
@@ -7735,7 +7738,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1357,
+        "line": 1358,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "properties": Array [
@@ -7751,7 +7754,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1384,
+            "line": 1385,
           },
           "name": "topologyKey",
           "type": Object {
@@ -7770,7 +7773,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1363,
+            "line": 1364,
           },
           "name": "labelSelector",
           "optional": true,
@@ -7790,7 +7793,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1377,
+            "line": 1378,
           },
           "name": "namespaces",
           "optional": true,
@@ -7815,7 +7818,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1370,
+            "line": 1371,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -7840,7 +7843,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1687,
+        "line": 1688,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "properties": Array [
@@ -7856,7 +7859,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1693,
+            "line": 1694,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -7881,7 +7884,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1700,
+            "line": 1701,
           },
           "name": "matchLabels",
           "optional": true,
@@ -7910,7 +7913,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1959,
+        "line": 1960,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "properties": Array [
@@ -7925,7 +7928,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1965,
+            "line": 1966,
           },
           "name": "key",
           "optional": true,
@@ -7945,7 +7948,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1972,
+            "line": 1973,
           },
           "name": "operator",
           "optional": true,
@@ -7965,7 +7968,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1979,
+            "line": 1980,
           },
           "name": "values",
           "optional": true,
@@ -7995,7 +7998,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1709,
+        "line": 1710,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
       "properties": Array [
@@ -8011,7 +8014,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1715,
+            "line": 1716,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -8036,7 +8039,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1722,
+            "line": 1723,
           },
           "name": "matchLabels",
           "optional": true,
@@ -8065,7 +8068,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1988,
+        "line": 1989,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -8080,7 +8083,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1994,
+            "line": 1995,
           },
           "name": "key",
           "optional": true,
@@ -8100,7 +8103,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2001,
+            "line": 2002,
           },
           "name": "operator",
           "optional": true,
@@ -8120,7 +8123,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2008,
+            "line": 2009,
           },
           "name": "values",
           "optional": true,
@@ -8149,7 +8152,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1197,
+        "line": 1198,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -8165,7 +8168,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1203,
+            "line": 1204,
           },
           "name": "labelSelector",
           "optional": true,
@@ -8185,7 +8188,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1217,
+            "line": 1218,
           },
           "name": "namespaces",
           "optional": true,
@@ -8210,7 +8213,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1210,
+            "line": 1211,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -8230,7 +8233,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1224,
+            "line": 1225,
           },
           "name": "topologyKey",
           "optional": true,
@@ -8255,7 +8258,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1393,
+        "line": 1394,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "properties": Array [
@@ -8271,7 +8274,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1399,
+            "line": 1400,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -8296,7 +8299,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1406,
+            "line": 1407,
           },
           "name": "matchLabels",
           "optional": true,
@@ -8325,7 +8328,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1731,
+        "line": 1732,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "properties": Array [
@@ -8340,7 +8343,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1737,
+            "line": 1738,
           },
           "name": "key",
           "optional": true,
@@ -8360,7 +8363,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1744,
+            "line": 1745,
           },
           "name": "operator",
           "optional": true,
@@ -8380,7 +8383,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1751,
+            "line": 1752,
           },
           "name": "values",
           "optional": true,
@@ -8410,7 +8413,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1415,
+        "line": 1416,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
       "properties": Array [
@@ -8426,7 +8429,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1421,
+            "line": 1422,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -8451,7 +8454,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1428,
+            "line": 1429,
           },
           "name": "matchLabels",
           "optional": true,
@@ -8480,7 +8483,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1760,
+        "line": 1761,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -8495,7 +8498,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1766,
+            "line": 1767,
           },
           "name": "key",
           "optional": true,
@@ -8515,7 +8518,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1773,
+            "line": 1774,
           },
           "name": "operator",
           "optional": true,
@@ -8535,7 +8538,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1780,
+            "line": 1781,
           },
           "name": "values",
           "optional": true,
@@ -8564,7 +8567,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 619,
+        "line": 620,
       },
       "name": "IoK8SApiCoreV1DaemonSetUpdateStrategy",
       "properties": Array [
@@ -8579,7 +8582,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 625,
+            "line": 626,
           },
           "name": "rollingUpdate",
           "optional": true,
@@ -8602,7 +8605,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 637,
+            "line": 638,
           },
           "name": "type",
           "optional": true,
@@ -8626,7 +8629,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1025,
+        "line": 1026,
       },
       "name": "IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
       "properties": Array [
@@ -8640,7 +8643,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1029,
+            "line": 1030,
           },
           "name": "maxSurge",
           "optional": true,
@@ -8658,7 +8661,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1034,
+            "line": 1035,
           },
           "name": "maxUnavailable",
           "optional": true,
@@ -8685,7 +8688,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1048,
+        "line": 1049,
       },
       "members": Array [
         Object {
@@ -8717,7 +8720,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 657,
+        "line": 658,
       },
       "name": "IoK8SApiCoreV1LocalObjectReference",
       "properties": Array [
@@ -8733,7 +8736,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 663,
+            "line": 664,
           },
           "name": "name",
           "optional": true,
@@ -8757,7 +8760,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 515,
+        "line": 516,
       },
       "name": "IoK8SApiCoreV1ResourceRequirements",
       "properties": Array [
@@ -8773,7 +8776,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 521,
+            "line": 522,
           },
           "name": "limits",
           "optional": true,
@@ -8798,7 +8801,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 528,
+            "line": 529,
           },
           "name": "requests",
           "optional": true,
@@ -8827,7 +8830,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 537,
+        "line": 538,
       },
       "name": "IoK8SApiCoreV1Toleration",
       "properties": Array [
@@ -8848,7 +8851,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 548,
+            "line": 549,
           },
           "name": "effect",
           "optional": true,
@@ -8868,7 +8871,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 555,
+            "line": 556,
           },
           "name": "key",
           "optional": true,
@@ -8893,7 +8896,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 567,
+            "line": 568,
           },
           "name": "operator",
           "optional": true,
@@ -8913,7 +8916,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 574,
+            "line": 575,
           },
           "name": "tolerationSeconds",
           "optional": true,
@@ -8933,7 +8936,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 581,
+            "line": 582,
           },
           "name": "value",
           "optional": true,
@@ -8962,7 +8965,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 928,
+        "line": 929,
       },
       "members": Array [
         Object {
@@ -9005,7 +9008,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 947,
+        "line": 948,
       },
       "members": Array [
         Object {
@@ -9036,7 +9039,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 242,
+        "line": 243,
       },
       "name": "LaceworkAgentCloudservice",
       "properties": Array [
@@ -9050,7 +9053,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 246,
+            "line": 247,
           },
           "name": "gke",
           "optional": true,
@@ -9073,7 +9076,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 644,
+        "line": 645,
       },
       "name": "LaceworkAgentCloudserviceGke",
       "properties": Array [
@@ -9087,7 +9090,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 648,
+            "line": 649,
           },
           "name": "autopilot",
           "optional": true,
@@ -9110,7 +9113,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 326,
+        "line": 327,
       },
       "name": "LaceworkAgentClusterAgent",
       "properties": Array [
@@ -9125,7 +9128,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 337,
+            "line": 338,
           },
           "name": "enable",
           "type": Object {
@@ -9142,7 +9145,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 330,
+            "line": 331,
           },
           "name": "image",
           "type": Object {
@@ -9160,7 +9163,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 372,
+            "line": 373,
           },
           "name": "additionalValues",
           "optional": true,
@@ -9184,7 +9187,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 351,
+            "line": 352,
           },
           "name": "clusterRegion",
           "optional": true,
@@ -9203,7 +9206,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 344,
+            "line": 345,
           },
           "name": "clusterType",
           "optional": true,
@@ -9222,7 +9225,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 358,
+            "line": 359,
           },
           "name": "scrapeInitialDelayMins",
           "optional": true,
@@ -9241,7 +9244,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 365,
+            "line": 366,
           },
           "name": "scrapeIntervalMins",
           "optional": true,
@@ -9264,7 +9267,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 740,
+        "line": 741,
       },
       "members": Array [
         Object {
@@ -9301,7 +9304,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 690,
+        "line": 691,
       },
       "name": "LaceworkAgentClusterAgentImage",
       "properties": Array [
@@ -9323,7 +9326,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 709,
+            "line": 710,
           },
           "name": "pullPolicy",
           "type": Object {
@@ -9340,7 +9343,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 714,
+            "line": 715,
           },
           "name": "registry",
           "type": Object {
@@ -9357,7 +9360,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 719,
+            "line": 720,
           },
           "name": "repository",
           "type": Object {
@@ -9374,7 +9377,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 724,
+            "line": 725,
           },
           "name": "tag",
           "type": Object {
@@ -9392,7 +9395,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 731,
+            "line": 732,
           },
           "name": "additionalValues",
           "optional": true,
@@ -9417,7 +9420,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 696,
+            "line": 697,
           },
           "name": "imagePullSecrets",
           "optional": true,
@@ -9452,7 +9455,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1066,
+        "line": 1067,
       },
       "members": Array [
         Object {
@@ -9489,7 +9492,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 160,
+        "line": 161,
       },
       "name": "LaceworkAgentDaemonset",
       "properties": Array [
@@ -9504,7 +9507,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 166,
+            "line": 167,
           },
           "name": "affinity",
           "type": Object {
@@ -9522,7 +9525,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 173,
+            "line": 174,
           },
           "name": "updateStrategy",
           "type": Object {
@@ -9544,7 +9547,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 253,
+        "line": 254,
       },
       "name": "LaceworkAgentDatacollector",
       "properties": Array [
@@ -9559,7 +9562,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 266,
+            "line": 267,
           },
           "name": "additionalValues",
           "optional": true,
@@ -9583,7 +9586,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 259,
+            "line": 260,
           },
           "name": "enable",
           "optional": true,
@@ -9606,7 +9609,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 180,
+        "line": 181,
       },
       "name": "LaceworkAgentDeployment",
       "properties": Array [
@@ -9621,7 +9624,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 186,
+            "line": 187,
           },
           "name": "affinity",
           "type": Object {
@@ -9639,7 +9642,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 193,
+            "line": 194,
           },
           "name": "updateStrategy",
           "type": Object {
@@ -9657,7 +9660,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 214,
+            "line": 215,
           },
           "name": "priorityClassCreate",
           "optional": true,
@@ -9677,7 +9680,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 207,
+            "line": 208,
           },
           "name": "priorityClassName",
           "optional": true,
@@ -9696,7 +9699,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 221,
+            "line": 222,
           },
           "name": "priorityClassPreemptionPolicy",
           "optional": true,
@@ -9715,7 +9718,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 228,
+            "line": 229,
           },
           "name": "priorityClassValue",
           "optional": true,
@@ -9735,7 +9738,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 200,
+            "line": 201,
           },
           "name": "resources",
           "optional": true,
@@ -9754,7 +9757,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 235,
+            "line": 236,
           },
           "name": "tolerations",
           "optional": true,
@@ -9782,7 +9785,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 273,
+        "line": 274,
       },
       "name": "LaceworkAgentImage",
       "properties": Array [
@@ -9804,7 +9807,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 292,
+            "line": 293,
           },
           "name": "pullPolicy",
           "type": Object {
@@ -9821,7 +9824,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 297,
+            "line": 298,
           },
           "name": "registry",
           "type": Object {
@@ -9838,7 +9841,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 302,
+            "line": 303,
           },
           "name": "repository",
           "type": Object {
@@ -9855,7 +9858,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 307,
+            "line": 308,
           },
           "name": "tag",
           "type": Object {
@@ -9873,7 +9876,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 319,
+            "line": 320,
           },
           "name": "additionalValues",
           "optional": true,
@@ -9898,7 +9901,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 279,
+            "line": 280,
           },
           "name": "imagePullSecrets",
           "optional": true,
@@ -9921,7 +9924,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 312,
+            "line": 313,
           },
           "name": "overrideValue",
           "optional": true,
@@ -9951,7 +9954,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 678,
+        "line": 679,
       },
       "members": Array [
         Object {
@@ -9988,7 +9991,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 379,
+        "line": 380,
       },
       "name": "LaceworkAgentLaceworkConfig",
       "properties": Array [
@@ -10002,7 +10005,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 383,
+            "line": 384,
           },
           "name": "accessToken",
           "type": Object {
@@ -10020,7 +10023,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 506,
+            "line": 507,
           },
           "name": "additionalValues",
           "optional": true,
@@ -10045,7 +10048,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 395,
+            "line": 396,
           },
           "name": "annotations",
           "optional": true,
@@ -10068,7 +10071,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 388,
+            "line": 389,
           },
           "name": "anonymizeIncoming",
           "optional": true,
@@ -10086,7 +10089,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 400,
+            "line": 401,
           },
           "name": "autoUpgrade",
           "optional": true,
@@ -10104,7 +10107,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 405,
+            "line": 406,
           },
           "name": "cmdlinefilter",
           "optional": true,
@@ -10122,7 +10125,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 410,
+            "line": 411,
           },
           "name": "codeaware",
           "optional": true,
@@ -10140,7 +10143,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 415,
+            "line": 416,
           },
           "name": "containerEngineEndpoint",
           "optional": true,
@@ -10158,7 +10161,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 420,
+            "line": 421,
           },
           "name": "containerRuntime",
           "optional": true,
@@ -10176,7 +10179,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 425,
+            "line": 426,
           },
           "name": "datacollector",
           "optional": true,
@@ -10194,7 +10197,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 454,
+            "line": 455,
           },
           "name": "env",
           "optional": true,
@@ -10212,7 +10215,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 459,
+            "line": 460,
           },
           "name": "fim",
           "optional": true,
@@ -10231,7 +10234,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 432,
+            "line": 433,
           },
           "name": "k8SNodeScrapeIntervalMins",
           "optional": true,
@@ -10249,7 +10252,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 437,
+            "line": 438,
           },
           "name": "kubernetesCluster",
           "optional": true,
@@ -10269,7 +10272,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 444,
+            "line": 445,
           },
           "name": "labels",
           "optional": true,
@@ -10292,7 +10295,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 449,
+            "line": 450,
           },
           "name": "metadataRequestInterval",
           "optional": true,
@@ -10310,7 +10313,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 464,
+            "line": 465,
           },
           "name": "packagescan",
           "optional": true,
@@ -10328,7 +10331,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 499,
+            "line": 500,
           },
           "name": "perfmode",
           "optional": true,
@@ -10346,7 +10349,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 469,
+            "line": 470,
           },
           "name": "procscan",
           "optional": true,
@@ -10364,7 +10367,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 474,
+            "line": 475,
           },
           "name": "proxyUrl",
           "optional": true,
@@ -10382,7 +10385,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 479,
+            "line": 480,
           },
           "name": "serverUrl",
           "optional": true,
@@ -10400,7 +10403,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 484,
+            "line": 485,
           },
           "name": "serviceAccountName",
           "optional": true,
@@ -10418,7 +10421,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 489,
+            "line": 490,
           },
           "name": "stdoutLogging",
           "optional": true,
@@ -10436,7 +10439,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 494,
+            "line": 495,
           },
           "name": "tags",
           "optional": true,
@@ -10464,7 +10467,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 752,
+        "line": 753,
       },
       "name": "LaceworkAgentLaceworkConfigAnonymizeIncoming",
       "properties": Array [
@@ -10479,7 +10482,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 763,
+            "line": 764,
           },
           "name": "additionalValues",
           "optional": true,
@@ -10502,7 +10505,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 756,
+            "line": 757,
           },
           "name": "netmask",
           "optional": true,
@@ -10524,7 +10527,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 770,
+        "line": 771,
       },
       "members": Array [
         Object {
@@ -10555,7 +10558,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 780,
+        "line": 781,
       },
       "name": "LaceworkAgentLaceworkConfigCmdlinefilter",
       "properties": Array [
@@ -10569,7 +10572,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 784,
+            "line": 785,
           },
           "name": "allow",
           "optional": true,
@@ -10587,7 +10590,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 789,
+            "line": 790,
           },
           "name": "disallow",
           "optional": true,
@@ -10610,7 +10613,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 796,
+        "line": 797,
       },
       "name": "LaceworkAgentLaceworkConfigCodeaware",
       "properties": Array [
@@ -10624,7 +10627,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 800,
+            "line": 801,
           },
           "name": "enable",
           "optional": true,
@@ -10646,7 +10649,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 807,
+        "line": 808,
       },
       "members": Array [
         Object {
@@ -10682,7 +10685,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 819,
+        "line": 820,
       },
       "members": Array [
         Object {
@@ -10713,7 +10716,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 829,
+        "line": 830,
       },
       "name": "LaceworkAgentLaceworkConfigFim",
       "properties": Array [
@@ -10727,7 +10730,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 843,
+            "line": 844,
           },
           "name": "enable",
           "type": Object {
@@ -10744,7 +10747,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 848,
+            "line": 849,
           },
           "name": "fileIgnore",
           "type": Object {
@@ -10766,7 +10769,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 853,
+            "line": 854,
           },
           "name": "filePath",
           "type": Object {
@@ -10789,7 +10792,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 870,
+            "line": 871,
           },
           "name": "additionalValues",
           "optional": true,
@@ -10812,7 +10815,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 833,
+            "line": 834,
           },
           "name": "coolingPeriod",
           "optional": true,
@@ -10830,7 +10833,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 838,
+            "line": 839,
           },
           "name": "crawlInterval",
           "optional": true,
@@ -10848,7 +10851,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 858,
+            "line": 859,
           },
           "name": "noAtime",
           "optional": true,
@@ -10866,7 +10869,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 863,
+            "line": 864,
           },
           "name": "runAt",
           "optional": true,
@@ -10889,7 +10892,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 877,
+        "line": 878,
       },
       "name": "LaceworkAgentLaceworkConfigPackagescan",
       "properties": Array [
@@ -10903,7 +10906,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 881,
+            "line": 882,
           },
           "name": "enable",
           "optional": true,
@@ -10921,7 +10924,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 886,
+            "line": 887,
           },
           "name": "interval",
           "optional": true,
@@ -10943,7 +10946,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 909,
+        "line": 910,
       },
       "members": Array [
         Object {
@@ -10980,7 +10983,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 893,
+        "line": 894,
       },
       "name": "LaceworkAgentLaceworkConfigProcscan",
       "properties": Array [
@@ -10994,7 +10997,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 897,
+            "line": 898,
           },
           "name": "enable",
           "optional": true,
@@ -11012,7 +11015,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 902,
+            "line": 903,
           },
           "name": "interval",
           "optional": true,
@@ -11156,7 +11159,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 65,
+        "line": 66,
       },
       "name": "LaceworkagentValues",
       "properties": Array [
@@ -11170,7 +11173,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 104,
+            "line": 105,
           },
           "name": "laceworkConfig",
           "type": Object {
@@ -11188,7 +11191,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 153,
+            "line": 154,
           },
           "name": "additionalValues",
           "optional": true,
@@ -11211,7 +11214,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 84,
+            "line": 85,
           },
           "name": "cloudservice",
           "optional": true,
@@ -11229,7 +11232,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 99,
+            "line": 100,
           },
           "name": "clusterAgent",
           "optional": true,
@@ -11247,7 +11250,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 74,
+            "line": 75,
           },
           "name": "daemonset",
           "optional": true,
@@ -11265,7 +11268,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 89,
+            "line": 90,
           },
           "name": "datacollector",
           "optional": true,
@@ -11283,7 +11286,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 79,
+            "line": 80,
           },
           "name": "deployment",
           "optional": true,
@@ -11301,7 +11304,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 69,
+            "line": 70,
           },
           "name": "global",
           "optional": true,
@@ -11324,7 +11327,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 94,
+            "line": 95,
           },
           "name": "image",
           "optional": true,
@@ -11343,7 +11346,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 125,
+            "line": 126,
           },
           "name": "priorityClassCreate",
           "optional": true,
@@ -11363,7 +11366,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 118,
+            "line": 119,
           },
           "name": "priorityClassName",
           "optional": true,
@@ -11382,7 +11385,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 132,
+            "line": 133,
           },
           "name": "priorityClassPreemptionPolicy",
           "optional": true,
@@ -11401,7 +11404,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 139,
+            "line": 140,
           },
           "name": "priorityClassValue",
           "optional": true,
@@ -11421,7 +11424,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 111,
+            "line": 112,
           },
           "name": "resources",
           "optional": true,
@@ -11440,7 +11443,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 146,
+            "line": 147,
           },
           "name": "tolerations",
           "optional": true,
@@ -17558,7 +17561,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 590,
+        "line": 591,
       },
       "name": "IoK8SApiCoreV1Affinity",
       "properties": Array [
@@ -17573,7 +17576,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 596,
+            "line": 597,
           },
           "name": "nodeAffinity",
           "optional": true,
@@ -17592,7 +17595,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 603,
+            "line": 604,
           },
           "name": "podAffinity",
           "optional": true,
@@ -17611,7 +17614,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 610,
+            "line": 611,
           },
           "name": "podAntiAffinity",
           "optional": true,
@@ -17635,7 +17638,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 959,
+        "line": 960,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinity",
       "properties": Array [
@@ -17651,7 +17654,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 965,
+            "line": 966,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -17676,7 +17679,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 972,
+            "line": 973,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -17700,7 +17703,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1080,
+        "line": 1081,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -17716,7 +17719,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1086,
+            "line": 1087,
           },
           "name": "preference",
           "optional": true,
@@ -17735,7 +17738,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1093,
+            "line": 1094,
           },
           "name": "weight",
           "optional": true,
@@ -17760,7 +17763,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1233,
+        "line": 1234,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
       "properties": Array [
@@ -17775,7 +17778,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1239,
+            "line": 1240,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -17799,7 +17802,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1246,
+            "line": 1247,
           },
           "name": "matchFields",
           "optional": true,
@@ -17828,7 +17831,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1437,
+        "line": 1438,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
       "properties": Array [
@@ -17843,7 +17846,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1443,
+            "line": 1444,
           },
           "name": "key",
           "optional": true,
@@ -17869,7 +17872,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1458,
+            "line": 1459,
           },
           "name": "operator",
           "optional": true,
@@ -17889,7 +17892,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1465,
+            "line": 1466,
           },
           "name": "values",
           "optional": true,
@@ -17924,7 +17927,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1797,
+        "line": 1798,
       },
       "members": Array [
         Object {
@@ -17980,7 +17983,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1474,
+        "line": 1475,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
       "properties": Array [
@@ -17995,7 +17998,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1480,
+            "line": 1481,
           },
           "name": "key",
           "optional": true,
@@ -18021,7 +18024,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1495,
+            "line": 1496,
           },
           "name": "operator",
           "optional": true,
@@ -18041,7 +18044,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1502,
+            "line": 1503,
           },
           "name": "values",
           "optional": true,
@@ -18076,7 +18079,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1825,
+        "line": 1826,
       },
       "members": Array [
         Object {
@@ -18133,7 +18136,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1102,
+        "line": 1103,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -18149,7 +18152,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1108,
+            "line": 1109,
           },
           "name": "nodeSelectorTerms",
           "optional": true,
@@ -18179,7 +18182,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1255,
+        "line": 1256,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
       "properties": Array [
@@ -18194,7 +18197,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1261,
+            "line": 1262,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -18218,7 +18221,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1268,
+            "line": 1269,
           },
           "name": "matchFields",
           "optional": true,
@@ -18247,7 +18250,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1511,
+        "line": 1512,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
       "properties": Array [
@@ -18262,7 +18265,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1517,
+            "line": 1518,
           },
           "name": "key",
           "optional": true,
@@ -18288,7 +18291,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1532,
+            "line": 1533,
           },
           "name": "operator",
           "optional": true,
@@ -18308,7 +18311,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1539,
+            "line": 1540,
           },
           "name": "values",
           "optional": true,
@@ -18343,7 +18346,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1853,
+        "line": 1854,
       },
       "members": Array [
         Object {
@@ -18399,7 +18402,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1548,
+        "line": 1549,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
       "properties": Array [
@@ -18414,7 +18417,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1554,
+            "line": 1555,
           },
           "name": "key",
           "optional": true,
@@ -18440,7 +18443,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1569,
+            "line": 1570,
           },
           "name": "operator",
           "optional": true,
@@ -18460,7 +18463,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1576,
+            "line": 1577,
           },
           "name": "values",
           "optional": true,
@@ -18495,7 +18498,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1881,
+        "line": 1882,
       },
       "members": Array [
         Object {
@@ -18551,7 +18554,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 981,
+        "line": 982,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinity",
       "properties": Array [
@@ -18567,7 +18570,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 987,
+            "line": 988,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -18592,7 +18595,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 994,
+            "line": 995,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -18621,7 +18624,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1117,
+        "line": 1118,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -18636,7 +18639,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1123,
+            "line": 1124,
           },
           "name": "podAffinityTerm",
           "optional": true,
@@ -18655,7 +18658,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1130,
+            "line": 1131,
           },
           "name": "weight",
           "optional": true,
@@ -18679,7 +18682,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1277,
+        "line": 1278,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "properties": Array [
@@ -18695,7 +18698,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1304,
+            "line": 1305,
           },
           "name": "topologyKey",
           "type": Object {
@@ -18714,7 +18717,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1283,
+            "line": 1284,
           },
           "name": "labelSelector",
           "optional": true,
@@ -18734,7 +18737,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1297,
+            "line": 1298,
           },
           "name": "namespaces",
           "optional": true,
@@ -18759,7 +18762,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1290,
+            "line": 1291,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -18784,7 +18787,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1585,
+        "line": 1586,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "properties": Array [
@@ -18800,7 +18803,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1591,
+            "line": 1592,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -18825,7 +18828,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1598,
+            "line": 1599,
           },
           "name": "matchLabels",
           "optional": true,
@@ -18854,7 +18857,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1901,
+        "line": 1902,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "properties": Array [
@@ -18869,7 +18872,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1907,
+            "line": 1908,
           },
           "name": "key",
           "optional": true,
@@ -18889,7 +18892,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1914,
+            "line": 1915,
           },
           "name": "operator",
           "optional": true,
@@ -18909,7 +18912,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1921,
+            "line": 1922,
           },
           "name": "values",
           "optional": true,
@@ -18939,7 +18942,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1607,
+        "line": 1608,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
       "properties": Array [
@@ -18955,7 +18958,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1613,
+            "line": 1614,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -18980,7 +18983,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1620,
+            "line": 1621,
           },
           "name": "matchLabels",
           "optional": true,
@@ -19009,7 +19012,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1930,
+        "line": 1931,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -19024,7 +19027,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1936,
+            "line": 1937,
           },
           "name": "key",
           "optional": true,
@@ -19044,7 +19047,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1943,
+            "line": 1944,
           },
           "name": "operator",
           "optional": true,
@@ -19064,7 +19067,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1950,
+            "line": 1951,
           },
           "name": "values",
           "optional": true,
@@ -19093,7 +19096,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1139,
+        "line": 1140,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -19109,7 +19112,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1145,
+            "line": 1146,
           },
           "name": "labelSelector",
           "optional": true,
@@ -19129,7 +19132,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1159,
+            "line": 1160,
           },
           "name": "namespaces",
           "optional": true,
@@ -19154,7 +19157,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1152,
+            "line": 1153,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -19174,7 +19177,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1166,
+            "line": 1167,
           },
           "name": "topologyKey",
           "optional": true,
@@ -19199,7 +19202,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1313,
+        "line": 1314,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "properties": Array [
@@ -19215,7 +19218,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1319,
+            "line": 1320,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -19240,7 +19243,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1326,
+            "line": 1327,
           },
           "name": "matchLabels",
           "optional": true,
@@ -19269,7 +19272,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1629,
+        "line": 1630,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "properties": Array [
@@ -19284,7 +19287,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1635,
+            "line": 1636,
           },
           "name": "key",
           "optional": true,
@@ -19304,7 +19307,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1642,
+            "line": 1643,
           },
           "name": "operator",
           "optional": true,
@@ -19324,7 +19327,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1649,
+            "line": 1650,
           },
           "name": "values",
           "optional": true,
@@ -19354,7 +19357,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1335,
+        "line": 1336,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
       "properties": Array [
@@ -19370,7 +19373,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1341,
+            "line": 1342,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -19395,7 +19398,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1348,
+            "line": 1349,
           },
           "name": "matchLabels",
           "optional": true,
@@ -19424,7 +19427,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1658,
+        "line": 1659,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -19439,7 +19442,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1664,
+            "line": 1665,
           },
           "name": "key",
           "optional": true,
@@ -19459,7 +19462,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1671,
+            "line": 1672,
           },
           "name": "operator",
           "optional": true,
@@ -19479,7 +19482,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1678,
+            "line": 1679,
           },
           "name": "values",
           "optional": true,
@@ -19508,7 +19511,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1003,
+        "line": 1004,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinity",
       "properties": Array [
@@ -19524,7 +19527,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1009,
+            "line": 1010,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -19549,7 +19552,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1016,
+            "line": 1017,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -19578,7 +19581,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1175,
+        "line": 1176,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -19593,7 +19596,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1181,
+            "line": 1182,
           },
           "name": "podAffinityTerm",
           "optional": true,
@@ -19612,7 +19615,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1188,
+            "line": 1189,
           },
           "name": "weight",
           "optional": true,
@@ -19636,7 +19639,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1357,
+        "line": 1358,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "properties": Array [
@@ -19652,7 +19655,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1384,
+            "line": 1385,
           },
           "name": "topologyKey",
           "type": Object {
@@ -19671,7 +19674,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1363,
+            "line": 1364,
           },
           "name": "labelSelector",
           "optional": true,
@@ -19691,7 +19694,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1377,
+            "line": 1378,
           },
           "name": "namespaces",
           "optional": true,
@@ -19716,7 +19719,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1370,
+            "line": 1371,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -19741,7 +19744,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1687,
+        "line": 1688,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "properties": Array [
@@ -19757,7 +19760,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1693,
+            "line": 1694,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -19782,7 +19785,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1700,
+            "line": 1701,
           },
           "name": "matchLabels",
           "optional": true,
@@ -19811,7 +19814,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1959,
+        "line": 1960,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "properties": Array [
@@ -19826,7 +19829,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1965,
+            "line": 1966,
           },
           "name": "key",
           "optional": true,
@@ -19846,7 +19849,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1972,
+            "line": 1973,
           },
           "name": "operator",
           "optional": true,
@@ -19866,7 +19869,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1979,
+            "line": 1980,
           },
           "name": "values",
           "optional": true,
@@ -19896,7 +19899,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1709,
+        "line": 1710,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
       "properties": Array [
@@ -19912,7 +19915,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1715,
+            "line": 1716,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -19937,7 +19940,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1722,
+            "line": 1723,
           },
           "name": "matchLabels",
           "optional": true,
@@ -19966,7 +19969,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1988,
+        "line": 1989,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -19981,7 +19984,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1994,
+            "line": 1995,
           },
           "name": "key",
           "optional": true,
@@ -20001,7 +20004,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2001,
+            "line": 2002,
           },
           "name": "operator",
           "optional": true,
@@ -20021,7 +20024,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2008,
+            "line": 2009,
           },
           "name": "values",
           "optional": true,
@@ -20050,7 +20053,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1197,
+        "line": 1198,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -20066,7 +20069,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1203,
+            "line": 1204,
           },
           "name": "labelSelector",
           "optional": true,
@@ -20086,7 +20089,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1217,
+            "line": 1218,
           },
           "name": "namespaces",
           "optional": true,
@@ -20111,7 +20114,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1210,
+            "line": 1211,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -20131,7 +20134,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1224,
+            "line": 1225,
           },
           "name": "topologyKey",
           "optional": true,
@@ -20156,7 +20159,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1393,
+        "line": 1394,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "properties": Array [
@@ -20172,7 +20175,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1399,
+            "line": 1400,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -20197,7 +20200,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1406,
+            "line": 1407,
           },
           "name": "matchLabels",
           "optional": true,
@@ -20226,7 +20229,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1731,
+        "line": 1732,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "properties": Array [
@@ -20241,7 +20244,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1737,
+            "line": 1738,
           },
           "name": "key",
           "optional": true,
@@ -20261,7 +20264,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1744,
+            "line": 1745,
           },
           "name": "operator",
           "optional": true,
@@ -20281,7 +20284,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1751,
+            "line": 1752,
           },
           "name": "values",
           "optional": true,
@@ -20311,7 +20314,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1415,
+        "line": 1416,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
       "properties": Array [
@@ -20327,7 +20330,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1421,
+            "line": 1422,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -20352,7 +20355,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1428,
+            "line": 1429,
           },
           "name": "matchLabels",
           "optional": true,
@@ -20381,7 +20384,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1760,
+        "line": 1761,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -20396,7 +20399,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1766,
+            "line": 1767,
           },
           "name": "key",
           "optional": true,
@@ -20416,7 +20419,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1773,
+            "line": 1774,
           },
           "name": "operator",
           "optional": true,
@@ -20436,7 +20439,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1780,
+            "line": 1781,
           },
           "name": "values",
           "optional": true,
@@ -20465,7 +20468,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 619,
+        "line": 620,
       },
       "name": "IoK8SApiCoreV1DaemonSetUpdateStrategy",
       "properties": Array [
@@ -20480,7 +20483,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 625,
+            "line": 626,
           },
           "name": "rollingUpdate",
           "optional": true,
@@ -20503,7 +20506,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 637,
+            "line": 638,
           },
           "name": "type",
           "optional": true,
@@ -20527,7 +20530,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1025,
+        "line": 1026,
       },
       "name": "IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
       "properties": Array [
@@ -20541,7 +20544,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1029,
+            "line": 1030,
           },
           "name": "maxSurge",
           "optional": true,
@@ -20559,7 +20562,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1034,
+            "line": 1035,
           },
           "name": "maxUnavailable",
           "optional": true,
@@ -20586,7 +20589,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1048,
+        "line": 1049,
       },
       "members": Array [
         Object {
@@ -20618,7 +20621,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 657,
+        "line": 658,
       },
       "name": "IoK8SApiCoreV1LocalObjectReference",
       "properties": Array [
@@ -20634,7 +20637,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 663,
+            "line": 664,
           },
           "name": "name",
           "optional": true,
@@ -20658,7 +20661,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 515,
+        "line": 516,
       },
       "name": "IoK8SApiCoreV1ResourceRequirements",
       "properties": Array [
@@ -20674,7 +20677,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 521,
+            "line": 522,
           },
           "name": "limits",
           "optional": true,
@@ -20699,7 +20702,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 528,
+            "line": 529,
           },
           "name": "requests",
           "optional": true,
@@ -20728,7 +20731,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 537,
+        "line": 538,
       },
       "name": "IoK8SApiCoreV1Toleration",
       "properties": Array [
@@ -20749,7 +20752,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 548,
+            "line": 549,
           },
           "name": "effect",
           "optional": true,
@@ -20769,7 +20772,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 555,
+            "line": 556,
           },
           "name": "key",
           "optional": true,
@@ -20794,7 +20797,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 567,
+            "line": 568,
           },
           "name": "operator",
           "optional": true,
@@ -20814,7 +20817,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 574,
+            "line": 575,
           },
           "name": "tolerationSeconds",
           "optional": true,
@@ -20834,7 +20837,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 581,
+            "line": 582,
           },
           "name": "value",
           "optional": true,
@@ -20863,7 +20866,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 928,
+        "line": 929,
       },
       "members": Array [
         Object {
@@ -20906,7 +20909,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 947,
+        "line": 948,
       },
       "members": Array [
         Object {
@@ -20937,7 +20940,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 242,
+        "line": 243,
       },
       "name": "LaceworkAgentCloudservice",
       "properties": Array [
@@ -20951,7 +20954,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 246,
+            "line": 247,
           },
           "name": "gke",
           "optional": true,
@@ -20974,7 +20977,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 644,
+        "line": 645,
       },
       "name": "LaceworkAgentCloudserviceGke",
       "properties": Array [
@@ -20988,7 +20991,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 648,
+            "line": 649,
           },
           "name": "autopilot",
           "optional": true,
@@ -21011,7 +21014,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 326,
+        "line": 327,
       },
       "name": "LaceworkAgentClusterAgent",
       "properties": Array [
@@ -21026,7 +21029,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 337,
+            "line": 338,
           },
           "name": "enable",
           "type": Object {
@@ -21043,7 +21046,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 330,
+            "line": 331,
           },
           "name": "image",
           "type": Object {
@@ -21061,7 +21064,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 372,
+            "line": 373,
           },
           "name": "additionalValues",
           "optional": true,
@@ -21085,7 +21088,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 351,
+            "line": 352,
           },
           "name": "clusterRegion",
           "optional": true,
@@ -21104,7 +21107,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 344,
+            "line": 345,
           },
           "name": "clusterType",
           "optional": true,
@@ -21123,7 +21126,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 358,
+            "line": 359,
           },
           "name": "scrapeInitialDelayMins",
           "optional": true,
@@ -21142,7 +21145,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 365,
+            "line": 366,
           },
           "name": "scrapeIntervalMins",
           "optional": true,
@@ -21165,7 +21168,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 740,
+        "line": 741,
       },
       "members": Array [
         Object {
@@ -21202,7 +21205,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 690,
+        "line": 691,
       },
       "name": "LaceworkAgentClusterAgentImage",
       "properties": Array [
@@ -21224,7 +21227,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 709,
+            "line": 710,
           },
           "name": "pullPolicy",
           "type": Object {
@@ -21241,7 +21244,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 714,
+            "line": 715,
           },
           "name": "registry",
           "type": Object {
@@ -21258,7 +21261,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 719,
+            "line": 720,
           },
           "name": "repository",
           "type": Object {
@@ -21275,7 +21278,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 724,
+            "line": 725,
           },
           "name": "tag",
           "type": Object {
@@ -21293,7 +21296,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 731,
+            "line": 732,
           },
           "name": "additionalValues",
           "optional": true,
@@ -21318,7 +21321,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 696,
+            "line": 697,
           },
           "name": "imagePullSecrets",
           "optional": true,
@@ -21353,7 +21356,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1066,
+        "line": 1067,
       },
       "members": Array [
         Object {
@@ -21390,7 +21393,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 160,
+        "line": 161,
       },
       "name": "LaceworkAgentDaemonset",
       "properties": Array [
@@ -21405,7 +21408,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 166,
+            "line": 167,
           },
           "name": "affinity",
           "type": Object {
@@ -21423,7 +21426,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 173,
+            "line": 174,
           },
           "name": "updateStrategy",
           "type": Object {
@@ -21445,7 +21448,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 253,
+        "line": 254,
       },
       "name": "LaceworkAgentDatacollector",
       "properties": Array [
@@ -21460,7 +21463,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 266,
+            "line": 267,
           },
           "name": "additionalValues",
           "optional": true,
@@ -21484,7 +21487,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 259,
+            "line": 260,
           },
           "name": "enable",
           "optional": true,
@@ -21507,7 +21510,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 180,
+        "line": 181,
       },
       "name": "LaceworkAgentDeployment",
       "properties": Array [
@@ -21522,7 +21525,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 186,
+            "line": 187,
           },
           "name": "affinity",
           "type": Object {
@@ -21540,7 +21543,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 193,
+            "line": 194,
           },
           "name": "updateStrategy",
           "type": Object {
@@ -21558,7 +21561,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 214,
+            "line": 215,
           },
           "name": "priorityClassCreate",
           "optional": true,
@@ -21578,7 +21581,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 207,
+            "line": 208,
           },
           "name": "priorityClassName",
           "optional": true,
@@ -21597,7 +21600,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 221,
+            "line": 222,
           },
           "name": "priorityClassPreemptionPolicy",
           "optional": true,
@@ -21616,7 +21619,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 228,
+            "line": 229,
           },
           "name": "priorityClassValue",
           "optional": true,
@@ -21636,7 +21639,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 200,
+            "line": 201,
           },
           "name": "resources",
           "optional": true,
@@ -21655,7 +21658,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 235,
+            "line": 236,
           },
           "name": "tolerations",
           "optional": true,
@@ -21683,7 +21686,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 273,
+        "line": 274,
       },
       "name": "LaceworkAgentImage",
       "properties": Array [
@@ -21705,7 +21708,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 292,
+            "line": 293,
           },
           "name": "pullPolicy",
           "type": Object {
@@ -21722,7 +21725,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 297,
+            "line": 298,
           },
           "name": "registry",
           "type": Object {
@@ -21739,7 +21742,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 302,
+            "line": 303,
           },
           "name": "repository",
           "type": Object {
@@ -21756,7 +21759,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 307,
+            "line": 308,
           },
           "name": "tag",
           "type": Object {
@@ -21774,7 +21777,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 319,
+            "line": 320,
           },
           "name": "additionalValues",
           "optional": true,
@@ -21799,7 +21802,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 279,
+            "line": 280,
           },
           "name": "imagePullSecrets",
           "optional": true,
@@ -21822,7 +21825,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 312,
+            "line": 313,
           },
           "name": "overrideValue",
           "optional": true,
@@ -21852,7 +21855,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 678,
+        "line": 679,
       },
       "members": Array [
         Object {
@@ -21889,7 +21892,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 379,
+        "line": 380,
       },
       "name": "LaceworkAgentLaceworkConfig",
       "properties": Array [
@@ -21903,7 +21906,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 383,
+            "line": 384,
           },
           "name": "accessToken",
           "type": Object {
@@ -21921,7 +21924,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 506,
+            "line": 507,
           },
           "name": "additionalValues",
           "optional": true,
@@ -21946,7 +21949,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 395,
+            "line": 396,
           },
           "name": "annotations",
           "optional": true,
@@ -21969,7 +21972,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 388,
+            "line": 389,
           },
           "name": "anonymizeIncoming",
           "optional": true,
@@ -21987,7 +21990,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 400,
+            "line": 401,
           },
           "name": "autoUpgrade",
           "optional": true,
@@ -22005,7 +22008,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 405,
+            "line": 406,
           },
           "name": "cmdlinefilter",
           "optional": true,
@@ -22023,7 +22026,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 410,
+            "line": 411,
           },
           "name": "codeaware",
           "optional": true,
@@ -22041,7 +22044,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 415,
+            "line": 416,
           },
           "name": "containerEngineEndpoint",
           "optional": true,
@@ -22059,7 +22062,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 420,
+            "line": 421,
           },
           "name": "containerRuntime",
           "optional": true,
@@ -22077,7 +22080,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 425,
+            "line": 426,
           },
           "name": "datacollector",
           "optional": true,
@@ -22095,7 +22098,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 454,
+            "line": 455,
           },
           "name": "env",
           "optional": true,
@@ -22113,7 +22116,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 459,
+            "line": 460,
           },
           "name": "fim",
           "optional": true,
@@ -22132,7 +22135,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 432,
+            "line": 433,
           },
           "name": "k8SNodeScrapeIntervalMins",
           "optional": true,
@@ -22150,7 +22153,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 437,
+            "line": 438,
           },
           "name": "kubernetesCluster",
           "optional": true,
@@ -22170,7 +22173,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 444,
+            "line": 445,
           },
           "name": "labels",
           "optional": true,
@@ -22193,7 +22196,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 449,
+            "line": 450,
           },
           "name": "metadataRequestInterval",
           "optional": true,
@@ -22211,7 +22214,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 464,
+            "line": 465,
           },
           "name": "packagescan",
           "optional": true,
@@ -22229,7 +22232,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 499,
+            "line": 500,
           },
           "name": "perfmode",
           "optional": true,
@@ -22247,7 +22250,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 469,
+            "line": 470,
           },
           "name": "procscan",
           "optional": true,
@@ -22265,7 +22268,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 474,
+            "line": 475,
           },
           "name": "proxyUrl",
           "optional": true,
@@ -22283,7 +22286,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 479,
+            "line": 480,
           },
           "name": "serverUrl",
           "optional": true,
@@ -22301,7 +22304,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 484,
+            "line": 485,
           },
           "name": "serviceAccountName",
           "optional": true,
@@ -22319,7 +22322,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 489,
+            "line": 490,
           },
           "name": "stdoutLogging",
           "optional": true,
@@ -22337,7 +22340,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 494,
+            "line": 495,
           },
           "name": "tags",
           "optional": true,
@@ -22365,7 +22368,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 752,
+        "line": 753,
       },
       "name": "LaceworkAgentLaceworkConfigAnonymizeIncoming",
       "properties": Array [
@@ -22380,7 +22383,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 763,
+            "line": 764,
           },
           "name": "additionalValues",
           "optional": true,
@@ -22403,7 +22406,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 756,
+            "line": 757,
           },
           "name": "netmask",
           "optional": true,
@@ -22425,7 +22428,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 770,
+        "line": 771,
       },
       "members": Array [
         Object {
@@ -22456,7 +22459,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 780,
+        "line": 781,
       },
       "name": "LaceworkAgentLaceworkConfigCmdlinefilter",
       "properties": Array [
@@ -22470,7 +22473,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 784,
+            "line": 785,
           },
           "name": "allow",
           "optional": true,
@@ -22488,7 +22491,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 789,
+            "line": 790,
           },
           "name": "disallow",
           "optional": true,
@@ -22511,7 +22514,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 796,
+        "line": 797,
       },
       "name": "LaceworkAgentLaceworkConfigCodeaware",
       "properties": Array [
@@ -22525,7 +22528,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 800,
+            "line": 801,
           },
           "name": "enable",
           "optional": true,
@@ -22547,7 +22550,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 807,
+        "line": 808,
       },
       "members": Array [
         Object {
@@ -22583,7 +22586,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 819,
+        "line": 820,
       },
       "members": Array [
         Object {
@@ -22614,7 +22617,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 829,
+        "line": 830,
       },
       "name": "LaceworkAgentLaceworkConfigFim",
       "properties": Array [
@@ -22628,7 +22631,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 843,
+            "line": 844,
           },
           "name": "enable",
           "type": Object {
@@ -22645,7 +22648,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 848,
+            "line": 849,
           },
           "name": "fileIgnore",
           "type": Object {
@@ -22667,7 +22670,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 853,
+            "line": 854,
           },
           "name": "filePath",
           "type": Object {
@@ -22690,7 +22693,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 870,
+            "line": 871,
           },
           "name": "additionalValues",
           "optional": true,
@@ -22713,7 +22716,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 833,
+            "line": 834,
           },
           "name": "coolingPeriod",
           "optional": true,
@@ -22731,7 +22734,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 838,
+            "line": 839,
           },
           "name": "crawlInterval",
           "optional": true,
@@ -22749,7 +22752,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 858,
+            "line": 859,
           },
           "name": "noAtime",
           "optional": true,
@@ -22767,7 +22770,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 863,
+            "line": 864,
           },
           "name": "runAt",
           "optional": true,
@@ -22790,7 +22793,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 877,
+        "line": 878,
       },
       "name": "LaceworkAgentLaceworkConfigPackagescan",
       "properties": Array [
@@ -22804,7 +22807,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 881,
+            "line": 882,
           },
           "name": "enable",
           "optional": true,
@@ -22822,7 +22825,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 886,
+            "line": 887,
           },
           "name": "interval",
           "optional": true,
@@ -22844,7 +22847,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 909,
+        "line": 910,
       },
       "members": Array [
         Object {
@@ -22881,7 +22884,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 893,
+        "line": 894,
       },
       "name": "LaceworkAgentLaceworkConfigProcscan",
       "properties": Array [
@@ -22895,7 +22898,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 897,
+            "line": 898,
           },
           "name": "enable",
           "optional": true,
@@ -22913,7 +22916,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 902,
+            "line": 903,
           },
           "name": "interval",
           "optional": true,
@@ -23057,7 +23060,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 65,
+        "line": 66,
       },
       "name": "LaceworkagentValues",
       "properties": Array [
@@ -23071,7 +23074,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 104,
+            "line": 105,
           },
           "name": "laceworkConfig",
           "type": Object {
@@ -23089,7 +23092,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 153,
+            "line": 154,
           },
           "name": "additionalValues",
           "optional": true,
@@ -23112,7 +23115,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 84,
+            "line": 85,
           },
           "name": "cloudservice",
           "optional": true,
@@ -23130,7 +23133,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 99,
+            "line": 100,
           },
           "name": "clusterAgent",
           "optional": true,
@@ -23148,7 +23151,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 74,
+            "line": 75,
           },
           "name": "daemonset",
           "optional": true,
@@ -23166,7 +23169,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 89,
+            "line": 90,
           },
           "name": "datacollector",
           "optional": true,
@@ -23184,7 +23187,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 79,
+            "line": 80,
           },
           "name": "deployment",
           "optional": true,
@@ -23202,7 +23205,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 69,
+            "line": 70,
           },
           "name": "global",
           "optional": true,
@@ -23225,7 +23228,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 94,
+            "line": 95,
           },
           "name": "image",
           "optional": true,
@@ -23244,7 +23247,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 125,
+            "line": 126,
           },
           "name": "priorityClassCreate",
           "optional": true,
@@ -23264,7 +23267,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 118,
+            "line": 119,
           },
           "name": "priorityClassName",
           "optional": true,
@@ -23283,7 +23286,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 132,
+            "line": 133,
           },
           "name": "priorityClassPreemptionPolicy",
           "optional": true,
@@ -23302,7 +23305,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 139,
+            "line": 140,
           },
           "name": "priorityClassValue",
           "optional": true,
@@ -23322,7 +23325,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 111,
+            "line": 112,
           },
           "name": "resources",
           "optional": true,
@@ -23341,7 +23344,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 146,
+            "line": 147,
           },
           "name": "tolerations",
           "optional": true,
@@ -23378,7 +23381,7 @@ export interface LaceworkagentProps {
 
 export class Laceworkagent extends Construct {
   public constructor(scope: Construct, id: string, props: LaceworkagentProps) {
-    super(scope, id)
+    super(scope, id);
     let updatedProps = {};
 
     if (props.values) {
@@ -23388,7 +23391,7 @@ export class Laceworkagent extends Construct {
         values: {
           ...this.flattenAdditionalValues(valuesWithoutAdditionalValues),
           ...additionalValues,
-        }
+        },
       };
     }
 
@@ -23399,636 +23402,251 @@ export class Laceworkagent extends Construct {
       ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
     };
 
-    new Helm(scope, \`Helm\${id}\`, finalProps)
+    new Helm(this, 'Helm', finalProps);
   }
 
   private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
     for (let prop in props) {
       if (Array.isArray(props[prop])) {
         props[prop].map((item: any) => {
-          if (typeof(item) === 'object' && prop !== 'additionalValues') {
+          if (typeof item === 'object' && prop !== 'additionalValues') {
             return this.flattenAdditionalValues(item);
           }
           return item;
         });
-        } else if (typeof(props[prop]) === 'object' && prop !== 'additionalValues') {
-          props[prop] = this.flattenAdditionalValues(props[prop]);
-        }
       }
-
-      const { additionalValues, ...valuesWithoutAdditionalValues } = props;
-
-      return {
-        ...valuesWithoutAdditionalValues,
-        ...additionalValues,
-      };
+      else if (typeof props[prop] === 'object' && prop !== 'additionalValues') {
+        props[prop] = this.flattenAdditionalValues(props[prop]);
+      }
     }
-  }
 
+    const { additionalValues, ...valuesWithoutAdditionalValues } = props;
+
+    return {
+      ...valuesWithoutAdditionalValues,
+      ...additionalValues,
+    };
+  }
+}
+
+/**
+ * @schema lacework-agent
+ */
+export interface LaceworkagentValues {
   /**
-   * @schema lacework-agent
+   * @schema lacework-agent#global
    */
-  export interface LaceworkagentValues {
-    /**
-     * @schema lacework-agent#global
-     */
-    readonly global?: { [key: string]: any };
-
-    /**
-     * @schema lacework-agent#daemonset
-     */
-    readonly daemonset?: LaceworkAgentDaemonset;
-
-    /**
-     * @schema lacework-agent#deployment
-     */
-    readonly deployment?: LaceworkAgentDeployment;
-
-    /**
-     * @schema lacework-agent#cloudservice
-     */
-    readonly cloudservice?: LaceworkAgentCloudservice;
-
-    /**
-     * @schema lacework-agent#datacollector
-     */
-    readonly datacollector?: LaceworkAgentDatacollector;
-
-    /**
-     * @schema lacework-agent#image
-     */
-    readonly image?: LaceworkAgentImage;
-
-    /**
-     * @schema lacework-agent#clusterAgent
-     */
-    readonly clusterAgent?: LaceworkAgentClusterAgent;
-
-    /**
-     * @schema lacework-agent#laceworkConfig
-     */
-    readonly laceworkConfig: LaceworkAgentLaceworkConfig;
-
-    /**
-     * Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-     *
-     * @schema lacework-agent#resources
-     */
-    readonly resources?: IoK8SApiCoreV1ResourceRequirements;
-
-    /**
-     * If specified, indicates the pod's priority. \\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
-     *
-     * @schema lacework-agent#priorityClassName
-     */
-    readonly priorityClassName?: string;
-
-    /**
-     * If specified, a priority class is created and used to deploy agent
-     *
-     * @schema lacework-agent#priorityClassCreate
-     */
-    readonly priorityClassCreate?: boolean;
-
-    /**
-     * If specified, it determines if agent pod can preempt a pod with a lower a priority
-     *
-     * @schema lacework-agent#priorityClassPreemptionPolicy
-     */
-    readonly priorityClassPreemptionPolicy?: string;
-
-    /**
-     * If specified, it represents the priority class value to use
-     *
-     * @schema lacework-agent#priorityClassValue
-     */
-    readonly priorityClassValue?: number;
-
-    /**
-     * If specified, the pod's tolerations.
-     *
-     * @schema lacework-agent#tolerations
-     */
-    readonly tolerations?: IoK8SApiCoreV1Toleration[];
-
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema lacework-agent#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
-
-  }
+  readonly global?: { [key: string]: any };
 
   /**
-   * @schema LaceworkAgentDaemonset
+   * @schema lacework-agent#daemonset
    */
-  export interface LaceworkAgentDaemonset {
-    /**
-     * If specified, the pod's scheduling constraints
-     *
-     * @schema LaceworkAgentDaemonset#affinity
-     */
-    readonly affinity: IoK8SApiCoreV1Affinity;
-
-    /**
-     * An update strategy to replace existing DaemonSet pods with new pods.
-     *
-     * @schema LaceworkAgentDaemonset#updateStrategy
-     */
-    readonly updateStrategy: IoK8SApiCoreV1DaemonSetUpdateStrategy;
-
-  }
+  readonly daemonset?: LaceworkAgentDaemonset;
 
   /**
-   * @schema LaceworkAgentDeployment
+   * @schema lacework-agent#deployment
    */
-  export interface LaceworkAgentDeployment {
-    /**
-     * If specified, the pod's scheduling constraints
-     *
-     * @schema LaceworkAgentDeployment#affinity
-     */
-    readonly affinity: IoK8SApiCoreV1Affinity;
-
-    /**
-     * An update strategy to replace existing DaemonSet pods with new pods.
-     *
-     * @schema LaceworkAgentDeployment#updateStrategy
-     */
-    readonly updateStrategy: IoK8SApiCoreV1DaemonSetUpdateStrategy;
-
-    /**
-     * Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-     *
-     * @schema LaceworkAgentDeployment#resources
-     */
-    readonly resources?: IoK8SApiCoreV1ResourceRequirements;
-
-    /**
-     * If specified, indicates the pod's priority. \\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
-     *
-     * @schema LaceworkAgentDeployment#priorityClassName
-     */
-    readonly priorityClassName?: string;
-
-    /**
-     * If specified, a priority class is created and used to deploy agent
-     *
-     * @schema LaceworkAgentDeployment#priorityClassCreate
-     */
-    readonly priorityClassCreate?: boolean;
-
-    /**
-     * If specified, it determines if agent pod can preempt a pod with a lower a priority
-     *
-     * @schema LaceworkAgentDeployment#priorityClassPreemptionPolicy
-     */
-    readonly priorityClassPreemptionPolicy?: string;
-
-    /**
-     * If specified, it represents the priority class value to use
-     *
-     * @schema LaceworkAgentDeployment#priorityClassValue
-     */
-    readonly priorityClassValue?: number;
-
-    /**
-     * If specified, the pod's tolerations.
-     *
-     * @schema LaceworkAgentDeployment#tolerations
-     */
-    readonly tolerations?: IoK8SApiCoreV1Toleration[];
-
-  }
+  readonly deployment?: LaceworkAgentDeployment;
 
   /**
-   * @schema LaceworkAgentCloudservice
+   * @schema lacework-agent#cloudservice
    */
-  export interface LaceworkAgentCloudservice {
-    /**
-     * @schema LaceworkAgentCloudservice#gke
-     */
-    readonly gke?: LaceworkAgentCloudserviceGke;
-
-  }
+  readonly cloudservice?: LaceworkAgentCloudservice;
 
   /**
-   * @schema LaceworkAgentDatacollector
+   * @schema lacework-agent#datacollector
    */
-  export interface LaceworkAgentDatacollector {
-    /**
-     * Enable lacework datacollector
-     *
-     * @schema LaceworkAgentDatacollector#enable
-     */
-    readonly enable?: boolean;
-
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema LaceworkAgentDatacollector#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
-
-  }
+  readonly datacollector?: LaceworkAgentDatacollector;
 
   /**
-   * @schema LaceworkAgentImage
+   * @schema lacework-agent#image
    */
-  export interface LaceworkAgentImage {
-    /**
-     * ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
-     *
-     * @schema LaceworkAgentImage#imagePullSecrets
-     */
-    readonly imagePullSecrets?: IoK8SApiCoreV1LocalObjectReference[];
-
-    /**
-     * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
-     *
-     * Possible enum values:
-     * - \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
-     * - \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
-     * - \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
-     *
-     * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
-     * @schema LaceworkAgentImage#pullPolicy
-     */
-    readonly pullPolicy: LaceworkAgentImagePullPolicy;
-
-    /**
-     * @schema LaceworkAgentImage#registry
-     */
-    readonly registry: string;
-
-    /**
-     * @schema LaceworkAgentImage#repository
-     */
-    readonly repository: string;
-
-    /**
-     * @schema LaceworkAgentImage#tag
-     */
-    readonly tag: string;
-
-    /**
-     * @schema LaceworkAgentImage#overrideValue
-     */
-    readonly overrideValue?: string;
-
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema LaceworkAgentImage#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
-
-  }
+  readonly image?: LaceworkAgentImage;
 
   /**
-   * @schema LaceworkAgentClusterAgent
+   * @schema lacework-agent#clusterAgent
    */
-  export interface LaceworkAgentClusterAgent {
-    /**
-     * @schema LaceworkAgentClusterAgent#image
-     */
-    readonly image: LaceworkAgentClusterAgentImage;
-
-    /**
-     * Enable cluster agent
-     *
-     * @schema LaceworkAgentClusterAgent#enable
-     */
-    readonly enable: boolean;
-
-    /**
-     * Kubernetes cluster type
-     *
-     * @schema LaceworkAgentClusterAgent#clusterType
-     */
-    readonly clusterType?: LaceworkAgentClusterAgentClusterType;
-
-    /**
-     * Kubernetes cluster cloud region
-     *
-     * @schema LaceworkAgentClusterAgent#clusterRegion
-     */
-    readonly clusterRegion?: string;
-
-    /**
-     * Cluster mode agent's initial delay of cluster scraping after startup in minutes
-     *
-     * @schema LaceworkAgentClusterAgent#scrapeInitialDelayMins
-     */
-    readonly scrapeInitialDelayMins?: number;
-
-    /**
-     * Cluster mode agent's scrape interval in minutes
-     *
-     * @schema LaceworkAgentClusterAgent#scrapeIntervalMins
-     */
-    readonly scrapeIntervalMins?: number;
-
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema LaceworkAgentClusterAgent#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
-
-  }
+  readonly clusterAgent?: LaceworkAgentClusterAgent;
 
   /**
-   * @schema LaceworkAgentLaceworkConfig
+   * @schema lacework-agent#laceworkConfig
    */
-  export interface LaceworkAgentLaceworkConfig {
-    /**
-     * @schema LaceworkAgentLaceworkConfig#accessToken
-     */
-    readonly accessToken: any;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#anonymizeIncoming
-     */
-    readonly anonymizeIncoming?: LaceworkAgentLaceworkConfigAnonymizeIncoming;
-
-    /**
-     * Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations
-     *
-     * @schema LaceworkAgentLaceworkConfig#annotations
-     */
-    readonly annotations?: { [key: string]: string };
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#autoUpgrade
-     */
-    readonly autoUpgrade?: LaceworkAgentLaceworkConfigAutoUpgrade;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#cmdlinefilter
-     */
-    readonly cmdlinefilter?: LaceworkAgentLaceworkConfigCmdlinefilter;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#codeaware
-     */
-    readonly codeaware?: LaceworkAgentLaceworkConfigCodeaware;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#containerEngineEndpoint
-     */
-    readonly containerEngineEndpoint?: string;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#containerRuntime
-     */
-    readonly containerRuntime?: LaceworkAgentLaceworkConfigContainerRuntime;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#datacollector
-     */
-    readonly datacollector?: LaceworkAgentLaceworkConfigDatacollector;
-
-    /**
-     * Kubernetes node's scrape interval in minutes
-     *
-     * @schema LaceworkAgentLaceworkConfig#k8sNodeScrapeIntervalMins
-     */
-    readonly k8SNodeScrapeIntervalMins?: number;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#kubernetesCluster
-     */
-    readonly kubernetesCluster?: string;
-
-    /**
-     * Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
-     *
-     * @schema LaceworkAgentLaceworkConfig#labels
-     */
-    readonly labels?: { [key: string]: string };
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#metadataRequestInterval
-     */
-    readonly metadataRequestInterval?: string;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#env
-     */
-    readonly env?: string;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#fim
-     */
-    readonly fim?: LaceworkAgentLaceworkConfigFim;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#packagescan
-     */
-    readonly packagescan?: LaceworkAgentLaceworkConfigPackagescan;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#procscan
-     */
-    readonly procscan?: LaceworkAgentLaceworkConfigProcscan;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#proxyUrl
-     */
-    readonly proxyUrl?: string;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#serverUrl
-     */
-    readonly serverUrl?: string;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#serviceAccountName
-     */
-    readonly serviceAccountName?: string;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#stdoutLogging
-     */
-    readonly stdoutLogging?: boolean;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#tags
-     */
-    readonly tags?: { [key: string]: string };
-
-    /**
-     * @schema LaceworkAgentLaceworkConfig#perfmode
-     */
-    readonly perfmode?: LaceworkAgentLaceworkConfigPerfmode;
-
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema LaceworkAgentLaceworkConfig#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
-
-  }
+  readonly laceworkConfig: LaceworkAgentLaceworkConfig;
 
   /**
-   * ResourceRequirements describes the compute resource requirements.
+   * Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
    *
-   * @schema io.k8s.api.core.v1.ResourceRequirements
+   * @schema lacework-agent#resources
    */
-  export interface IoK8SApiCoreV1ResourceRequirements {
-    /**
-     * Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-     *
-     * @schema io.k8s.api.core.v1.ResourceRequirements#limits
-     */
-    readonly limits?: { [key: string]: any };
-
-    /**
-     * Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-     *
-     * @schema io.k8s.api.core.v1.ResourceRequirements#requests
-     */
-    readonly requests?: { [key: string]: any };
-
-  }
+  readonly resources?: IoK8SApiCoreV1ResourceRequirements;
 
   /**
-   * The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+   * If specified, indicates the pod's priority. \\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
    *
-   * @schema io.k8s.api.core.v1.Toleration
+   * @schema lacework-agent#priorityClassName
    */
-  export interface IoK8SApiCoreV1Toleration {
-    /**
-     * Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-     *
-     * Possible enum values:
-     * - \`\\"NoExecute\\"\` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
-     * - \`\\"NoSchedule\\"\` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
-     * - \`\\"PreferNoSchedule\\"\` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
-     *
-     * @schema io.k8s.api.core.v1.Toleration#effect
-     */
-    readonly effect?: IoK8SApiCoreV1TolerationEffect;
-
-    /**
-     * Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-     *
-     * @schema io.k8s.api.core.v1.Toleration#key
-     */
-    readonly key?: string;
-
-    /**
-     * Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
-     *
-     * Possible enum values:
-     * - \`\\"Equal\\"\`
-     * - \`\\"Exists\\"\`
-     *
-     * @default Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
-     * @schema io.k8s.api.core.v1.Toleration#operator
-     */
-    readonly operator?: IoK8SApiCoreV1TolerationOperator;
-
-    /**
-     * TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
-     *
-     * @schema io.k8s.api.core.v1.Toleration#tolerationSeconds
-     */
-    readonly tolerationSeconds?: number;
-
-    /**
-     * Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
-     *
-     * @schema io.k8s.api.core.v1.Toleration#value
-     */
-    readonly value?: string;
-
-  }
+  readonly priorityClassName?: string;
 
   /**
-   * Affinity is a group of affinity scheduling rules.
+   * If specified, a priority class is created and used to deploy agent
    *
-   * @schema io.k8s.api.core.v1.Affinity
+   * @schema lacework-agent#priorityClassCreate
    */
-  export interface IoK8SApiCoreV1Affinity {
-    /**
-     * Node affinity is a group of node affinity scheduling rules.
-     *
-     * @schema io.k8s.api.core.v1.Affinity#nodeAffinity
-     */
-    readonly nodeAffinity?: IoK8SApiCoreV1AffinityNodeAffinity;
-
-    /**
-     * Pod affinity is a group of inter pod affinity scheduling rules.
-     *
-     * @schema io.k8s.api.core.v1.Affinity#podAffinity
-     */
-    readonly podAffinity?: IoK8SApiCoreV1AffinityPodAffinity;
-
-    /**
-     * Pod anti affinity is a group of inter pod anti affinity scheduling rules.
-     *
-     * @schema io.k8s.api.core.v1.Affinity#podAntiAffinity
-     */
-    readonly podAntiAffinity?: IoK8SApiCoreV1AffinityPodAntiAffinity;
-
-  }
+  readonly priorityClassCreate?: boolean;
 
   /**
-   * DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.
+   * If specified, it determines if agent pod can preempt a pod with a lower a priority
    *
-   * @schema io.k8s.api.core.v1.DaemonSetUpdateStrategy
+   * @schema lacework-agent#priorityClassPreemptionPolicy
    */
-  export interface IoK8SApiCoreV1DaemonSetUpdateStrategy {
-    /**
-     * Spec to control the desired behavior of daemon set rolling update.
-     *
-     * @schema io.k8s.api.core.v1.DaemonSetUpdateStrategy#rollingUpdate
-     */
-    readonly rollingUpdate?: IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate;
-
-    /**
-     * Type of daemon set update. Can be \\"RollingUpdate\\" or \\"OnDelete\\". Default is RollingUpdate.
-     *
-     * Possible enum values:
-     * - \`\\"OnDelete\\"\` Replace the old daemons only when it's killed
-     * - \`\\"RollingUpdate\\"\` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.
-     *
-     * @default RollingUpdate.
-     * @schema io.k8s.api.core.v1.DaemonSetUpdateStrategy#type
-     */
-    readonly type?: IoK8SApiCoreV1DaemonSetUpdateStrategyType;
-
-  }
+  readonly priorityClassPreemptionPolicy?: string;
 
   /**
-   * @schema LaceworkAgentCloudserviceGke
-   */
-  export interface LaceworkAgentCloudserviceGke {
-    /**
-     * @schema LaceworkAgentCloudserviceGke#autopilot
-     */
-    readonly autopilot?: boolean;
-
-  }
-
-  /**
-   * LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+   * If specified, it represents the priority class value to use
    *
-   * @schema io.k8s.api.core.v1.LocalObjectReference
+   * @schema lacework-agent#priorityClassValue
    */
-  export interface IoK8SApiCoreV1LocalObjectReference {
-    /**
-     * Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-     *
-     * @schema io.k8s.api.core.v1.LocalObjectReference#name
-     */
-    readonly name?: string;
+  readonly priorityClassValue?: number;
 
-  }
+  /**
+   * If specified, the pod's tolerations.
+   *
+   * @schema lacework-agent#tolerations
+   */
+  readonly tolerations?: IoK8SApiCoreV1Toleration[];
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema lacework-agent#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema LaceworkAgentDaemonset
+ */
+export interface LaceworkAgentDaemonset {
+  /**
+   * If specified, the pod's scheduling constraints
+   *
+   * @schema LaceworkAgentDaemonset#affinity
+   */
+  readonly affinity: IoK8SApiCoreV1Affinity;
+
+  /**
+   * An update strategy to replace existing DaemonSet pods with new pods.
+   *
+   * @schema LaceworkAgentDaemonset#updateStrategy
+   */
+  readonly updateStrategy: IoK8SApiCoreV1DaemonSetUpdateStrategy;
+
+}
+
+/**
+ * @schema LaceworkAgentDeployment
+ */
+export interface LaceworkAgentDeployment {
+  /**
+   * If specified, the pod's scheduling constraints
+   *
+   * @schema LaceworkAgentDeployment#affinity
+   */
+  readonly affinity: IoK8SApiCoreV1Affinity;
+
+  /**
+   * An update strategy to replace existing DaemonSet pods with new pods.
+   *
+   * @schema LaceworkAgentDeployment#updateStrategy
+   */
+  readonly updateStrategy: IoK8SApiCoreV1DaemonSetUpdateStrategy;
+
+  /**
+   * Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+   *
+   * @schema LaceworkAgentDeployment#resources
+   */
+  readonly resources?: IoK8SApiCoreV1ResourceRequirements;
+
+  /**
+   * If specified, indicates the pod's priority. \\"system-node-critical\\" and \\"system-cluster-critical\\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+   *
+   * @schema LaceworkAgentDeployment#priorityClassName
+   */
+  readonly priorityClassName?: string;
+
+  /**
+   * If specified, a priority class is created and used to deploy agent
+   *
+   * @schema LaceworkAgentDeployment#priorityClassCreate
+   */
+  readonly priorityClassCreate?: boolean;
+
+  /**
+   * If specified, it determines if agent pod can preempt a pod with a lower a priority
+   *
+   * @schema LaceworkAgentDeployment#priorityClassPreemptionPolicy
+   */
+  readonly priorityClassPreemptionPolicy?: string;
+
+  /**
+   * If specified, it represents the priority class value to use
+   *
+   * @schema LaceworkAgentDeployment#priorityClassValue
+   */
+  readonly priorityClassValue?: number;
+
+  /**
+   * If specified, the pod's tolerations.
+   *
+   * @schema LaceworkAgentDeployment#tolerations
+   */
+  readonly tolerations?: IoK8SApiCoreV1Toleration[];
+
+}
+
+/**
+ * @schema LaceworkAgentCloudservice
+ */
+export interface LaceworkAgentCloudservice {
+  /**
+   * @schema LaceworkAgentCloudservice#gke
+   */
+  readonly gke?: LaceworkAgentCloudserviceGke;
+
+}
+
+/**
+ * @schema LaceworkAgentDatacollector
+ */
+export interface LaceworkAgentDatacollector {
+  /**
+   * Enable lacework datacollector
+   *
+   * @schema LaceworkAgentDatacollector#enable
+   */
+  readonly enable?: boolean;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema LaceworkAgentDatacollector#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema LaceworkAgentImage
+ */
+export interface LaceworkAgentImage {
+  /**
+   * ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+   *
+   * @schema LaceworkAgentImage#imagePullSecrets
+   */
+  readonly imagePullSecrets?: IoK8SApiCoreV1LocalObjectReference[];
 
   /**
    * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
@@ -24039,248 +23657,254 @@ export class Laceworkagent extends Construct {
    * - \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
    *
    * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
-   * @schema LaceworkAgentImagePullPolicy
+   * @schema LaceworkAgentImage#pullPolicy
    */
-  export enum LaceworkAgentImagePullPolicy {
-    /** Always */
-    ALWAYS = \\"Always\\",
-    /** IfNotPresent */
-    IF_NOT_PRESENT = \\"IfNotPresent\\",
-    /** Never */
-    NEVER = \\"Never\\",
-  }
+  readonly pullPolicy: LaceworkAgentImagePullPolicy;
 
   /**
-   * @schema LaceworkAgentClusterAgentImage
+   * @schema LaceworkAgentImage#registry
    */
-  export interface LaceworkAgentClusterAgentImage {
-    /**
-     * ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
-     *
-     * @schema LaceworkAgentClusterAgentImage#imagePullSecrets
-     */
-    readonly imagePullSecrets?: IoK8SApiCoreV1LocalObjectReference[];
+  readonly registry: string;
 
-    /**
-     * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
-     *
-     * Possible enum values:
-     * - \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
-     * - \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
-     * - \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
-     *
-     * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
-     * @schema LaceworkAgentClusterAgentImage#pullPolicy
-     */
-    readonly pullPolicy: LaceworkAgentClusterAgentImagePullPolicy;
+  /**
+   * @schema LaceworkAgentImage#repository
+   */
+  readonly repository: string;
 
-    /**
-     * @schema LaceworkAgentClusterAgentImage#registry
-     */
-    readonly registry: string;
+  /**
+   * @schema LaceworkAgentImage#tag
+   */
+  readonly tag: string;
 
-    /**
-     * @schema LaceworkAgentClusterAgentImage#repository
-     */
-    readonly repository: string;
+  /**
+   * @schema LaceworkAgentImage#overrideValue
+   */
+  readonly overrideValue?: string;
 
-    /**
-     * @schema LaceworkAgentClusterAgentImage#tag
-     */
-    readonly tag: string;
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema LaceworkAgentImage#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
 
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema LaceworkAgentClusterAgentImage#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
+}
 
-  }
+/**
+ * @schema LaceworkAgentClusterAgent
+ */
+export interface LaceworkAgentClusterAgent {
+  /**
+   * @schema LaceworkAgentClusterAgent#image
+   */
+  readonly image: LaceworkAgentClusterAgentImage;
+
+  /**
+   * Enable cluster agent
+   *
+   * @schema LaceworkAgentClusterAgent#enable
+   */
+  readonly enable: boolean;
 
   /**
    * Kubernetes cluster type
    *
-   * @schema LaceworkAgentClusterAgentClusterType
+   * @schema LaceworkAgentClusterAgent#clusterType
    */
-  export enum LaceworkAgentClusterAgentClusterType {
-    /** eks */
-    EKS = \\"eks\\",
-    /** gke */
-    GKE = \\"gke\\",
-    /** unknown */
-    UNKNOWN = \\"unknown\\",
-  }
+  readonly clusterType?: LaceworkAgentClusterAgentClusterType;
 
   /**
-   * @schema LaceworkAgentLaceworkConfigAnonymizeIncoming
+   * Kubernetes cluster cloud region
+   *
+   * @schema LaceworkAgentClusterAgent#clusterRegion
    */
-  export interface LaceworkAgentLaceworkConfigAnonymizeIncoming {
-    /**
-     * @schema LaceworkAgentLaceworkConfigAnonymizeIncoming#netmask
-     */
-    readonly netmask?: string;
-
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema LaceworkAgentLaceworkConfigAnonymizeIncoming#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
-
-  }
+  readonly clusterRegion?: string;
 
   /**
-   * @schema LaceworkAgentLaceworkConfigAutoUpgrade
+   * Cluster mode agent's initial delay of cluster scraping after startup in minutes
+   *
+   * @schema LaceworkAgentClusterAgent#scrapeInitialDelayMins
    */
-  export enum LaceworkAgentLaceworkConfigAutoUpgrade {
-    /** disable */
-    DISABLE = \\"disable\\",
-    /** enable */
-    ENABLE = \\"enable\\",
-  }
+  readonly scrapeInitialDelayMins?: number;
 
   /**
-   * @schema LaceworkAgentLaceworkConfigCmdlinefilter
+   * Cluster mode agent's scrape interval in minutes
+   *
+   * @schema LaceworkAgentClusterAgent#scrapeIntervalMins
    */
-  export interface LaceworkAgentLaceworkConfigCmdlinefilter {
-    /**
-     * @schema LaceworkAgentLaceworkConfigCmdlinefilter#allow
-     */
-    readonly allow?: string;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfigCmdlinefilter#disallow
-     */
-    readonly disallow?: string;
-
-  }
+  readonly scrapeIntervalMins?: number;
 
   /**
-   * @schema LaceworkAgentLaceworkConfigCodeaware
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema LaceworkAgentClusterAgent#additionalValues
    */
-  export interface LaceworkAgentLaceworkConfigCodeaware {
-    /**
-     * @schema LaceworkAgentLaceworkConfigCodeaware#enable
-     */
-    readonly enable?: boolean;
+  readonly additionalValues?: { [key: string]: any };
 
-  }
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfig
+ */
+export interface LaceworkAgentLaceworkConfig {
+  /**
+   * @schema LaceworkAgentLaceworkConfig#accessToken
+   */
+  readonly accessToken: any;
 
   /**
-   * @schema LaceworkAgentLaceworkConfigContainerRuntime
+   * @schema LaceworkAgentLaceworkConfig#anonymizeIncoming
    */
-  export enum LaceworkAgentLaceworkConfigContainerRuntime {
-    /** containerd */
-    CONTAINERD = \\"containerd\\",
-    /** cri-o */
-    CRI_O = \\"cri-o\\",
-    /** docker */
-    DOCKER = \\"docker\\",
-  }
+  readonly anonymizeIncoming?: LaceworkAgentLaceworkConfigAnonymizeIncoming;
 
   /**
-   * @schema LaceworkAgentLaceworkConfigDatacollector
+   * Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations
+   *
+   * @schema LaceworkAgentLaceworkConfig#annotations
    */
-  export enum LaceworkAgentLaceworkConfigDatacollector {
-    /** disable */
-    DISABLE = \\"disable\\",
-    /** enable */
-    ENABLE = \\"enable\\",
-  }
+  readonly annotations?: { [key: string]: string };
 
   /**
-   * @schema LaceworkAgentLaceworkConfigFim
+   * @schema LaceworkAgentLaceworkConfig#autoUpgrade
    */
-  export interface LaceworkAgentLaceworkConfigFim {
-    /**
-     * @schema LaceworkAgentLaceworkConfigFim#coolingPeriod
-     */
-    readonly coolingPeriod?: number;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfigFim#crawlInterval
-     */
-    readonly crawlInterval?: number;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfigFim#enable
-     */
-    readonly enable: boolean;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfigFim#fileIgnore
-     */
-    readonly fileIgnore: string[];
-
-    /**
-     * @schema LaceworkAgentLaceworkConfigFim#filePath
-     */
-    readonly filePath: string[];
-
-    /**
-     * @schema LaceworkAgentLaceworkConfigFim#noAtime
-     */
-    readonly noAtime?: boolean;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfigFim#runAt
-     */
-    readonly runAt?: any;
-
-    /**
-     * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
-     *
-     * @schema LaceworkAgentLaceworkConfigFim#additionalValues
-     */
-    readonly additionalValues?: { [key: string]: any };
-
-  }
+  readonly autoUpgrade?: LaceworkAgentLaceworkConfigAutoUpgrade;
 
   /**
-   * @schema LaceworkAgentLaceworkConfigPackagescan
+   * @schema LaceworkAgentLaceworkConfig#cmdlinefilter
    */
-  export interface LaceworkAgentLaceworkConfigPackagescan {
-    /**
-     * @schema LaceworkAgentLaceworkConfigPackagescan#enable
-     */
-    readonly enable?: boolean;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfigPackagescan#interval
-     */
-    readonly interval?: number;
-
-  }
+  readonly cmdlinefilter?: LaceworkAgentLaceworkConfigCmdlinefilter;
 
   /**
-   * @schema LaceworkAgentLaceworkConfigProcscan
+   * @schema LaceworkAgentLaceworkConfig#codeaware
    */
-  export interface LaceworkAgentLaceworkConfigProcscan {
-    /**
-     * @schema LaceworkAgentLaceworkConfigProcscan#enable
-     */
-    readonly enable?: boolean;
-
-    /**
-     * @schema LaceworkAgentLaceworkConfigProcscan#interval
-     */
-    readonly interval?: number;
-
-  }
+  readonly codeaware?: LaceworkAgentLaceworkConfigCodeaware;
 
   /**
-   * @schema LaceworkAgentLaceworkConfigPerfmode
+   * @schema LaceworkAgentLaceworkConfig#containerEngineEndpoint
    */
-  export enum LaceworkAgentLaceworkConfigPerfmode {
-    /** lite */
-    LITE = \\"lite\\",
-    /** scan */
-    SCAN = \\"scan\\",
-    /** ebpflite */
-    EBPFLITE = \\"ebpflite\\",
-  }
+  readonly containerEngineEndpoint?: string;
 
+  /**
+   * @schema LaceworkAgentLaceworkConfig#containerRuntime
+   */
+  readonly containerRuntime?: LaceworkAgentLaceworkConfigContainerRuntime;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#datacollector
+   */
+  readonly datacollector?: LaceworkAgentLaceworkConfigDatacollector;
+
+  /**
+   * Kubernetes node's scrape interval in minutes
+   *
+   * @schema LaceworkAgentLaceworkConfig#k8sNodeScrapeIntervalMins
+   */
+  readonly k8SNodeScrapeIntervalMins?: number;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#kubernetesCluster
+   */
+  readonly kubernetesCluster?: string;
+
+  /**
+   * Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
+   *
+   * @schema LaceworkAgentLaceworkConfig#labels
+   */
+  readonly labels?: { [key: string]: string };
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#metadataRequestInterval
+   */
+  readonly metadataRequestInterval?: string;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#env
+   */
+  readonly env?: string;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#fim
+   */
+  readonly fim?: LaceworkAgentLaceworkConfigFim;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#packagescan
+   */
+  readonly packagescan?: LaceworkAgentLaceworkConfigPackagescan;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#procscan
+   */
+  readonly procscan?: LaceworkAgentLaceworkConfigProcscan;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#proxyUrl
+   */
+  readonly proxyUrl?: string;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#serverUrl
+   */
+  readonly serverUrl?: string;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#serviceAccountName
+   */
+  readonly serviceAccountName?: string;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#stdoutLogging
+   */
+  readonly stdoutLogging?: boolean;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#tags
+   */
+  readonly tags?: { [key: string]: string };
+
+  /**
+   * @schema LaceworkAgentLaceworkConfig#perfmode
+   */
+  readonly perfmode?: LaceworkAgentLaceworkConfigPerfmode;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema LaceworkAgentLaceworkConfig#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * ResourceRequirements describes the compute resource requirements.
+ *
+ * @schema io.k8s.api.core.v1.ResourceRequirements
+ */
+export interface IoK8SApiCoreV1ResourceRequirements {
+  /**
+   * Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+   *
+   * @schema io.k8s.api.core.v1.ResourceRequirements#limits
+   */
+  readonly limits?: { [key: string]: any };
+
+  /**
+   * Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+   *
+   * @schema io.k8s.api.core.v1.ResourceRequirements#requests
+   */
+  readonly requests?: { [key: string]: any };
+
+}
+
+/**
+ * The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+ *
+ * @schema io.k8s.api.core.v1.Toleration
+ */
+export interface IoK8SApiCoreV1Toleration {
   /**
    * Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
    *
@@ -24289,16 +23913,16 @@ export class Laceworkagent extends Construct {
    * - \`\\"NoSchedule\\"\` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
    * - \`\\"PreferNoSchedule\\"\` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
    *
-   * @schema IoK8SApiCoreV1TolerationEffect
+   * @schema io.k8s.api.core.v1.Toleration#effect
    */
-  export enum IoK8SApiCoreV1TolerationEffect {
-    /** NoExecute */
-    NO_EXECUTE = \\"NoExecute\\",
-    /** NoSchedule */
-    NO_SCHEDULE = \\"NoSchedule\\",
-    /** PreferNoSchedule */
-    PREFER_NO_SCHEDULE = \\"PreferNoSchedule\\",
-  }
+  readonly effect?: IoK8SApiCoreV1TolerationEffect;
+
+  /**
+   * Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+   *
+   * @schema io.k8s.api.core.v1.Toleration#key
+   */
+  readonly key?: string;
 
   /**
    * Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
@@ -24308,98 +23932,67 @@ export class Laceworkagent extends Construct {
    * - \`\\"Exists\\"\`
    *
    * @default Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
-   * @schema IoK8SApiCoreV1TolerationOperator
+   * @schema io.k8s.api.core.v1.Toleration#operator
    */
-  export enum IoK8SApiCoreV1TolerationOperator {
-    /** Equal */
-    EQUAL = \\"Equal\\",
-    /** Exists */
-    EXISTS = \\"Exists\\",
-  }
+  readonly operator?: IoK8SApiCoreV1TolerationOperator;
 
+  /**
+   * TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+   *
+   * @schema io.k8s.api.core.v1.Toleration#tolerationSeconds
+   */
+  readonly tolerationSeconds?: number;
+
+  /**
+   * Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+   *
+   * @schema io.k8s.api.core.v1.Toleration#value
+   */
+  readonly value?: string;
+
+}
+
+/**
+ * Affinity is a group of affinity scheduling rules.
+ *
+ * @schema io.k8s.api.core.v1.Affinity
+ */
+export interface IoK8SApiCoreV1Affinity {
   /**
    * Node affinity is a group of node affinity scheduling rules.
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinity
+   * @schema io.k8s.api.core.v1.Affinity#nodeAffinity
    */
-  export interface IoK8SApiCoreV1AffinityNodeAffinity {
-    /**
-     * The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinity#preferredDuringSchedulingIgnoredDuringExecution
-     */
-    readonly preferredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution[];
-
-    /**
-     * A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinity#requiredDuringSchedulingIgnoredDuringExecution
-     */
-    readonly requiredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution;
-
-  }
+  readonly nodeAffinity?: IoK8SApiCoreV1AffinityNodeAffinity;
 
   /**
    * Pod affinity is a group of inter pod affinity scheduling rules.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinity
+   * @schema io.k8s.api.core.v1.Affinity#podAffinity
    */
-  export interface IoK8SApiCoreV1AffinityPodAffinity {
-    /**
-     * The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinity#preferredDuringSchedulingIgnoredDuringExecution
-     */
-    readonly preferredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution[];
-
-    /**
-     * If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinity#requiredDuringSchedulingIgnoredDuringExecution
-     */
-    readonly requiredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution[];
-
-  }
+  readonly podAffinity?: IoK8SApiCoreV1AffinityPodAffinity;
 
   /**
    * Pod anti affinity is a group of inter pod anti affinity scheduling rules.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinity
+   * @schema io.k8s.api.core.v1.Affinity#podAntiAffinity
    */
-  export interface IoK8SApiCoreV1AffinityPodAntiAffinity {
-    /**
-     * The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinity#preferredDuringSchedulingIgnoredDuringExecution
-     */
-    readonly preferredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution[];
+  readonly podAntiAffinity?: IoK8SApiCoreV1AffinityPodAntiAffinity;
 
-    /**
-     * If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinity#requiredDuringSchedulingIgnoredDuringExecution
-     */
-    readonly requiredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution[];
+}
 
-  }
-
+/**
+ * DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.
+ *
+ * @schema io.k8s.api.core.v1.DaemonSetUpdateStrategy
+ */
+export interface IoK8SApiCoreV1DaemonSetUpdateStrategy {
   /**
    * Spec to control the desired behavior of daemon set rolling update.
    *
-   * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate
+   * @schema io.k8s.api.core.v1.DaemonSetUpdateStrategy#rollingUpdate
    */
-  export interface IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate {
-    /**
-     * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate#maxSurge
-     */
-    readonly maxSurge?: any;
-
-    /**
-     * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate#maxUnavailable
-     */
-    readonly maxUnavailable?: any;
-
-  }
+  readonly rollingUpdate?: IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate;
 
   /**
    * Type of daemon set update. Can be \\"RollingUpdate\\" or \\"OnDelete\\". Default is RollingUpdate.
@@ -24409,14 +24002,68 @@ export class Laceworkagent extends Construct {
    * - \`\\"RollingUpdate\\"\` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.
    *
    * @default RollingUpdate.
-   * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyType
+   * @schema io.k8s.api.core.v1.DaemonSetUpdateStrategy#type
    */
-  export enum IoK8SApiCoreV1DaemonSetUpdateStrategyType {
-    /** OnDelete */
-    ON_DELETE = \\"OnDelete\\",
-    /** RollingUpdate */
-    ROLLING_UPDATE = \\"RollingUpdate\\",
-  }
+  readonly type?: IoK8SApiCoreV1DaemonSetUpdateStrategyType;
+
+}
+
+/**
+ * @schema LaceworkAgentCloudserviceGke
+ */
+export interface LaceworkAgentCloudserviceGke {
+  /**
+   * @schema LaceworkAgentCloudserviceGke#autopilot
+   */
+  readonly autopilot?: boolean;
+
+}
+
+/**
+ * LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+ *
+ * @schema io.k8s.api.core.v1.LocalObjectReference
+ */
+export interface IoK8SApiCoreV1LocalObjectReference {
+  /**
+   * Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+   *
+   * @schema io.k8s.api.core.v1.LocalObjectReference#name
+   */
+  readonly name?: string;
+
+}
+
+/**
+ * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+ *
+ * Possible enum values:
+ * - \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+ * - \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+ * - \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+ *
+ * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+ * @schema LaceworkAgentImagePullPolicy
+ */
+export enum LaceworkAgentImagePullPolicy {
+  /** Always */
+  ALWAYS = \\"Always\\",
+  /** IfNotPresent */
+  IF_NOT_PRESENT = \\"IfNotPresent\\",
+  /** Never */
+  NEVER = \\"Never\\",
+}
+
+/**
+ * @schema LaceworkAgentClusterAgentImage
+ */
+export interface LaceworkAgentClusterAgentImage {
+  /**
+   * ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+   *
+   * @schema LaceworkAgentClusterAgentImage#imagePullSecrets
+   */
+  readonly imagePullSecrets?: IoK8SApiCoreV1LocalObjectReference[];
 
   /**
    * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
@@ -24427,725 +24074,743 @@ export class Laceworkagent extends Construct {
    * - \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
    *
    * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
-   * @schema LaceworkAgentClusterAgentImagePullPolicy
+   * @schema LaceworkAgentClusterAgentImage#pullPolicy
    */
-  export enum LaceworkAgentClusterAgentImagePullPolicy {
-    /** Always */
-    ALWAYS = \\"Always\\",
-    /** IfNotPresent */
-    IF_NOT_PRESENT = \\"IfNotPresent\\",
-    /** Never */
-    NEVER = \\"Never\\",
-  }
+  readonly pullPolicy: LaceworkAgentClusterAgentImagePullPolicy;
 
   /**
-   * An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
-   *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution
+   * @schema LaceworkAgentClusterAgentImage#registry
    */
-  export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution {
-    /**
-     * A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution#preference
-     */
-    readonly preference?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference;
+  readonly registry: string;
 
-    /**
-     * Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
-     */
-    readonly weight?: number;
+  /**
+   * @schema LaceworkAgentClusterAgentImage#repository
+   */
+  readonly repository: string;
 
-  }
+  /**
+   * @schema LaceworkAgentClusterAgentImage#tag
+   */
+  readonly tag: string;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema LaceworkAgentClusterAgentImage#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * Kubernetes cluster type
+ *
+ * @schema LaceworkAgentClusterAgentClusterType
+ */
+export enum LaceworkAgentClusterAgentClusterType {
+  /** eks */
+  EKS = \\"eks\\",
+  /** gke */
+  GKE = \\"gke\\",
+  /** unknown */
+  UNKNOWN = \\"unknown\\",
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigAnonymizeIncoming
+ */
+export interface LaceworkAgentLaceworkConfigAnonymizeIncoming {
+  /**
+   * @schema LaceworkAgentLaceworkConfigAnonymizeIncoming#netmask
+   */
+  readonly netmask?: string;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema LaceworkAgentLaceworkConfigAnonymizeIncoming#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigAutoUpgrade
+ */
+export enum LaceworkAgentLaceworkConfigAutoUpgrade {
+  /** disable */
+  DISABLE = \\"disable\\",
+  /** enable */
+  ENABLE = \\"enable\\",
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigCmdlinefilter
+ */
+export interface LaceworkAgentLaceworkConfigCmdlinefilter {
+  /**
+   * @schema LaceworkAgentLaceworkConfigCmdlinefilter#allow
+   */
+  readonly allow?: string;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigCmdlinefilter#disallow
+   */
+  readonly disallow?: string;
+
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigCodeaware
+ */
+export interface LaceworkAgentLaceworkConfigCodeaware {
+  /**
+   * @schema LaceworkAgentLaceworkConfigCodeaware#enable
+   */
+  readonly enable?: boolean;
+
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigContainerRuntime
+ */
+export enum LaceworkAgentLaceworkConfigContainerRuntime {
+  /** containerd */
+  CONTAINERD = \\"containerd\\",
+  /** cri-o */
+  CRI_O = \\"cri-o\\",
+  /** docker */
+  DOCKER = \\"docker\\",
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigDatacollector
+ */
+export enum LaceworkAgentLaceworkConfigDatacollector {
+  /** disable */
+  DISABLE = \\"disable\\",
+  /** enable */
+  ENABLE = \\"enable\\",
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigFim
+ */
+export interface LaceworkAgentLaceworkConfigFim {
+  /**
+   * @schema LaceworkAgentLaceworkConfigFim#coolingPeriod
+   */
+  readonly coolingPeriod?: number;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigFim#crawlInterval
+   */
+  readonly crawlInterval?: number;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigFim#enable
+   */
+  readonly enable: boolean;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigFim#fileIgnore
+   */
+  readonly fileIgnore: string[];
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigFim#filePath
+   */
+  readonly filePath: string[];
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigFim#noAtime
+   */
+  readonly noAtime?: boolean;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigFim#runAt
+   */
+  readonly runAt?: any;
+
+  /**
+   * Values that are not available in values.schema.json will not be code generated. You can add such values to this property.
+   *
+   * @schema LaceworkAgentLaceworkConfigFim#additionalValues
+   */
+  readonly additionalValues?: { [key: string]: any };
+
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigPackagescan
+ */
+export interface LaceworkAgentLaceworkConfigPackagescan {
+  /**
+   * @schema LaceworkAgentLaceworkConfigPackagescan#enable
+   */
+  readonly enable?: boolean;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigPackagescan#interval
+   */
+  readonly interval?: number;
+
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigProcscan
+ */
+export interface LaceworkAgentLaceworkConfigProcscan {
+  /**
+   * @schema LaceworkAgentLaceworkConfigProcscan#enable
+   */
+  readonly enable?: boolean;
+
+  /**
+   * @schema LaceworkAgentLaceworkConfigProcscan#interval
+   */
+  readonly interval?: number;
+
+}
+
+/**
+ * @schema LaceworkAgentLaceworkConfigPerfmode
+ */
+export enum LaceworkAgentLaceworkConfigPerfmode {
+  /** lite */
+  LITE = \\"lite\\",
+  /** scan */
+  SCAN = \\"scan\\",
+  /** ebpflite */
+  EBPFLITE = \\"ebpflite\\",
+}
+
+/**
+ * Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+ *
+ * Possible enum values:
+ * - \`\\"NoExecute\\"\` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+ * - \`\\"NoSchedule\\"\` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+ * - \`\\"PreferNoSchedule\\"\` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+ *
+ * @schema IoK8SApiCoreV1TolerationEffect
+ */
+export enum IoK8SApiCoreV1TolerationEffect {
+  /** NoExecute */
+  NO_EXECUTE = \\"NoExecute\\",
+  /** NoSchedule */
+  NO_SCHEDULE = \\"NoSchedule\\",
+  /** PreferNoSchedule */
+  PREFER_NO_SCHEDULE = \\"PreferNoSchedule\\",
+}
+
+/**
+ * Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+ *
+ * Possible enum values:
+ * - \`\\"Equal\\"\`
+ * - \`\\"Exists\\"\`
+ *
+ * @default Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+ * @schema IoK8SApiCoreV1TolerationOperator
+ */
+export enum IoK8SApiCoreV1TolerationOperator {
+  /** Equal */
+  EQUAL = \\"Equal\\",
+  /** Exists */
+  EXISTS = \\"Exists\\",
+}
+
+/**
+ * Node affinity is a group of node affinity scheduling rules.
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinity
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinity {
+  /**
+   * The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinity#preferredDuringSchedulingIgnoredDuringExecution
+   */
+  readonly preferredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution[];
 
   /**
    * A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution
+   * @schema IoK8SApiCoreV1AffinityNodeAffinity#requiredDuringSchedulingIgnoredDuringExecution
    */
-  export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution {
-    /**
-     * Required. A list of node selector terms. The terms are ORed.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution#nodeSelectorTerms
-     */
-    readonly nodeSelectorTerms?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms[];
+  readonly requiredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution;
 
-  }
+}
+
+/**
+ * Pod affinity is a group of inter pod affinity scheduling rules.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinity
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinity {
+  /**
+   * The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinity#preferredDuringSchedulingIgnoredDuringExecution
+   */
+  readonly preferredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution[];
 
   /**
-   * The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+   * If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution
+   * @schema IoK8SApiCoreV1AffinityPodAffinity#requiredDuringSchedulingIgnoredDuringExecution
    */
-  export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution {
-    /**
-     * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution#podAffinityTerm
-     */
-    readonly podAffinityTerm?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm;
+  readonly requiredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution[];
 
-    /**
-     * weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
-     */
-    readonly weight?: number;
+}
 
-  }
+/**
+ * Pod anti affinity is a group of inter pod anti affinity scheduling rules.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinity
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinity {
+  /**
+   * The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \\"weight\\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinity#preferredDuringSchedulingIgnoredDuringExecution
+   */
+  readonly preferredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution[];
 
   /**
-   * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+   * If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinity#requiredDuringSchedulingIgnoredDuringExecution
    */
-  export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution {
-    /**
-     * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#labelSelector
-     */
-    readonly labelSelector?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector;
+  readonly requiredDuringSchedulingIgnoredDuringExecution?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution[];
 
-    /**
-     * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaceSelector
-     */
-    readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector;
+}
 
-    /**
-     * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaces
-     */
-    readonly namespaces?: string[];
-
-    /**
-     * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#topologyKey
-     */
-    readonly topologyKey?: string;
-
-  }
+/**
+ * Spec to control the desired behavior of daemon set rolling update.
+ *
+ * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate
+ */
+export interface IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate {
+  /**
+   * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate#maxSurge
+   */
+  readonly maxSurge?: any;
 
   /**
-   * The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution
+   * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate#maxUnavailable
    */
-  export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution {
-    /**
-     * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution#podAffinityTerm
-     */
-    readonly podAffinityTerm?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm;
+  readonly maxUnavailable?: any;
 
-    /**
-     * weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
-     */
-    readonly weight?: number;
+}
 
-  }
+/**
+ * Type of daemon set update. Can be \\"RollingUpdate\\" or \\"OnDelete\\". Default is RollingUpdate.
+ *
+ * Possible enum values:
+ * - \`\\"OnDelete\\"\` Replace the old daemons only when it's killed
+ * - \`\\"RollingUpdate\\"\` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.
+ *
+ * @default RollingUpdate.
+ * @schema IoK8SApiCoreV1DaemonSetUpdateStrategyType
+ */
+export enum IoK8SApiCoreV1DaemonSetUpdateStrategyType {
+  /** OnDelete */
+  ON_DELETE = \\"OnDelete\\",
+  /** RollingUpdate */
+  ROLLING_UPDATE = \\"RollingUpdate\\",
+}
 
-  /**
-   * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution
-   */
-  export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution {
-    /**
-     * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#labelSelector
-     */
-    readonly labelSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector;
+/**
+ * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+ *
+ * Possible enum values:
+ * - \`\\"Always\\"\` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+ * - \`\\"IfNotPresent\\"\` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+ * - \`\\"Never\\"\` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+ *
+ * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+ * @schema LaceworkAgentClusterAgentImagePullPolicy
+ */
+export enum LaceworkAgentClusterAgentImagePullPolicy {
+  /** Always */
+  ALWAYS = \\"Always\\",
+  /** IfNotPresent */
+  IF_NOT_PRESENT = \\"IfNotPresent\\",
+  /** Never */
+  NEVER = \\"Never\\",
+}
 
-    /**
-     * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaceSelector
-     */
-    readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector;
-
-    /**
-     * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaces
-     */
-    readonly namespaces?: string[];
-
-    /**
-     * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#topologyKey
-     */
-    readonly topologyKey?: string;
-
-  }
-
+/**
+ * An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution {
   /**
    * A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution#preference
    */
-  export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference {
-    /**
-     * A list of node selector requirements by node's labels.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference#matchExpressions
-     */
-    readonly matchExpressions?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions[];
-
-    /**
-     * A list of node selector requirements by node's fields.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference#matchFields
-     */
-    readonly matchFields?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields[];
-
-  }
+  readonly preference?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference;
 
   /**
-   * A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+   * Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
    */
-  export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms {
-    /**
-     * A list of node selector requirements by node's labels.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms#matchExpressions
-     */
-    readonly matchExpressions?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions[];
+  readonly weight?: number;
 
-    /**
-     * A list of node selector requirements by node's fields.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms#matchFields
-     */
-    readonly matchFields?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields[];
+}
 
-  }
+/**
+ * A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution {
+  /**
+   * Required. A list of node selector terms. The terms are ORed.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution#nodeSelectorTerms
+   */
+  readonly nodeSelectorTerms?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms[];
 
+}
+
+/**
+ * The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution {
   /**
    * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution#podAffinityTerm
    */
-  export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm {
-    /**
-     * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#labelSelector
-     */
-    readonly labelSelector?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector;
+  readonly podAffinityTerm?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm;
 
-    /**
-     * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaceSelector
-     */
-    readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector;
+  /**
+   * weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
+   */
+  readonly weight?: number;
 
-    /**
-     * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaces
-     */
-    readonly namespaces?: string[];
+}
 
-    /**
-     * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#topologyKey
-     */
-    readonly topologyKey: string;
-
-  }
+/**
+ * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution {
+  /**
+   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#labelSelector
+   */
+  readonly labelSelector?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector;
 
   /**
    * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaceSelector
    */
-  export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector {
-    /**
-     * matchExpressions is a list of label selector requirements. The requirements are ANDed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchExpressions
-     */
-    readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions[];
-
-    /**
-     * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchLabels
-     */
-    readonly matchLabels?: { [key: string]: string };
-
-  }
+  readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector;
 
   /**
-   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaces
    */
-  export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector {
-    /**
-     * matchExpressions is a list of label selector requirements. The requirements are ANDed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchExpressions
-     */
-    readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions[];
+  readonly namespaces?: string[];
 
-    /**
-     * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchLabels
-     */
-    readonly matchLabels?: { [key: string]: string };
+  /**
+   * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution#topologyKey
+   */
+  readonly topologyKey?: string;
 
-  }
+}
 
+/**
+ * The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution {
   /**
    * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
    *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution#podAffinityTerm
    */
-  export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm {
-    /**
-     * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#labelSelector
-     */
-    readonly labelSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector;
+  readonly podAffinityTerm?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm;
 
-    /**
-     * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaceSelector
-     */
-    readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector;
+  /**
+   * weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution#weight
+   */
+  readonly weight?: number;
 
-    /**
-     * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaces
-     */
-    readonly namespaces?: string[];
+}
 
-    /**
-     * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#topologyKey
-     */
-    readonly topologyKey: string;
-
-  }
+/**
+ * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution {
+  /**
+   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#labelSelector
+   */
+  readonly labelSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector;
 
   /**
    * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaceSelector
    */
-  export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector {
-    /**
-     * matchExpressions is a list of label selector requirements. The requirements are ANDed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchExpressions
-     */
-    readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions[];
+  readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector;
 
-    /**
-     * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchLabels
-     */
-    readonly matchLabels?: { [key: string]: string };
+  /**
+   * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#namespaces
+   */
+  readonly namespaces?: string[];
 
-  }
+  /**
+   * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution#topologyKey
+   */
+  readonly topologyKey?: string;
+
+}
+
+/**
+ * A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference {
+  /**
+   * A list of node selector requirements by node's labels.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions[];
+
+  /**
+   * A list of node selector requirements by node's fields.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference#matchFields
+   */
+  readonly matchFields?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields[];
+
+}
+
+/**
+ * A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms {
+  /**
+   * A list of node selector requirements by node's labels.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions[];
+
+  /**
+   * A list of node selector requirements by node's fields.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms#matchFields
+   */
+  readonly matchFields?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields[];
+
+}
+
+/**
+ * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm {
+  /**
+   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#labelSelector
+   */
+  readonly labelSelector?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector;
 
   /**
    * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaceSelector
    */
-  export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector {
-    /**
-     * matchExpressions is a list of label selector requirements. The requirements are ANDed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchExpressions
-     */
-    readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions[];
-
-    /**
-     * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchLabels
-     */
-    readonly matchLabels?: { [key: string]: string };
-
-  }
+  readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector;
 
   /**
-   * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaces
    */
-  export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions {
-    /**
-     * The label key that the selector applies to.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#key
-     */
-    readonly key?: string;
-
-    /**
-     * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-     *
-     * Possible enum values:
-     * - \`\\"DoesNotExist\\"\`
-     * - \`\\"Exists\\"\`
-     * - \`\\"Gt\\"\`
-     * - \`\\"In\\"\`
-     * - \`\\"Lt\\"\`
-     * - \`\\"NotIn\\"\`
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#operator
-     */
-    readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator;
-
-    /**
-     * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#values
-     */
-    readonly values?: string[];
-
-  }
+  readonly namespaces?: string[];
 
   /**
-   * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#topologyKey
    */
-  export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields {
-    /**
-     * The label key that the selector applies to.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#key
-     */
-    readonly key?: string;
+  readonly topologyKey: string;
 
-    /**
-     * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-     *
-     * Possible enum values:
-     * - \`\\"DoesNotExist\\"\`
-     * - \`\\"Exists\\"\`
-     * - \`\\"Gt\\"\`
-     * - \`\\"In\\"\`
-     * - \`\\"Lt\\"\`
-     * - \`\\"NotIn\\"\`
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#operator
-     */
-    readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator;
+}
 
-    /**
-     * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#values
-     */
-    readonly values?: string[];
-
-  }
+/**
+ * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector {
+  /**
+   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions[];
 
   /**
-   * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchLabels
    */
-  export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions {
-    /**
-     * The label key that the selector applies to.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#key
-     */
-    readonly key?: string;
+  readonly matchLabels?: { [key: string]: string };
 
-    /**
-     * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-     *
-     * Possible enum values:
-     * - \`\\"DoesNotExist\\"\`
-     * - \`\\"Exists\\"\`
-     * - \`\\"Gt\\"\`
-     * - \`\\"In\\"\`
-     * - \`\\"Lt\\"\`
-     * - \`\\"NotIn\\"\`
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#operator
-     */
-    readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator;
+}
 
-    /**
-     * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#values
-     */
-    readonly values?: string[];
-
-  }
+/**
+ * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector {
+  /**
+   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions[];
 
   /**
-   * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchLabels
    */
-  export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields {
-    /**
-     * The label key that the selector applies to.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#key
-     */
-    readonly key?: string;
+  readonly matchLabels?: { [key: string]: string };
 
-    /**
-     * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-     *
-     * Possible enum values:
-     * - \`\\"DoesNotExist\\"\`
-     * - \`\\"Exists\\"\`
-     * - \`\\"Gt\\"\`
-     * - \`\\"In\\"\`
-     * - \`\\"Lt\\"\`
-     * - \`\\"NotIn\\"\`
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#operator
-     */
-    readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator;
+}
 
-    /**
-     * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-     *
-     * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#values
-     */
-    readonly values?: string[];
-
-  }
+/**
+ * Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm {
+  /**
+   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#labelSelector
+   */
+  readonly labelSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector;
 
   /**
    * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaceSelector
    */
-  export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector {
-    /**
-     * matchExpressions is a list of label selector requirements. The requirements are ANDed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchExpressions
-     */
-    readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions[];
-
-    /**
-     * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchLabels
-     */
-    readonly matchLabels?: { [key: string]: string };
-
-  }
+  readonly namespaceSelector?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector;
 
   /**
-   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   * namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \\"this pod's namespace\\".
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#namespaces
    */
-  export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector {
-    /**
-     * matchExpressions is a list of label selector requirements. The requirements are ANDed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchExpressions
-     */
-    readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions[];
-
-    /**
-     * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchLabels
-     */
-    readonly matchLabels?: { [key: string]: string };
-
-  }
+  readonly namespaces?: string[];
 
   /**
-   * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   * This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm#topologyKey
    */
-  export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions {
-    /**
-     * key is the label key that the selector applies to.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#key
-     */
-    readonly key?: string;
+  readonly topologyKey: string;
 
-    /**
-     * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#operator
-     */
-    readonly operator?: string;
+}
 
-    /**
-     * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#values
-     */
-    readonly values?: string[];
-
-  }
+/**
+ * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector {
+  /**
+   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions[];
 
   /**
-   * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector#matchLabels
    */
-  export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions {
-    /**
-     * key is the label key that the selector applies to.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#key
-     */
-    readonly key?: string;
+  readonly matchLabels?: { [key: string]: string };
 
-    /**
-     * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#operator
-     */
-    readonly operator?: string;
+}
 
-    /**
-     * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#values
-     */
-    readonly values?: string[];
-
-  }
+/**
+ * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector {
+  /**
+   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions[];
 
   /**
-   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector#matchLabels
    */
-  export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector {
-    /**
-     * matchExpressions is a list of label selector requirements. The requirements are ANDed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchExpressions
-     */
-    readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions[];
+  readonly matchLabels?: { [key: string]: string };
 
-    /**
-     * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchLabels
-     */
-    readonly matchLabels?: { [key: string]: string };
+}
 
-  }
-
+/**
+ * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions {
   /**
-   * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+   * The label key that the selector applies to.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#key
    */
-  export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector {
-    /**
-     * matchExpressions is a list of label selector requirements. The requirements are ANDed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchExpressions
-     */
-    readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions[];
-
-    /**
-     * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchLabels
-     */
-    readonly matchLabels?: { [key: string]: string };
-
-  }
-
-  /**
-   * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions
-   */
-  export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions {
-    /**
-     * key is the label key that the selector applies to.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#key
-     */
-    readonly key?: string;
-
-    /**
-     * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#operator
-     */
-    readonly operator?: string;
-
-    /**
-     * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#values
-     */
-    readonly values?: string[];
-
-  }
-
-  /**
-   * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-   *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions
-   */
-  export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions {
-    /**
-     * key is the label key that the selector applies to.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#key
-     */
-    readonly key?: string;
-
-    /**
-     * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#operator
-     */
-    readonly operator?: string;
-
-    /**
-     * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#values
-     */
-    readonly values?: string[];
-
-  }
+  readonly key?: string;
 
   /**
    * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
@@ -25158,22 +24823,31 @@ export class Laceworkagent extends Construct {
    * - \`\\"Lt\\"\`
    * - \`\\"NotIn\\"\`
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#operator
    */
-  export enum IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator {
-    /** DoesNotExist */
-    DOES_NOT_EXIST = \\"DoesNotExist\\",
-    /** Exists */
-    EXISTS = \\"Exists\\",
-    /** Gt */
-    GT = \\"Gt\\",
-    /** In */
-    IN = \\"In\\",
-    /** Lt */
-    LT = \\"Lt\\",
-    /** NotIn */
-    NOT_IN = \\"NotIn\\",
-  }
+  readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator;
+
+  /**
+   * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields {
+  /**
+   * The label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#key
+   */
+  readonly key?: string;
 
   /**
    * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
@@ -25186,22 +24860,31 @@ export class Laceworkagent extends Construct {
    * - \`\\"Lt\\"\`
    * - \`\\"NotIn\\"\`
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#operator
    */
-  export enum IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator {
-    /** DoesNotExist */
-    DOES_NOT_EXIST = \\"DoesNotExist\\",
-    /** Exists */
-    EXISTS = \\"Exists\\",
-    /** Gt */
-    GT = \\"Gt\\",
-    /** In */
-    IN = \\"In\\",
-    /** Lt */
-    LT = \\"Lt\\",
-    /** NotIn */
-    NOT_IN = \\"NotIn\\",
-  }
+  readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator;
+
+  /**
+   * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions {
+  /**
+   * The label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#key
+   */
+  readonly key?: string;
 
   /**
    * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
@@ -25214,22 +24897,31 @@ export class Laceworkagent extends Construct {
    * - \`\\"Lt\\"\`
    * - \`\\"NotIn\\"\`
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#operator
    */
-  export enum IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator {
-    /** DoesNotExist */
-    DOES_NOT_EXIST = \\"DoesNotExist\\",
-    /** Exists */
-    EXISTS = \\"Exists\\",
-    /** Gt */
-    GT = \\"Gt\\",
-    /** In */
-    IN = \\"In\\",
-    /** Lt */
-    LT = \\"Lt\\",
-    /** NotIn */
-    NOT_IN = \\"NotIn\\",
-  }
+  readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator;
+
+  /**
+   * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields
+ */
+export interface IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields {
+  /**
+   * The label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#key
+   */
+  readonly key?: string;
 
   /**
    * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
@@ -25242,138 +24934,450 @@ export class Laceworkagent extends Construct {
    * - \`\\"Lt\\"\`
    * - \`\\"NotIn\\"\`
    *
-   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#operator
    */
-  export enum IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator {
-    /** DoesNotExist */
-    DOES_NOT_EXIST = \\"DoesNotExist\\",
-    /** Exists */
-    EXISTS = \\"Exists\\",
-    /** Gt */
-    GT = \\"Gt\\",
-    /** In */
-    IN = \\"In\\",
-    /** Lt */
-    LT = \\"Lt\\",
-    /** NotIn */
-    NOT_IN = \\"NotIn\\",
-  }
+  readonly operator?: IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator;
 
   /**
-   * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions
+   * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields#values
    */
-  export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions {
-    /**
-     * key is the label key that the selector applies to.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#key
-     */
-    readonly key?: string;
+  readonly values?: string[];
 
-    /**
-     * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#operator
-     */
-    readonly operator?: string;
+}
 
-    /**
-     * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#values
-     */
-    readonly values?: string[];
-
-  }
+/**
+ * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector {
+  /**
+   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions[];
 
   /**
-   * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchLabels
    */
-  export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions {
-    /**
-     * key is the label key that the selector applies to.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#key
-     */
-    readonly key?: string;
+  readonly matchLabels?: { [key: string]: string };
 
-    /**
-     * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#operator
-     */
-    readonly operator?: string;
+}
 
-    /**
-     * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#values
-     */
-    readonly values?: string[];
-
-  }
+/**
+ * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector {
+  /**
+   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions[];
 
   /**
-   * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchLabels
    */
-  export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions {
-    /**
-     * key is the label key that the selector applies to.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#key
-     */
-    readonly key?: string;
+  readonly matchLabels?: { [key: string]: string };
 
-    /**
-     * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#operator
-     */
-    readonly operator?: string;
+}
 
-    /**
-     * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#values
-     */
-    readonly values?: string[];
-
-  }
+/**
+ * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions {
+  /**
+   * key is the label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#key
+   */
+  readonly key?: string;
 
   /**
-   * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
    *
-   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#operator
    */
-  export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions {
-    /**
-     * key is the label key that the selector applies to.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#key
-     */
-    readonly key?: string;
+  readonly operator?: string;
 
-    /**
-     * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#operator
-     */
-    readonly operator?: string;
+  /**
+   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#values
+   */
+  readonly values?: string[];
 
-    /**
-     * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-     *
-     * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#values
-     */
-    readonly values?: string[];
+}
 
-  }
+/**
+ * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions {
+  /**
+   * key is the label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#operator
+   */
+  readonly operator?: string;
+
+  /**
+   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector {
+  /**
+   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions[];
+
+  /**
+   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector#matchLabels
+   */
+  readonly matchLabels?: { [key: string]: string };
+
+}
+
+/**
+ * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector {
+  /**
+   * matchExpressions is a list of label selector requirements. The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchExpressions
+   */
+  readonly matchExpressions?: IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions[];
+
+  /**
+   * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \\"key\\", the operator is \\"In\\", and the values array contains only \\"value\\". The requirements are ANDed.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector#matchLabels
+   */
+  readonly matchLabels?: { [key: string]: string };
+
+}
+
+/**
+ * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions {
+  /**
+   * key is the label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#operator
+   */
+  readonly operator?: string;
+
+  /**
+   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions {
+  /**
+   * key is the label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#operator
+   */
+  readonly operator?: string;
+
+  /**
+   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+ *
+ * Possible enum values:
+ * - \`\\"DoesNotExist\\"\`
+ * - \`\\"Exists\\"\`
+ * - \`\\"Gt\\"\`
+ * - \`\\"In\\"\`
+ * - \`\\"Lt\\"\`
+ * - \`\\"NotIn\\"\`
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator
+ */
+export enum IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressionsOperator {
+  /** DoesNotExist */
+  DOES_NOT_EXIST = \\"DoesNotExist\\",
+  /** Exists */
+  EXISTS = \\"Exists\\",
+  /** Gt */
+  GT = \\"Gt\\",
+  /** In */
+  IN = \\"In\\",
+  /** Lt */
+  LT = \\"Lt\\",
+  /** NotIn */
+  NOT_IN = \\"NotIn\\",
+}
+
+/**
+ * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+ *
+ * Possible enum values:
+ * - \`\\"DoesNotExist\\"\`
+ * - \`\\"Exists\\"\`
+ * - \`\\"Gt\\"\`
+ * - \`\\"In\\"\`
+ * - \`\\"Lt\\"\`
+ * - \`\\"NotIn\\"\`
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator
+ */
+export enum IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFieldsOperator {
+  /** DoesNotExist */
+  DOES_NOT_EXIST = \\"DoesNotExist\\",
+  /** Exists */
+  EXISTS = \\"Exists\\",
+  /** Gt */
+  GT = \\"Gt\\",
+  /** In */
+  IN = \\"In\\",
+  /** Lt */
+  LT = \\"Lt\\",
+  /** NotIn */
+  NOT_IN = \\"NotIn\\",
+}
+
+/**
+ * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+ *
+ * Possible enum values:
+ * - \`\\"DoesNotExist\\"\`
+ * - \`\\"Exists\\"\`
+ * - \`\\"Gt\\"\`
+ * - \`\\"In\\"\`
+ * - \`\\"Lt\\"\`
+ * - \`\\"NotIn\\"\`
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator
+ */
+export enum IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressionsOperator {
+  /** DoesNotExist */
+  DOES_NOT_EXIST = \\"DoesNotExist\\",
+  /** Exists */
+  EXISTS = \\"Exists\\",
+  /** Gt */
+  GT = \\"Gt\\",
+  /** In */
+  IN = \\"In\\",
+  /** Lt */
+  LT = \\"Lt\\",
+  /** NotIn */
+  NOT_IN = \\"NotIn\\",
+}
+
+/**
+ * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+ *
+ * Possible enum values:
+ * - \`\\"DoesNotExist\\"\`
+ * - \`\\"Exists\\"\`
+ * - \`\\"Gt\\"\`
+ * - \`\\"In\\"\`
+ * - \`\\"Lt\\"\`
+ * - \`\\"NotIn\\"\`
+ *
+ * @schema IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator
+ */
+export enum IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFieldsOperator {
+  /** DoesNotExist */
+  DOES_NOT_EXIST = \\"DoesNotExist\\",
+  /** Exists */
+  EXISTS = \\"Exists\\",
+  /** Gt */
+  GT = \\"Gt\\",
+  /** In */
+  IN = \\"In\\",
+  /** Lt */
+  LT = \\"Lt\\",
+  /** NotIn */
+  NOT_IN = \\"NotIn\\",
+}
+
+/**
+ * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions {
+  /**
+   * key is the label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#operator
+   */
+  readonly operator?: string;
+
+  /**
+   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions {
+  /**
+   * key is the label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#operator
+   */
+  readonly operator?: string;
+
+  /**
+   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions {
+  /**
+   * key is the label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#operator
+   */
+  readonly operator?: string;
+
+  /**
+   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
+
+/**
+ * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+ *
+ * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions
+ */
+export interface IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions {
+  /**
+   * key is the label key that the selector applies to.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#key
+   */
+  readonly key?: string;
+
+  /**
+   * operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#operator
+   */
+  readonly operator?: string;
+
+  /**
+   * values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+   *
+   * @schema IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions#values
+   */
+  readonly values?: string[];
+
+}
 
 ",
 }
@@ -26039,7 +26043,7 @@ export interface OperatorProps {
 
 export class Operator extends Construct {
   public constructor(scope: Construct, id: string, props: OperatorProps = {}) {
-    super(scope, id)
+    super(scope, id);
     let updatedProps = {};
 
     if (props.values) {
@@ -26049,7 +26053,7 @@ export class Operator extends Construct {
         values: {
           ...this.flattenAdditionalValues(valuesWithoutAdditionalValues),
           ...additionalValues,
-        }
+        },
       };
     }
 
@@ -26060,31 +26064,32 @@ export class Operator extends Construct {
       ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
     };
 
-    new Helm(scope, \`Helm\${id}\`, finalProps)
+    new Helm(this, 'Helm', finalProps);
   }
 
   private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
     for (let prop in props) {
       if (Array.isArray(props[prop])) {
         props[prop].map((item: any) => {
-          if (typeof(item) === 'object' && prop !== 'additionalValues') {
+          if (typeof item === 'object' && prop !== 'additionalValues') {
             return this.flattenAdditionalValues(item);
           }
           return item;
         });
-        } else if (typeof(props[prop]) === 'object' && prop !== 'additionalValues') {
-          props[prop] = this.flattenAdditionalValues(props[prop]);
-        }
       }
-
-      const { additionalValues, ...valuesWithoutAdditionalValues } = props;
-
-      return {
-        ...valuesWithoutAdditionalValues,
-        ...additionalValues,
-      };
+      else if (typeof props[prop] === 'object' && prop !== 'additionalValues') {
+        props[prop] = this.flattenAdditionalValues(props[prop]);
+      }
     }
+
+    const { additionalValues, ...valuesWithoutAdditionalValues } = props;
+
+    return {
+      ...valuesWithoutAdditionalValues,
+      ...additionalValues,
+    };
   }
+}
 
 ",
 }

--- a/test/import/import-helm.test.ts
+++ b/test/import/import-helm.test.ts
@@ -7,7 +7,9 @@ import { parseImports } from '../../src/util';
 describe.each([
   'helm:https://charts.bitnami.com/bitnami/mysql@9.10.10', // Contains schema and dependencies
   'helm:https://kubernetes.github.io/ingress-nginx/ingress-nginx@4.8.0', // Does not contain schema
-  'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0', //
+  'helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0',
+  'minio:=helm:https://operator.min.io/operator@5.0.9',
+  'helm:https://grafana.github.io/helm-charts/loki@5.27.0',
 ])('importing helm chart %s', (testChartUrl) => {
   const spec = parseImports(testChartUrl);
 

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -77,6 +77,7 @@ test('import is helm', () => {
   expect(isHelmImport('helm:https://charts.bitnami.com/bitnami/mysql@9.10.10')).toBeTruthy();
   expect(isHelmImport('helm:https://kubernetes.github.io/ingress-nginx/ingress-nginx@4.8.0')).toBeTruthy();
   expect(isHelmImport('helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0')).toBeTruthy();
+  expect(isHelmImport('minio:=helm:https://operator.min.io/operator@5.0.9')).toBeTruthy();
   expect(isHelmImport('foo')).toBeFalsy();
 });
 


### PR DESCRIPTION
Currently, `flattenAdditionalValues` is not handling arrays correctly since these are also handled similar to `objects`. Adding functionality to support this. 
* Also updating `Helm` construct id to unique `ids`. 
* And, adding `:=helm:` to `isHelmImport` function.

Fixes https://github.com/cdk8s-team/cdk8s-cli/issues/1538