### PR TITLE
fix(templates): tell jest to prefer ts files over compiled js files

### DIFF
--- a/templates/typescript-app/jest.config.js
+++ b/templates/typescript-app/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
     "roots": [
         "<rootDir>"
     ],
+    moduleFileExtensions: ["ts", "tsx", "js", "mjs", "cjs", "jsx", "json", "node"],
     testMatch: [ '**/*.test.ts'],
     "transform": {
         "^.+\\.tsx?$": "ts-jest"


### PR DESCRIPTION
The template project can run completely without emitting `.js` files, - e.g. `ts-node` is used for synth and `ts-jest`.
However, if `js` files are emitted via `npm run compile`, they are imported by test files instead of `.ts` files that may have been updated.

i.e. given this import in `main.test.ts`,  it will import and test `main.ts` unless `main.js` exists in which case `main.js` is imported.
```typescript
import {MyChart} from './main';
```
This is rather confusing if e.g. some changes to `main.ts` have been pulled. Let's fix this!

Approach: per https://jestjs.io/docs/configuration#modulefileextensions-arraystring
> We recommend placing the extensions most commonly used in your project on the left, so if you are using TypeScript, you may want to consider moving "ts" and/or "tsx" to the beginning of the array.

