### PR TITLE
fix: dummy to trigger release

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ See [cdk8s.io](https://cdk8s.io).
 This project is distributed under the [Apache License, Version 2.0](./LICENSE).
 
 This module is part of the [cdk8s project](https://github.com/awslabs/cdk8s).
+


### PR DESCRIPTION
Even though https://github.com/cdk8s-team/cdk8s-cli/pull/2409 was chore, we actually need it to be part of the tag, so we need to release it :\

Dummy `fix` commit to trigger the release and update the tags. 