### PR TITLE
chore: install helm before running tests

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -150,6 +150,16 @@
         }
       ]
     },
+    "install-helm": {
+      "name": "install-helm",
+      "description": "Install helm3",
+      "steps": [
+        {
+          "exec": "curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash"
+        }
+      ],
+      "condition": "! (helm version | grep \"v3.\")"
+    },
     "install:ci": {
       "name": "install:ci",
       "description": "Install project dependencies using frozen lockfile",
@@ -371,6 +381,9 @@
       "name": "test",
       "description": "Run tests",
       "steps": [
+        {
+          "spawn": "install-helm"
+        },
         {
           "exec": "jest --passWithNoTests --updateSnapshot",
           "receiveArgs": true

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -89,6 +89,16 @@ project.deps.addDependency('@types/node@^16', DependencyType.RUNTIME);
 const schemas = project.addTask('schemas');
 schemas.exec('ts-node scripts/crd.schema.ts');
 
+const installHelm = project.addTask('install-helm', {
+  exec: 'curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash',
+  description: 'Install helm3',
+
+  // will exit with non-zero if helm is not installed or has the wrong version
+  condition: '! (helm version | grep "v3.")',
+});
+
+project.testTask.prependSpawn(installHelm);
+
 project.compileTask.spawn(schemas);
 
 // so that it works on windows as well

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "default": "npx projen default",
     "eject": "npx projen eject",
     "eslint": "npx projen eslint",
+    "install-helm": "npx projen install-helm",
     "integ:init": "npx projen integ:init",
     "integ:init:go-app-npm": "npx projen integ:init:go-app-npm",
     "integ:init:go-app-yarn": "npx projen integ:init:go-app-yarn",


### PR DESCRIPTION
Makes it easier to build cdk8s on different platforms that might not have `helm` installed by default. (e.g CodeBuild).

This is consistent with what we have in [cdk8s-core](https://github.com/cdk8s-team/cdk8s-core/blob/832e3b13a077a58a03d72f34d37c27df48150603/.projenrc.js#L55-L63).