### PR TITLE
chore: can skip tests during build by setting SKIP_TESTS=1

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -346,7 +346,8 @@
         {
           "spawn": "eslint"
         }
-      ]
+      ],
+      "condition": "node -e \"if (process.env.SKIP_TESTS==='1') process.exit(1)\""
     },
     "test:watch": {
       "name": "test:watch",

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -97,7 +97,7 @@ project.compileTask.spawn(schemas);
 
 // Allow skipping tests in build based on an env variable
 // This is only used by the package integrity check running outside the repo
-// While this check needs to replicate the release, it does not need to run tests 
+// While this check needs to replicate the release, it does not need to run tests
 project.testTask.addCondition("node -e \"if (process.env.SKIP_TESTS==='1') process.exit(1)\"");
 
 

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -95,11 +95,10 @@ project.testTask.prependSpawn(installHelm);
 
 project.compileTask.spawn(schemas);
 
-// so that it works on windows as well
-// default projen uses $(npm pack) which fails
-project.packageTask.reset();
-project.packageTask.exec('mkdir -p dist/js');
-project.packageTask.exec('npm pack --pack-destination dist/js');
+// Allow skipping tests in build based on an env variable
+// This is only used by the package integrity check running outside the repo
+// While this check needs to replicate the release, it does not need to run tests 
+project.testTask.addCondition("node -e \"if (process.env.SKIP_TESTS==='1') process.exit(1)\"");
 
 
 addIntegTests(project);


### PR DESCRIPTION
This is only used by the package integrity check running outside the repo. While this check needs to replicate the release, it does not need to run tests.

To skip tests, set `SKIP_TESTS=1`
