### PR TITLE
fix(init): init templates are using an unmanitained version of cdk8s-plus

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -109,7 +109,7 @@
       "type": "runtime"
     },
     {
-      "name": "cdk8s-plus-25",
+      "name": "cdk8s-plus-28",
       "type": "runtime"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -499,13 +499,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=prod,optional --filter=ajv,cdk8s,cdk8s-plus-25,codemaker,colors,constructs,jsii-pacmak,jsii-rosetta,jsii-srcmak,json2jsii,semver,sscaff,table,yaml"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=prod,optional --filter=ajv,cdk8s,cdk8s-plus-28,codemaker,colors,constructs,jsii-pacmak,jsii-rosetta,jsii-srcmak,json2jsii,semver,sscaff,table,yaml"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @types/node ajv cdk8s cdk8s-plus-25 codemaker colors constructs fs-extra jsii-pacmak jsii-rosetta jsii-srcmak json2jsii semver sscaff table yaml yargs"
+          "exec": "yarn upgrade @types/node ajv cdk8s cdk8s-plus-28 codemaker colors constructs fs-extra jsii-pacmak jsii-rosetta jsii-srcmak json2jsii semver sscaff table yaml yargs"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -34,7 +34,7 @@ const project = new Cdk8sTeamTypeScriptProject({
   },
   deps: [
     'cdk8s',
-    'cdk8s-plus-25',
+    'cdk8s-plus-28',
     'codemaker',
     'constructs',
     'fs-extra@^8',

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@types/node": "^16",
     "ajv": "^8.17.1",
     "cdk8s": "^2.68.92",
-    "cdk8s-plus-25": "^2.22.79",
+    "cdk8s-plus-28": "^2.3.17",
     "codemaker": "^1.102.0",
     "colors": "1.4.0",
     "constructs": "^10.3.0",

--- a/src/cli/cmds/init.ts
+++ b/src/cli/cmds/init.ts
@@ -42,7 +42,7 @@ class Command implements yargs.CommandModule {
 
 async function determineDeps(): Promise<Deps> {
   const cdk8s = new ModuleVersion('cdk8s', { jsii: true });
-  const cdk8sPlus = new ModuleVersion('cdk8s-plus-25', { jsii: true });
+  const cdk8sPlus = new ModuleVersion('cdk8s-plus-28', { jsii: true });
   const cdk8sCli = new ModuleVersion('cdk8s-cli');
   const jsii = new ModuleVersion('jsii-pacmak');
 

--- a/templates/java-app/.hooks.sscaff.js
+++ b/templates/java-app/.hooks.sscaff.js
@@ -31,7 +31,7 @@ exports.post = options => {
   }
 
   if (mvn_cdk8s_plus.endsWith('.jar')) {
-    execSync(`mvn install:install-file -Dfile=${mvn_cdk8s_plus} -DgroupId=org.cdk8s -DartifactId=cdk8s-plus-25 -Dversion=${cdk8s_plus_version} -Dpackaging=jar`)
+    execSync(`mvn install:install-file -Dfile=${mvn_cdk8s_plus} -DgroupId=org.cdk8s -DartifactId=cdk8s-plus-28 -Dversion=${cdk8s_plus_version} -Dpackaging=jar`)
   }
 
   execSync(`mvn install`);

--- a/templates/java-app/pom.xml
+++ b/templates/java-app/pom.xml
@@ -15,7 +15,7 @@
     </dependency>
     <dependency>
       <groupId>org.cdk8s</groupId>
-      <artifactId>cdk8s-plus-25</artifactId>
+      <artifactId>cdk8s-plus-28</artifactId>
       <version>{{ cdk8s_plus_version }}</version>
     </dependency>
     <dependency>

--- a/templates/typescript-app/package.json
+++ b/templates/typescript-app/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "cdk8s": "^{{ cdk8s_core_version }}",
-    "cdk8s-plus-25": "^{{ cdk8s_plus_version }}",
+    "cdk8s-plus-28": "^{{ cdk8s_plus_version }}",
     "constructs": "^{{ constructs_version }}"
   },
   "devDependencies": {

--- a/test/import/__snapshots__/import-helm.test.ts.snap
+++ b/test/import/__snapshots__/import-helm.test.ts.snap
@@ -1249,7 +1249,10 @@ Object {
 
 exports[`importing helm chart helm:https://charts.bitnami.com/bitnami/mysql@9.10.10 with python lanugage 2`] = `
 Object {
-  "mysql/__init__.py": "import abc
+  "mysql/__init__.py": "from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)
+
+import abc
 import builtins
 import datetime
 import enum
@@ -2491,7 +2494,10 @@ def _typecheckingstub__ba4b7249d1a1862400c9b19cff8ae48324c2ce9cf5eddeb6ee91753a0
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 ",
-  "mysql/_jsii/__init__.py": "import abc
+  "mysql/_jsii/__init__.py": "from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)
+
+import abc
 import builtins
 import datetime
 import enum
@@ -4358,7 +4364,10 @@ Object {
 
 exports[`importing helm chart helm:https://grafana.github.io/helm-charts/loki@5.27.0 with python lanugage 2`] = `
 Object {
-  "loki/__init__.py": "import abc
+  "loki/__init__.py": "from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)
+
+import abc
 import builtins
 import datetime
 import enum
@@ -4530,7 +4539,10 @@ def _typecheckingstub__c8e7d6706b1656a9b1ed96c19860786a777f4336504fed38f4230700c
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 ",
-  "loki/_jsii/__init__.py": "import abc
+  "loki/_jsii/__init__.py": "from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)
+
+import abc
 import builtins
 import datetime
 import enum
@@ -5070,7 +5082,10 @@ Object {
 
 exports[`importing helm chart helm:https://kubernetes.github.io/ingress-nginx/ingress-nginx@4.8.0 with python lanugage 2`] = `
 Object {
-  "ingress_nginx/__init__.py": "import abc
+  "ingress_nginx/__init__.py": "from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)
+
+import abc
 import builtins
 import datetime
 import enum
@@ -5242,7 +5257,10 @@ def _typecheckingstub__85110f2d73c16d180cff3964310561744c0306d72b234ccd18c0a1c76
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 ",
-  "ingress_nginx/_jsii/__init__.py": "import abc
+  "ingress_nginx/_jsii/__init__.py": "from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)
+
+import abc
 import builtins
 import datetime
 import enum
@@ -11466,7 +11484,10 @@ Possible enum values:
 
 exports[`importing helm chart helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0 with python lanugage 2`] = `
 Object {
-  "lacework_agent/__init__.py": "import abc
+  "lacework_agent/__init__.py": "from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)
+
+import abc
 import builtins
 import datetime
 import enum
@@ -17433,7 +17454,10 @@ def _typecheckingstub__75de6b5286dea4b274a90e031e8b30635c9eeb0419b57e7aeb0962ead
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 ",
-  "lacework_agent/_jsii/__init__.py": "import abc
+  "lacework_agent/_jsii/__init__.py": "from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)
+
+import abc
 import builtins
 import datetime
 import enum
@@ -26632,7 +26656,10 @@ Object {
 
 exports[`importing helm chart helm:oci://registry-1.docker.io/bitnamicharts/mysql@9.12.5 with python lanugage 2`] = `
 Object {
-  "mysql/__init__.py": "import abc
+  "mysql/__init__.py": "from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)
+
+import abc
 import builtins
 import datetime
 import enum
@@ -27874,7 +27901,10 @@ def _typecheckingstub__ba4b7249d1a1862400c9b19cff8ae48324c2ce9cf5eddeb6ee91753a0
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 ",
-  "mysql/_jsii/__init__.py": "import abc
+  "mysql/_jsii/__init__.py": "from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)
+
+import abc
 import builtins
 import datetime
 import enum
@@ -29740,7 +29770,10 @@ Object {
 
 exports[`importing helm chart minio:=helm:https://operator.min.io/operator@5.0.9 with python lanugage 2`] = `
 Object {
-  "operator/__init__.py": "import abc
+  "operator/__init__.py": "from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)
+
+import abc
 import builtins
 import datetime
 import enum
@@ -29912,7 +29945,10 @@ def _typecheckingstub__1ba6cfa05344ec1eb73016e5b58b05d2a9a2e22bf82546647dd2d6dac
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 ",
-  "operator/_jsii/__init__.py": "import abc
+  "operator/_jsii/__init__.py": "from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)
+
+import abc
 import builtins
 import datetime
 import enum

--- a/test/import/__snapshots__/import-helm.test.ts.snap
+++ b/test/import/__snapshots__/import-helm.test.ts.snap
@@ -1249,10 +1249,7 @@ Object {
 
 exports[`importing helm chart helm:https://charts.bitnami.com/bitnami/mysql@9.10.10 with python lanugage 2`] = `
 Object {
-  "mysql/__init__.py": "from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)
-
-import abc
+  "mysql/__init__.py": "import abc
 import builtins
 import datetime
 import enum
@@ -2494,10 +2491,7 @@ def _typecheckingstub__ba4b7249d1a1862400c9b19cff8ae48324c2ce9cf5eddeb6ee91753a0
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 ",
-  "mysql/_jsii/__init__.py": "from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)
-
-import abc
+  "mysql/_jsii/__init__.py": "import abc
 import builtins
 import datetime
 import enum
@@ -4364,10 +4358,7 @@ Object {
 
 exports[`importing helm chart helm:https://grafana.github.io/helm-charts/loki@5.27.0 with python lanugage 2`] = `
 Object {
-  "loki/__init__.py": "from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)
-
-import abc
+  "loki/__init__.py": "import abc
 import builtins
 import datetime
 import enum
@@ -4539,10 +4530,7 @@ def _typecheckingstub__c8e7d6706b1656a9b1ed96c19860786a777f4336504fed38f4230700c
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 ",
-  "loki/_jsii/__init__.py": "from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)
-
-import abc
+  "loki/_jsii/__init__.py": "import abc
 import builtins
 import datetime
 import enum
@@ -5082,10 +5070,7 @@ Object {
 
 exports[`importing helm chart helm:https://kubernetes.github.io/ingress-nginx/ingress-nginx@4.8.0 with python lanugage 2`] = `
 Object {
-  "ingress_nginx/__init__.py": "from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)
-
-import abc
+  "ingress_nginx/__init__.py": "import abc
 import builtins
 import datetime
 import enum
@@ -5257,10 +5242,7 @@ def _typecheckingstub__85110f2d73c16d180cff3964310561744c0306d72b234ccd18c0a1c76
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 ",
-  "ingress_nginx/_jsii/__init__.py": "from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)
-
-import abc
+  "ingress_nginx/_jsii/__init__.py": "import abc
 import builtins
 import datetime
 import enum
@@ -11484,10 +11466,7 @@ Possible enum values:
 
 exports[`importing helm chart helm:https://lacework.github.io/helm-charts/lacework-agent@6.9.0 with python lanugage 2`] = `
 Object {
-  "lacework_agent/__init__.py": "from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)
-
-import abc
+  "lacework_agent/__init__.py": "import abc
 import builtins
 import datetime
 import enum
@@ -17454,10 +17433,7 @@ def _typecheckingstub__75de6b5286dea4b274a90e031e8b30635c9eeb0419b57e7aeb0962ead
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 ",
-  "lacework_agent/_jsii/__init__.py": "from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)
-
-import abc
+  "lacework_agent/_jsii/__init__.py": "import abc
 import builtins
 import datetime
 import enum
@@ -26656,10 +26632,7 @@ Object {
 
 exports[`importing helm chart helm:oci://registry-1.docker.io/bitnamicharts/mysql@9.12.5 with python lanugage 2`] = `
 Object {
-  "mysql/__init__.py": "from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)
-
-import abc
+  "mysql/__init__.py": "import abc
 import builtins
 import datetime
 import enum
@@ -27901,10 +27874,7 @@ def _typecheckingstub__ba4b7249d1a1862400c9b19cff8ae48324c2ce9cf5eddeb6ee91753a0
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 ",
-  "mysql/_jsii/__init__.py": "from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)
-
-import abc
+  "mysql/_jsii/__init__.py": "import abc
 import builtins
 import datetime
 import enum
@@ -29770,10 +29740,7 @@ Object {
 
 exports[`importing helm chart minio:=helm:https://operator.min.io/operator@5.0.9 with python lanugage 2`] = `
 Object {
-  "operator/__init__.py": "from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)
-
-import abc
+  "operator/__init__.py": "import abc
 import builtins
 import datetime
 import enum
@@ -29945,10 +29912,7 @@ def _typecheckingstub__1ba6cfa05344ec1eb73016e5b58b05d2a9a2e22bf82546647dd2d6dac
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 ",
-  "operator/_jsii/__init__.py": "from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)
-
-import abc
+  "operator/_jsii/__init__.py": "import abc
 import builtins
 import datetime
 import enum

--- a/yarn.lock
+++ b/yarn.lock
@@ -626,30 +626,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@octokit/auth-token@^2.4.4":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.5.0.tgz#27c37ea26c205f28443402477ffd261311f21e36"
-  integrity sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==
-  dependencies:
-    "@octokit/types" "^6.0.3"
-
 "@octokit/auth-token@^3.0.0":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-3.0.4.tgz#70e941ba742bdd2b49bdb7393e821dea8520a3db"
   integrity sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==
-
-"@octokit/core@^3.5.1":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.6.0.tgz#3376cb9f3008d9b3d110370d90e0a1fcd5fe6085"
-  integrity sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==
-  dependencies:
-    "@octokit/auth-token" "^2.4.4"
-    "@octokit/graphql" "^4.5.8"
-    "@octokit/request" "^5.6.3"
-    "@octokit/request-error" "^2.0.5"
-    "@octokit/types" "^6.0.3"
-    before-after-hook "^2.2.0"
-    universal-user-agent "^6.0.0"
 
 "@octokit/core@^4.2.1":
   version "4.2.4"
@@ -664,15 +644,6 @@
     before-after-hook "^2.2.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/endpoint@^6.0.1":
-  version "6.0.12"
-  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.12.tgz#3b4d47a4b0e79b1027fb8d75d4221928b2d05658"
-  integrity sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==
-  dependencies:
-    "@octokit/types" "^6.0.3"
-    is-plain-object "^5.0.0"
-    universal-user-agent "^6.0.0"
-
 "@octokit/endpoint@^7.0.0":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-7.0.6.tgz#791f65d3937555141fb6c08f91d618a7d645f1e2"
@@ -680,15 +651,6 @@
   dependencies:
     "@octokit/types" "^9.0.0"
     is-plain-object "^5.0.0"
-    universal-user-agent "^6.0.0"
-
-"@octokit/graphql@^4.5.8":
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.8.0.tgz#664d9b11c0e12112cbf78e10f49a05959aa22cc3"
-  integrity sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==
-  dependencies:
-    "@octokit/request" "^5.6.0"
-    "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
 
 "@octokit/graphql@^5.0.0":
@@ -700,22 +662,10 @@
     "@octokit/types" "^9.0.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/openapi-types@^12.11.0":
-  version "12.11.0"
-  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-12.11.0.tgz#da5638d64f2b919bca89ce6602d059f1b52d3ef0"
-  integrity sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ==
-
 "@octokit/openapi-types@^18.0.0":
   version "18.1.1"
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-18.1.1.tgz#09bdfdabfd8e16d16324326da5148010d765f009"
   integrity sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw==
-
-"@octokit/plugin-paginate-rest@^2.16.8":
-  version "2.21.3"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz#7f12532797775640dbb8224da577da7dc210c87e"
-  integrity sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==
-  dependencies:
-    "@octokit/types" "^6.40.0"
 
 "@octokit/plugin-paginate-rest@^6.1.2":
   version "6.1.2"
@@ -730,29 +680,12 @@
   resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz#5e50ed7083a613816b1e4a28aeec5fb7f1462e85"
   integrity sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==
 
-"@octokit/plugin-rest-endpoint-methods@^5.12.0":
-  version "5.16.2"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz#7ee8bf586df97dd6868cf68f641354e908c25342"
-  integrity sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==
-  dependencies:
-    "@octokit/types" "^6.39.0"
-    deprecation "^2.3.1"
-
 "@octokit/plugin-rest-endpoint-methods@^7.1.2":
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz#37a84b171a6cb6658816c82c4082ac3512021797"
   integrity sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==
   dependencies:
     "@octokit/types" "^10.0.0"
-
-"@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
-  integrity sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==
-  dependencies:
-    "@octokit/types" "^6.0.3"
-    deprecation "^2.0.0"
-    once "^1.4.0"
 
 "@octokit/request-error@^3.0.0":
   version "3.0.3"
@@ -762,18 +695,6 @@
     "@octokit/types" "^9.0.0"
     deprecation "^2.0.0"
     once "^1.4.0"
-
-"@octokit/request@^5.6.0", "@octokit/request@^5.6.3":
-  version "5.6.3"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.3.tgz#19a022515a5bba965ac06c9d1334514eb50c48b0"
-  integrity sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==
-  dependencies:
-    "@octokit/endpoint" "^6.0.1"
-    "@octokit/request-error" "^2.1.0"
-    "@octokit/types" "^6.16.1"
-    is-plain-object "^5.0.0"
-    node-fetch "^2.6.7"
-    universal-user-agent "^6.0.0"
 
 "@octokit/request@^6.0.0":
   version "6.2.8"
@@ -786,16 +707,6 @@
     is-plain-object "^5.0.0"
     node-fetch "^2.6.7"
     universal-user-agent "^6.0.0"
-
-"@octokit/rest@^18.12.0":
-  version "18.12.0"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.12.0.tgz#f06bc4952fc87130308d810ca9d00e79f6988881"
-  integrity sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==
-  dependencies:
-    "@octokit/core" "^3.5.1"
-    "@octokit/plugin-paginate-rest" "^2.16.8"
-    "@octokit/plugin-request-log" "^1.0.4"
-    "@octokit/plugin-rest-endpoint-methods" "^5.12.0"
 
 "@octokit/rest@^19.0.7":
   version "19.0.13"
@@ -818,13 +729,6 @@
   integrity sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
-
-"@octokit/types@^6.0.3", "@octokit/types@^6.16.1", "@octokit/types@^6.39.0", "@octokit/types@^6.40.0":
-  version "6.41.0"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.41.0.tgz#e58ef78d78596d2fb7df9c6259802464b5f84a04"
-  integrity sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==
-  dependencies:
-    "@octokit/openapi-types" "^12.11.0"
 
 "@octokit/types@^9.0.0", "@octokit/types@^9.2.3":
   version "9.3.2"
@@ -1475,14 +1379,6 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^0.27.2:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
-  dependencies:
-    follow-redirects "^1.14.9"
-    form-data "^4.0.0"
-
 axios@^1.3.4:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.3.tgz#a1125f2faf702bc8e8f2104ec3a76fab40257d85"
@@ -1552,31 +1448,6 @@ babel-preset-jest@^27.5.1:
   dependencies:
     babel-plugin-jest-hoist "^27.5.1"
     babel-preset-current-node-syntax "^1.0.0"
-
-backport@8.5.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/backport/-/backport-8.5.0.tgz#f37459eaa4272d47efe050b06a22b10209f16d49"
-  integrity sha512-gX8v+l+BTue2lmmqD/yQiR6JUUY+5OWNZTI1qyusViqC9R2iv4YFPqT23IcJfpYqlYb3DOiwunfVjKLickdQ6g==
-  dependencies:
-    "@octokit/rest" "^18.12.0"
-    axios "^0.27.2"
-    dedent "^0.7.0"
-    del "^6.1.1"
-    dotenv "^16.0.1"
-    find-up "^5.0.0"
-    graphql "^16.5.0"
-    graphql-tag "^2.12.6"
-    inquirer "^8.2.3"
-    lodash "^4.17.21"
-    make-dir "^3.1.0"
-    ora "^5.4.1"
-    safe-json-stringify "^1.2.0"
-    strip-json-comments "^3.1.1"
-    terminal-link "^2.1.1"
-    utility-types "^3.10.0"
-    winston "^3.7.2"
-    yargs "^17.5.1"
-    yargs-parser "^21.0.1"
 
 backport@8.9.9:
   version "8.9.9"
@@ -1756,14 +1627,12 @@ case@^1.6.3:
   resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
   integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
-cdk8s-plus-25@^2.22.79:
-  version "2.22.79"
-  resolved "https://registry.yarnpkg.com/cdk8s-plus-25/-/cdk8s-plus-25-2.22.79.tgz#2b9a5230668c671a7fbdd213c08e1d3e3f2f9ff6"
-  integrity sha512-QSxCBAbLvDJvC3lqt7lO2x8Il84kCsrwIdfAVFxUiwh4wHQxi18ENI9JI16tEhS/2gxv1YyeUNBM1ucH6q9oJA==
+cdk8s-plus-28@^2.3.17:
+  version "2.3.17"
+  resolved "https://registry.yarnpkg.com/cdk8s-plus-28/-/cdk8s-plus-28-2.3.17.tgz#b39ae257cf0847a3f54ce715ec71ffe8e03150ba"
+  integrity sha512-ZFKJ8bmQBK+d1INy38gAdE5Ufw4sYuis83wzOxtYIUGJ4tg+evKhRvz8xrJkKE/Z8Psmf3yB3h65fKplhwpo3g==
   dependencies:
     minimatch "^3.1.2"
-  optionalDependencies:
-    backport "8.5.0"
 
 cdk8s@^2.68.92:
   version "2.68.92"
@@ -2363,7 +2232,7 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-deprecation@^2.0.0, deprecation@^2.3.1:
+deprecation@^2.0.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
@@ -2441,7 +2310,7 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
-dotenv@^16.0.1, dotenv@^16.0.3:
+dotenv@^16.0.3:
   version "16.4.5"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
   integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
@@ -3016,7 +2885,7 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.14.9, follow-redirects@^1.15.6:
+follow-redirects@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
@@ -3286,7 +3155,7 @@ graphql-tag@^2.12.6:
   dependencies:
     tslib "^2.1.0"
 
-graphql@^16.5.0, graphql@^16.6.0:
+graphql@^16.6.0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.9.0.tgz#1c310e63f16a49ce1fbb230bd0a000e99f6f115f"
   integrity sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==
@@ -3495,7 +3364,7 @@ ini@^2.0.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
   integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
-inquirer@^8.2.3, inquirer@^8.2.5:
+inquirer@^8.2.5:
   version "8.2.6"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.6.tgz#733b74888195d8d400a67ac332011b5fae5ea562"
   integrity sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==
@@ -6566,7 +6435,7 @@ winston-transport@^4.7.0:
     readable-stream "^3.6.2"
     triple-beam "^1.3.0"
 
-winston@^3.7.2, winston@^3.8.2:
+winston@^3.8.2:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/winston/-/winston-3.13.1.tgz#53ddadb9c2332eb12cff8306413b3480dc82b6c3"
   integrity sha512-SvZit7VFNvXRzbqGHsv5KSmgbEYR5EiQfDAL9gxYkRqa934Hnk++zze0wANKtMHcy/gI4W/3xmSDwlhf865WGw==
@@ -6714,7 +6583,7 @@ yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^21.0.1, yargs-parser@^21.1.1:
+yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
@@ -6749,7 +6618,7 @@ yargs@^16.0.0, yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.1.1, yargs@^17.5.1, yargs@^17.7.1, yargs@^17.7.2:
+yargs@^17.1.1, yargs@^17.7.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
Support for k8s 1.25 ended a while ago, and so did support for cdk8s-plus-25. 

> See https://endoflife.date/kubernetes

Bump the init templates to use the minimum supported version as of now, which is 28. We will also add bumping this as part of cdk8s-plus rotation. 

