### PR TITLE
chore: Update backport dependency to 9.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     }
   },
   "optionalDependencies": {
-    "backport": "8.5.0"
+    "backport": "9.5.0"
   },
   "exports": {
     "./plugins": "./lib/plugins/index.js",


### PR DESCRIPTION
Backport < 9 has an old version of axios which has a security vuln