### PR TITLE
feat: expose helm from Helm chart class

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -57,4 +57,4 @@ jobs:
       fail-fast: false
       matrix:
         nodeVersion:
-          - 18
+          - 20

--- a/projenrc/integ.ts
+++ b/projenrc/integ.ts
@@ -33,7 +33,7 @@ export function addIntegTests(project: typescript.TypeScriptProject) {
     }
   }
 
-  // run all init tests on node 16
+  // run all init tests on all node LTS
   integWorkflow.addJob('init', {
     runsOn: ['${{ matrix.os }}'],
     strategy: {
@@ -48,8 +48,8 @@ export function addIntegTests(project: typescript.TypeScriptProject) {
     steps: runSteps([initTask.name], 'lts/*', true, true),
   });
 
-  // run typescript app on node 18 as well
-  const nodeVersions = [18];
+  // run typescript app on node 20 as well
+  const nodeVersions = [20];
   integWorkflow.addJob('init-typescript-app', {
     runsOn: ['ubuntu-latest'],
     strategy: {

--- a/src/import/codegen.ts
+++ b/src/import/codegen.ts
@@ -346,6 +346,8 @@ export function generateHelmConstruct(typegen: TypeGenerator, def: HelmObjectDef
 
     function emitConstruct() {
       code.openBlock(`export class ${chartName} extends Construct`);
+      code.line('public helm: Helm;');
+      code.line();
 
       emitInitializer();
 
@@ -396,7 +398,7 @@ export function generateHelmConstruct(typegen: TypeGenerator, def: HelmObjectDef
       code.close('};');
 
       code.line();
-      code.line('new Helm(this, \'Helm\', finalProps);');
+      code.line('this.helm = new Helm(this, \'Helm\', finalProps);');
       code.closeBlock();
     }
 

--- a/test/import/__snapshots__/import-helm.test.ts.snap
+++ b/test/import/__snapshots__/import-helm.test.ts.snap
@@ -101,7 +101,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "test-chart.ts",
-        "line": 118,
+        "line": 120,
       },
       "name": "TestChartImage",
       "properties": Array [
@@ -116,7 +116,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 134,
+            "line": 136,
           },
           "name": "additionalValues",
           "optional": true,
@@ -139,7 +139,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 122,
+            "line": 124,
           },
           "name": "repository",
           "optional": true,
@@ -157,7 +157,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 127,
+            "line": 129,
           },
           "name": "tag",
           "optional": true,
@@ -180,7 +180,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "test-chart.ts",
-        "line": 156,
+        "line": 158,
       },
       "name": "TestChartService",
       "properties": Array [
@@ -195,7 +195,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 172,
+            "line": 174,
           },
           "name": "additionalValues",
           "optional": true,
@@ -218,7 +218,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 165,
+            "line": 167,
           },
           "name": "port",
           "optional": true,
@@ -236,7 +236,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 160,
+            "line": 162,
           },
           "name": "type",
           "optional": true,
@@ -258,7 +258,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "test-chart.ts",
-        "line": 194,
+        "line": 196,
       },
       "members": Array [
         Object {
@@ -290,7 +290,7 @@ Object {
       "initializer": Object {
         "locationInModule": Object {
           "filename": "test-chart.ts",
-          "line": 14,
+          "line": 16,
         },
         "parameters": Array [
           Object {
@@ -320,6 +320,18 @@ Object {
         "line": 13,
       },
       "name": "Testchart",
+      "properties": Array [
+        Object {
+          "locationInModule": Object {
+            "filename": "test-chart.ts",
+            "line": 14,
+          },
+          "name": "helm",
+          "type": Object {
+            "fqn": "cdk8s.Helm",
+          },
+        },
+      ],
       "symbolId": "test-chart:Testchart",
     },
     "test-chart.TestchartProps": Object {
@@ -418,7 +430,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "test-chart.ts",
-        "line": 68,
+        "line": 70,
       },
       "name": "TestchartValues",
       "properties": Array [
@@ -433,7 +445,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 94,
+            "line": 96,
           },
           "name": "additionalValues",
           "optional": true,
@@ -456,7 +468,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 87,
+            "line": 89,
           },
           "name": "global",
           "optional": true,
@@ -479,7 +491,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 72,
+            "line": 74,
           },
           "name": "image",
           "optional": true,
@@ -497,7 +509,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 82,
+            "line": 84,
           },
           "name": "replicas",
           "optional": true,
@@ -515,7 +527,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 77,
+            "line": 79,
           },
           "name": "service",
           "optional": true,
@@ -565,6 +577,7 @@ def check_type(argname: str, value: object, expected_type: typing.Any) -> typing
 
 from ._jsii import *
 
+import cdk8s as _cdk8s_d3d9af27
 import constructs as _constructs_77d1e7e8
 
 
@@ -772,6 +785,18 @@ class Testchart(
         )
 
         jsii.create(self.__class__, self, [scope, id, props])
+
+    @builtins.property
+    @jsii.member(jsii_name=\\"helm\\")
+    def helm(self) -> \\"_cdk8s_d3d9af27.Helm\\":
+        return typing.cast(\\"_cdk8s_d3d9af27.Helm\\", jsii.get(self, \\"helm\\"))
+
+    @helm.setter
+    def helm(self, value: \\"_cdk8s_d3d9af27.Helm\\") -> None:
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__23f40195a50c0655f06379461cfa07590ec2e9eda498c85ac16857038295ee7f)
+            check_type(argname=\\"argument value\\", value=value, expected_type=type_hints[\\"value\\"])
+        jsii.set(self, \\"helm\\", value) # pyright: ignore[reportArgumentType]
 
 
 @jsii.data_type(
@@ -1010,6 +1035,12 @@ def _typecheckingstub__a94d4cc6ded4283bb13f9ec7bf5c5bea04c59d18599a4b71ee1bddba8
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 
+def _typecheckingstub__23f40195a50c0655f06379461cfa07590ec2e9eda498c85ac16857038295ee7f(
+    value: _cdk8s_d3d9af27.Helm,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
 def _typecheckingstub__ccefddf4edf9004c9d8a5f37470f96d7d9a2d3cd446153b027e4b4b276151f0c(
     *,
     helm_executable: typing.Optional[builtins.str] = None,
@@ -1177,7 +1208,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "test-chart.ts",
-        "line": 118,
+        "line": 120,
       },
       "name": "TestChartImage",
       "properties": Array [
@@ -1192,7 +1223,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 134,
+            "line": 136,
           },
           "name": "additionalValues",
           "optional": true,
@@ -1215,7 +1246,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 122,
+            "line": 124,
           },
           "name": "repository",
           "optional": true,
@@ -1233,7 +1264,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 127,
+            "line": 129,
           },
           "name": "tag",
           "optional": true,
@@ -1256,7 +1287,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "test-chart.ts",
-        "line": 156,
+        "line": 158,
       },
       "name": "TestChartService",
       "properties": Array [
@@ -1271,7 +1302,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 172,
+            "line": 174,
           },
           "name": "additionalValues",
           "optional": true,
@@ -1294,7 +1325,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 165,
+            "line": 167,
           },
           "name": "port",
           "optional": true,
@@ -1312,7 +1343,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 160,
+            "line": 162,
           },
           "name": "type",
           "optional": true,
@@ -1334,7 +1365,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "test-chart.ts",
-        "line": 194,
+        "line": 196,
       },
       "members": Array [
         Object {
@@ -1366,7 +1397,7 @@ Object {
       "initializer": Object {
         "locationInModule": Object {
           "filename": "test-chart.ts",
-          "line": 14,
+          "line": 16,
         },
         "parameters": Array [
           Object {
@@ -1396,6 +1427,18 @@ Object {
         "line": 13,
       },
       "name": "Testchart",
+      "properties": Array [
+        Object {
+          "locationInModule": Object {
+            "filename": "test-chart.ts",
+            "line": 14,
+          },
+          "name": "helm",
+          "type": Object {
+            "fqn": "cdk8s.Helm",
+          },
+        },
+      ],
       "symbolId": "test-chart:Testchart",
     },
     "test-chart.TestchartProps": Object {
@@ -1494,7 +1537,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "test-chart.ts",
-        "line": 68,
+        "line": 70,
       },
       "name": "TestchartValues",
       "properties": Array [
@@ -1509,7 +1552,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 94,
+            "line": 96,
           },
           "name": "additionalValues",
           "optional": true,
@@ -1532,7 +1575,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 87,
+            "line": 89,
           },
           "name": "global",
           "optional": true,
@@ -1555,7 +1598,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 72,
+            "line": 74,
           },
           "name": "image",
           "optional": true,
@@ -1573,7 +1616,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 82,
+            "line": 84,
           },
           "name": "replicas",
           "optional": true,
@@ -1591,7 +1634,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "test-chart.ts",
-            "line": 77,
+            "line": 79,
           },
           "name": "service",
           "optional": true,
@@ -1622,6 +1665,8 @@ export interface TestchartProps {
 }
 
 export class Testchart extends Construct {
+  public helm: Helm;
+
   public constructor(scope: Construct, id: string, props: TestchartProps = {}) {
     super(scope, id);
     let updatedProps = {};
@@ -1646,7 +1691,7 @@ export class Testchart extends Construct {
       ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
     };
 
-    new Helm(this, 'Helm', finalProps);
+    this.helm = new Helm(this, 'Helm', finalProps);
   }
 
   private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
@@ -1911,7 +1956,7 @@ Object {
       "initializer": Object {
         "locationInModule": Object {
           "filename": "mysql.ts",
-          "line": 14,
+          "line": 16,
         },
         "parameters": Array [
           Object {
@@ -1941,6 +1986,18 @@ Object {
         "line": 13,
       },
       "name": "Mysql",
+      "properties": Array [
+        Object {
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 14,
+          },
+          "name": "helm",
+          "type": Object {
+            "fqn": "cdk8s.Helm",
+          },
+        },
+      ],
       "symbolId": "mysql:Mysql",
     },
     "mysql.MysqlArchitecture": Object {
@@ -1955,7 +2012,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 135,
+        "line": 137,
       },
       "members": Array [
         Object {
@@ -1986,7 +2043,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 145,
+        "line": 147,
       },
       "name": "MysqlAuth",
       "properties": Array [
@@ -2000,7 +2057,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 167,
+            "line": 169,
           },
           "name": "password",
           "type": Object {
@@ -2017,7 +2074,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 162,
+            "line": 164,
           },
           "name": "username",
           "type": Object {
@@ -2035,7 +2092,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 189,
+            "line": 191,
           },
           "name": "additionalValues",
           "optional": true,
@@ -2058,7 +2115,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 182,
+            "line": 184,
           },
           "name": "createDatabase",
           "optional": true,
@@ -2076,7 +2133,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 157,
+            "line": 159,
           },
           "name": "database",
           "optional": true,
@@ -2094,7 +2151,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 177,
+            "line": 179,
           },
           "name": "replicationPassword",
           "optional": true,
@@ -2112,7 +2169,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 172,
+            "line": 174,
           },
           "name": "replicationUser",
           "optional": true,
@@ -2132,7 +2189,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 152,
+            "line": 154,
           },
           "name": "rootPassword",
           "optional": true,
@@ -2155,7 +2212,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 216,
+        "line": 218,
       },
       "name": "MysqlPrimary",
       "properties": Array [
@@ -2170,7 +2227,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 237,
+            "line": 239,
           },
           "name": "additionalValues",
           "optional": true,
@@ -2193,7 +2250,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 225,
+            "line": 227,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -2211,7 +2268,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 230,
+            "line": 232,
           },
           "name": "persistence",
           "optional": true,
@@ -2229,7 +2286,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 220,
+            "line": 222,
           },
           "name": "podSecurityContext",
           "optional": true,
@@ -2252,7 +2309,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 342,
+        "line": 344,
       },
       "name": "MysqlPrimaryContainerSecurityContext",
       "properties": Array [
@@ -2267,7 +2324,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 358,
+            "line": 360,
           },
           "name": "additionalValues",
           "optional": true,
@@ -2290,7 +2347,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 346,
+            "line": 348,
           },
           "name": "enabled",
           "optional": true,
@@ -2308,7 +2365,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 351,
+            "line": 353,
           },
           "name": "runAsUser",
           "optional": true,
@@ -2331,7 +2388,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 380,
+        "line": 382,
       },
       "name": "MysqlPrimaryPersistence",
       "properties": Array [
@@ -2346,7 +2403,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 396,
+            "line": 398,
           },
           "name": "additionalValues",
           "optional": true,
@@ -2369,7 +2426,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 384,
+            "line": 386,
           },
           "name": "enabled",
           "optional": true,
@@ -2387,7 +2444,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 389,
+            "line": 391,
           },
           "name": "size",
           "optional": true,
@@ -2410,7 +2467,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 304,
+        "line": 306,
       },
       "name": "MysqlPrimaryPodSecurityContext",
       "properties": Array [
@@ -2425,7 +2482,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 320,
+            "line": 322,
           },
           "name": "additionalValues",
           "optional": true,
@@ -2448,7 +2505,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 308,
+            "line": 310,
           },
           "name": "enabled",
           "optional": true,
@@ -2466,7 +2523,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 313,
+            "line": 315,
           },
           "name": "fsGroup",
           "optional": true,
@@ -2573,7 +2630,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 260,
+        "line": 262,
       },
       "name": "MysqlSecondary",
       "properties": Array [
@@ -2588,7 +2645,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 281,
+            "line": 283,
           },
           "name": "additionalValues",
           "optional": true,
@@ -2611,7 +2668,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 269,
+            "line": 271,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -2629,7 +2686,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 274,
+            "line": 276,
           },
           "name": "persistence",
           "optional": true,
@@ -2647,7 +2704,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 264,
+            "line": 266,
           },
           "name": "podSecurityContext",
           "optional": true,
@@ -2670,7 +2727,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 456,
+        "line": 458,
       },
       "name": "MysqlSecondaryContainerSecurityContext",
       "properties": Array [
@@ -2685,7 +2742,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 472,
+            "line": 474,
           },
           "name": "additionalValues",
           "optional": true,
@@ -2708,7 +2765,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 460,
+            "line": 462,
           },
           "name": "enabled",
           "optional": true,
@@ -2726,7 +2783,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 465,
+            "line": 467,
           },
           "name": "runAsUser",
           "optional": true,
@@ -2749,7 +2806,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 494,
+        "line": 496,
       },
       "name": "MysqlSecondaryPersistence",
       "properties": Array [
@@ -2764,7 +2821,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 510,
+            "line": 512,
           },
           "name": "additionalValues",
           "optional": true,
@@ -2787,7 +2844,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 498,
+            "line": 500,
           },
           "name": "enabled",
           "optional": true,
@@ -2805,7 +2862,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 503,
+            "line": 505,
           },
           "name": "size",
           "optional": true,
@@ -2828,7 +2885,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 418,
+        "line": 420,
       },
       "name": "MysqlSecondaryPodSecurityContext",
       "properties": Array [
@@ -2843,7 +2900,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 434,
+            "line": 436,
           },
           "name": "additionalValues",
           "optional": true,
@@ -2866,7 +2923,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 422,
+            "line": 424,
           },
           "name": "enabled",
           "optional": true,
@@ -2884,7 +2941,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 427,
+            "line": 429,
           },
           "name": "fsGroup",
           "optional": true,
@@ -2907,7 +2964,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 69,
+        "line": 71,
       },
       "name": "MysqlValues",
       "properties": Array [
@@ -2922,7 +2979,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 107,
+            "line": 109,
           },
           "name": "additionalValues",
           "optional": true,
@@ -2946,7 +3003,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 75,
+            "line": 77,
           },
           "name": "architecture",
           "optional": true,
@@ -2964,7 +3021,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 80,
+            "line": 82,
           },
           "name": "auth",
           "optional": true,
@@ -2982,7 +3039,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 95,
+            "line": 97,
           },
           "name": "common",
           "optional": true,
@@ -3005,7 +3062,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 100,
+            "line": 102,
           },
           "name": "global",
           "optional": true,
@@ -3028,7 +3085,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 85,
+            "line": 87,
           },
           "name": "primary",
           "optional": true,
@@ -3046,7 +3103,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 90,
+            "line": 92,
           },
           "name": "secondary",
           "optional": true,
@@ -3096,6 +3153,7 @@ def check_type(argname: str, value: object, expected_type: typing.Any) -> typing
 
 from ._jsii import *
 
+import cdk8s as _cdk8s_d3d9af27
 import constructs as _constructs_77d1e7e8
 
 
@@ -3137,6 +3195,18 @@ class Mysql(
         )
 
         jsii.create(self.__class__, self, [scope, id, props])
+
+    @builtins.property
+    @jsii.member(jsii_name=\\"helm\\")
+    def helm(self) -> \\"_cdk8s_d3d9af27.Helm\\":
+        return typing.cast(\\"_cdk8s_d3d9af27.Helm\\", jsii.get(self, \\"helm\\"))
+
+    @helm.setter
+    def helm(self, value: \\"_cdk8s_d3d9af27.Helm\\") -> None:
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__6a97335aab88f219ab5d33fb1f96a2580c2e2edc13fd76a090b1f7ebb25cbd52)
+            check_type(argname=\\"argument value\\", value=value, expected_type=type_hints[\\"value\\"])
+        jsii.set(self, \\"helm\\", value) # pyright: ignore[reportArgumentType]
 
 
 @jsii.enum(jsii_type=\\"mysql.MysqlArchitecture\\")
@@ -4212,6 +4282,12 @@ def _typecheckingstub__95a811b01af67eee2d8e2ae24fcefa9fa2ac995a1f9685f3e921af533
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 
+def _typecheckingstub__6a97335aab88f219ab5d33fb1f96a2580c2e2edc13fd76a090b1f7ebb25cbd52(
+    value: _cdk8s_d3d9af27.Helm,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
 def _typecheckingstub__ee06bc5fa81868398bad26c41946af017c8765bcca5abe66e5d88d360a20e315(
     *,
     password: builtins.str,
@@ -4464,7 +4540,7 @@ Object {
       "initializer": Object {
         "locationInModule": Object {
           "filename": "mysql.ts",
-          "line": 14,
+          "line": 16,
         },
         "parameters": Array [
           Object {
@@ -4494,6 +4570,18 @@ Object {
         "line": 13,
       },
       "name": "Mysql",
+      "properties": Array [
+        Object {
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 14,
+          },
+          "name": "helm",
+          "type": Object {
+            "fqn": "cdk8s.Helm",
+          },
+        },
+      ],
       "symbolId": "mysql:Mysql",
     },
     "mysql.MysqlArchitecture": Object {
@@ -4508,7 +4596,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 135,
+        "line": 137,
       },
       "members": Array [
         Object {
@@ -4539,7 +4627,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 145,
+        "line": 147,
       },
       "name": "MysqlAuth",
       "properties": Array [
@@ -4553,7 +4641,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 167,
+            "line": 169,
           },
           "name": "password",
           "type": Object {
@@ -4570,7 +4658,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 162,
+            "line": 164,
           },
           "name": "username",
           "type": Object {
@@ -4588,7 +4676,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 189,
+            "line": 191,
           },
           "name": "additionalValues",
           "optional": true,
@@ -4611,7 +4699,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 182,
+            "line": 184,
           },
           "name": "createDatabase",
           "optional": true,
@@ -4629,7 +4717,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 157,
+            "line": 159,
           },
           "name": "database",
           "optional": true,
@@ -4647,7 +4735,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 177,
+            "line": 179,
           },
           "name": "replicationPassword",
           "optional": true,
@@ -4665,7 +4753,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 172,
+            "line": 174,
           },
           "name": "replicationUser",
           "optional": true,
@@ -4685,7 +4773,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 152,
+            "line": 154,
           },
           "name": "rootPassword",
           "optional": true,
@@ -4708,7 +4796,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 216,
+        "line": 218,
       },
       "name": "MysqlPrimary",
       "properties": Array [
@@ -4723,7 +4811,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 237,
+            "line": 239,
           },
           "name": "additionalValues",
           "optional": true,
@@ -4746,7 +4834,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 225,
+            "line": 227,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -4764,7 +4852,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 230,
+            "line": 232,
           },
           "name": "persistence",
           "optional": true,
@@ -4782,7 +4870,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 220,
+            "line": 222,
           },
           "name": "podSecurityContext",
           "optional": true,
@@ -4805,7 +4893,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 342,
+        "line": 344,
       },
       "name": "MysqlPrimaryContainerSecurityContext",
       "properties": Array [
@@ -4820,7 +4908,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 358,
+            "line": 360,
           },
           "name": "additionalValues",
           "optional": true,
@@ -4843,7 +4931,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 346,
+            "line": 348,
           },
           "name": "enabled",
           "optional": true,
@@ -4861,7 +4949,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 351,
+            "line": 353,
           },
           "name": "runAsUser",
           "optional": true,
@@ -4884,7 +4972,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 380,
+        "line": 382,
       },
       "name": "MysqlPrimaryPersistence",
       "properties": Array [
@@ -4899,7 +4987,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 396,
+            "line": 398,
           },
           "name": "additionalValues",
           "optional": true,
@@ -4922,7 +5010,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 384,
+            "line": 386,
           },
           "name": "enabled",
           "optional": true,
@@ -4940,7 +5028,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 389,
+            "line": 391,
           },
           "name": "size",
           "optional": true,
@@ -4963,7 +5051,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 304,
+        "line": 306,
       },
       "name": "MysqlPrimaryPodSecurityContext",
       "properties": Array [
@@ -4978,7 +5066,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 320,
+            "line": 322,
           },
           "name": "additionalValues",
           "optional": true,
@@ -5001,7 +5089,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 308,
+            "line": 310,
           },
           "name": "enabled",
           "optional": true,
@@ -5019,7 +5107,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 313,
+            "line": 315,
           },
           "name": "fsGroup",
           "optional": true,
@@ -5126,7 +5214,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 260,
+        "line": 262,
       },
       "name": "MysqlSecondary",
       "properties": Array [
@@ -5141,7 +5229,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 281,
+            "line": 283,
           },
           "name": "additionalValues",
           "optional": true,
@@ -5164,7 +5252,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 269,
+            "line": 271,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -5182,7 +5270,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 274,
+            "line": 276,
           },
           "name": "persistence",
           "optional": true,
@@ -5200,7 +5288,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 264,
+            "line": 266,
           },
           "name": "podSecurityContext",
           "optional": true,
@@ -5223,7 +5311,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 456,
+        "line": 458,
       },
       "name": "MysqlSecondaryContainerSecurityContext",
       "properties": Array [
@@ -5238,7 +5326,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 472,
+            "line": 474,
           },
           "name": "additionalValues",
           "optional": true,
@@ -5261,7 +5349,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 460,
+            "line": 462,
           },
           "name": "enabled",
           "optional": true,
@@ -5279,7 +5367,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 465,
+            "line": 467,
           },
           "name": "runAsUser",
           "optional": true,
@@ -5302,7 +5390,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 494,
+        "line": 496,
       },
       "name": "MysqlSecondaryPersistence",
       "properties": Array [
@@ -5317,7 +5405,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 510,
+            "line": 512,
           },
           "name": "additionalValues",
           "optional": true,
@@ -5340,7 +5428,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 498,
+            "line": 500,
           },
           "name": "enabled",
           "optional": true,
@@ -5358,7 +5446,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 503,
+            "line": 505,
           },
           "name": "size",
           "optional": true,
@@ -5381,7 +5469,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 418,
+        "line": 420,
       },
       "name": "MysqlSecondaryPodSecurityContext",
       "properties": Array [
@@ -5396,7 +5484,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 434,
+            "line": 436,
           },
           "name": "additionalValues",
           "optional": true,
@@ -5419,7 +5507,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 422,
+            "line": 424,
           },
           "name": "enabled",
           "optional": true,
@@ -5437,7 +5525,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 427,
+            "line": 429,
           },
           "name": "fsGroup",
           "optional": true,
@@ -5460,7 +5548,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 69,
+        "line": 71,
       },
       "name": "MysqlValues",
       "properties": Array [
@@ -5475,7 +5563,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 107,
+            "line": 109,
           },
           "name": "additionalValues",
           "optional": true,
@@ -5499,7 +5587,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 75,
+            "line": 77,
           },
           "name": "architecture",
           "optional": true,
@@ -5517,7 +5605,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 80,
+            "line": 82,
           },
           "name": "auth",
           "optional": true,
@@ -5535,7 +5623,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 95,
+            "line": 97,
           },
           "name": "common",
           "optional": true,
@@ -5558,7 +5646,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 100,
+            "line": 102,
           },
           "name": "global",
           "optional": true,
@@ -5581,7 +5669,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 85,
+            "line": 87,
           },
           "name": "primary",
           "optional": true,
@@ -5599,7 +5687,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 90,
+            "line": 92,
           },
           "name": "secondary",
           "optional": true,
@@ -5630,6 +5718,8 @@ export interface MysqlProps {
 }
 
 export class Mysql extends Construct {
+  public helm: Helm;
+
   public constructor(scope: Construct, id: string, props: MysqlProps = {}) {
     super(scope, id);
     let updatedProps = {};
@@ -5655,7 +5745,7 @@ export class Mysql extends Construct {
       ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
     };
 
-    new Helm(this, 'Helm', finalProps);
+    this.helm = new Helm(this, 'Helm', finalProps);
   }
 
   private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
@@ -6245,7 +6335,7 @@ Object {
       "initializer": Object {
         "locationInModule": Object {
           "filename": "cert-manager.ts",
-          "line": 14,
+          "line": 16,
         },
         "parameters": Array [
           Object {
@@ -6275,6 +6365,18 @@ Object {
         "line": 13,
       },
       "name": "Certmanager",
+      "properties": Array [
+        Object {
+          "locationInModule": Object {
+            "filename": "cert-manager.ts",
+            "line": 14,
+          },
+          "name": "helm",
+          "type": Object {
+            "fqn": "cdk8s.Helm",
+          },
+        },
+      ],
       "symbolId": "cert-manager:Certmanager",
     },
     "cert-manager.CertmanagerProps": Object {
@@ -6373,7 +6475,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 69,
+        "line": 71,
       },
       "name": "HelmValues",
       "properties": Array [
@@ -6387,7 +6489,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 73,
+            "line": 75,
           },
           "name": "acmesolver",
           "optional": true,
@@ -6405,7 +6507,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 78,
+            "line": 80,
           },
           "name": "affinity",
           "optional": true,
@@ -6423,7 +6525,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 83,
+            "line": 85,
           },
           "name": "approveSignerNames",
           "optional": true,
@@ -6446,7 +6548,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 88,
+            "line": 90,
           },
           "name": "automountServiceAccountToken",
           "optional": true,
@@ -6464,7 +6566,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 93,
+            "line": 95,
           },
           "name": "cainjector",
           "optional": true,
@@ -6482,7 +6584,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 98,
+            "line": 100,
           },
           "name": "clusterResourceNamespace",
           "optional": true,
@@ -6500,7 +6602,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 103,
+            "line": 105,
           },
           "name": "config",
           "optional": true,
@@ -6518,7 +6620,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 108,
+            "line": 110,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -6536,7 +6638,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 113,
+            "line": 115,
           },
           "name": "crds",
           "optional": true,
@@ -6554,7 +6656,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 118,
+            "line": 120,
           },
           "name": "creator",
           "optional": true,
@@ -6572,7 +6674,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 123,
+            "line": 125,
           },
           "name": "deploymentAnnotations",
           "optional": true,
@@ -6590,7 +6692,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 128,
+            "line": 130,
           },
           "name": "disableAutoApproval",
           "optional": true,
@@ -6608,7 +6710,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 133,
+            "line": 135,
           },
           "name": "dns01RecursiveNameservers",
           "optional": true,
@@ -6626,7 +6728,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 138,
+            "line": 140,
           },
           "name": "dns01RecursiveNameserversOnly",
           "optional": true,
@@ -6644,7 +6746,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 143,
+            "line": 145,
           },
           "name": "enableCertificateOwnerRef",
           "optional": true,
@@ -6662,7 +6764,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 153,
+            "line": 155,
           },
           "name": "enabled",
           "optional": true,
@@ -6680,7 +6782,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 148,
+            "line": 150,
           },
           "name": "enableServiceLinks",
           "optional": true,
@@ -6698,7 +6800,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 158,
+            "line": 160,
           },
           "name": "extraArgs",
           "optional": true,
@@ -6721,7 +6823,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 163,
+            "line": 165,
           },
           "name": "extraEnv",
           "optional": true,
@@ -6744,7 +6846,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 168,
+            "line": 170,
           },
           "name": "extraObjects",
           "optional": true,
@@ -6767,7 +6869,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 173,
+            "line": 175,
           },
           "name": "featureGates",
           "optional": true,
@@ -6785,7 +6887,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 178,
+            "line": 180,
           },
           "name": "fullnameOverride",
           "optional": true,
@@ -6803,7 +6905,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 183,
+            "line": 185,
           },
           "name": "global",
           "optional": true,
@@ -6821,7 +6923,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 188,
+            "line": 190,
           },
           "name": "hostAliases",
           "optional": true,
@@ -6844,7 +6946,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 193,
+            "line": 195,
           },
           "name": "httpProxy",
           "optional": true,
@@ -6862,7 +6964,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 198,
+            "line": 200,
           },
           "name": "httpsProxy",
           "optional": true,
@@ -6880,7 +6982,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 203,
+            "line": 205,
           },
           "name": "image",
           "optional": true,
@@ -6898,7 +7000,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 208,
+            "line": 210,
           },
           "name": "ingressShim",
           "optional": true,
@@ -6916,7 +7018,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 213,
+            "line": 215,
           },
           "name": "installCrDs",
           "optional": true,
@@ -6934,7 +7036,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 218,
+            "line": 220,
           },
           "name": "livenessProbe",
           "optional": true,
@@ -6952,7 +7054,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 223,
+            "line": 225,
           },
           "name": "maxConcurrentChallenges",
           "optional": true,
@@ -6970,7 +7072,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 228,
+            "line": 230,
           },
           "name": "nameOverride",
           "optional": true,
@@ -6988,7 +7090,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 233,
+            "line": 235,
           },
           "name": "namespace",
           "optional": true,
@@ -7006,7 +7108,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 243,
+            "line": 245,
           },
           "name": "nodeSelector",
           "optional": true,
@@ -7024,7 +7126,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 238,
+            "line": 240,
           },
           "name": "noProxy",
           "optional": true,
@@ -7042,7 +7144,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 248,
+            "line": 250,
           },
           "name": "podAnnotations",
           "optional": true,
@@ -7060,7 +7162,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 253,
+            "line": 255,
           },
           "name": "podDisruptionBudget",
           "optional": true,
@@ -7078,7 +7180,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 258,
+            "line": 260,
           },
           "name": "podDnsConfig",
           "optional": true,
@@ -7096,7 +7198,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 263,
+            "line": 265,
           },
           "name": "podDnsPolicy",
           "optional": true,
@@ -7114,7 +7216,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 268,
+            "line": 270,
           },
           "name": "podLabels",
           "optional": true,
@@ -7132,7 +7234,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 273,
+            "line": 275,
           },
           "name": "prometheus",
           "optional": true,
@@ -7150,7 +7252,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 278,
+            "line": 280,
           },
           "name": "replicaCount",
           "optional": true,
@@ -7168,7 +7270,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 283,
+            "line": 285,
           },
           "name": "resources",
           "optional": true,
@@ -7186,7 +7288,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 288,
+            "line": 290,
           },
           "name": "securityContext",
           "optional": true,
@@ -7204,7 +7306,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 293,
+            "line": 295,
           },
           "name": "serviceAccount",
           "optional": true,
@@ -7222,7 +7324,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 298,
+            "line": 300,
           },
           "name": "serviceAnnotations",
           "optional": true,
@@ -7240,7 +7342,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 303,
+            "line": 305,
           },
           "name": "serviceIpFamilies",
           "optional": true,
@@ -7263,7 +7365,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 308,
+            "line": 310,
           },
           "name": "serviceIpFamilyPolicy",
           "optional": true,
@@ -7281,7 +7383,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 313,
+            "line": 315,
           },
           "name": "serviceLabels",
           "optional": true,
@@ -7299,7 +7401,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 318,
+            "line": 320,
           },
           "name": "startupapicheck",
           "optional": true,
@@ -7317,7 +7419,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 323,
+            "line": 325,
           },
           "name": "strategy",
           "optional": true,
@@ -7335,7 +7437,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 328,
+            "line": 330,
           },
           "name": "tolerations",
           "optional": true,
@@ -7358,7 +7460,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 333,
+            "line": 335,
           },
           "name": "topologySpreadConstraints",
           "optional": true,
@@ -7381,7 +7483,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 338,
+            "line": 340,
           },
           "name": "volumeMounts",
           "optional": true,
@@ -7404,7 +7506,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 343,
+            "line": 345,
           },
           "name": "volumes",
           "optional": true,
@@ -7427,7 +7529,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 348,
+            "line": 350,
           },
           "name": "webhook",
           "optional": true,
@@ -7450,7 +7552,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 423,
+        "line": 425,
       },
       "name": "HelmValuesAcmesolver",
       "properties": Array [
@@ -7464,7 +7566,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 427,
+            "line": 429,
           },
           "name": "image",
           "optional": true,
@@ -7487,7 +7589,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1325,
+        "line": 1327,
       },
       "name": "HelmValuesAcmesolverImage",
       "properties": Array [
@@ -7501,7 +7603,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1329,
+            "line": 1331,
           },
           "name": "digest",
           "optional": true,
@@ -7519,7 +7621,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1334,
+            "line": 1336,
           },
           "name": "pullPolicy",
           "optional": true,
@@ -7537,7 +7639,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1339,
+            "line": 1341,
           },
           "name": "registry",
           "optional": true,
@@ -7555,7 +7657,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1344,
+            "line": 1346,
           },
           "name": "repository",
           "optional": true,
@@ -7573,7 +7675,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1349,
+            "line": 1351,
           },
           "name": "tag",
           "optional": true,
@@ -7596,7 +7698,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 447,
+        "line": 449,
       },
       "name": "HelmValuesCainjector",
       "properties": Array [
@@ -7610,7 +7712,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 451,
+            "line": 453,
           },
           "name": "affinity",
           "optional": true,
@@ -7628,7 +7730,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 456,
+            "line": 458,
           },
           "name": "automountServiceAccountToken",
           "optional": true,
@@ -7646,7 +7748,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 461,
+            "line": 463,
           },
           "name": "config",
           "optional": true,
@@ -7664,7 +7766,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 466,
+            "line": 468,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -7682,7 +7784,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 471,
+            "line": 473,
           },
           "name": "deploymentAnnotations",
           "optional": true,
@@ -7700,7 +7802,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 481,
+            "line": 483,
           },
           "name": "enabled",
           "optional": true,
@@ -7718,7 +7820,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 476,
+            "line": 478,
           },
           "name": "enableServiceLinks",
           "optional": true,
@@ -7736,7 +7838,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 486,
+            "line": 488,
           },
           "name": "extraArgs",
           "optional": true,
@@ -7759,7 +7861,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 491,
+            "line": 493,
           },
           "name": "extraEnv",
           "optional": true,
@@ -7782,7 +7884,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 496,
+            "line": 498,
           },
           "name": "featureGates",
           "optional": true,
@@ -7800,7 +7902,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 501,
+            "line": 503,
           },
           "name": "image",
           "optional": true,
@@ -7818,7 +7920,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 506,
+            "line": 508,
           },
           "name": "nodeSelector",
           "optional": true,
@@ -7836,7 +7938,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 511,
+            "line": 513,
           },
           "name": "podAnnotations",
           "optional": true,
@@ -7854,7 +7956,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 516,
+            "line": 518,
           },
           "name": "podDisruptionBudget",
           "optional": true,
@@ -7872,7 +7974,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 521,
+            "line": 523,
           },
           "name": "podLabels",
           "optional": true,
@@ -7890,7 +7992,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 526,
+            "line": 528,
           },
           "name": "replicaCount",
           "optional": true,
@@ -7908,7 +8010,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 531,
+            "line": 533,
           },
           "name": "resources",
           "optional": true,
@@ -7926,7 +8028,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 536,
+            "line": 538,
           },
           "name": "securityContext",
           "optional": true,
@@ -7944,7 +8046,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 541,
+            "line": 543,
           },
           "name": "serviceAccount",
           "optional": true,
@@ -7962,7 +8064,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 546,
+            "line": 548,
           },
           "name": "serviceAnnotations",
           "optional": true,
@@ -7980,7 +8082,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 551,
+            "line": 553,
           },
           "name": "serviceLabels",
           "optional": true,
@@ -7998,7 +8100,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 556,
+            "line": 558,
           },
           "name": "strategy",
           "optional": true,
@@ -8016,7 +8118,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 561,
+            "line": 563,
           },
           "name": "tolerations",
           "optional": true,
@@ -8039,7 +8141,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 566,
+            "line": 568,
           },
           "name": "topologySpreadConstraints",
           "optional": true,
@@ -8062,7 +8164,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 571,
+            "line": 573,
           },
           "name": "volumeMounts",
           "optional": true,
@@ -8085,7 +8187,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 576,
+            "line": 578,
           },
           "name": "volumes",
           "optional": true,
@@ -8113,7 +8215,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1373,
+        "line": 1375,
       },
       "name": "HelmValuesCainjectorImage",
       "properties": Array [
@@ -8127,7 +8229,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1377,
+            "line": 1379,
           },
           "name": "digest",
           "optional": true,
@@ -8145,7 +8247,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1382,
+            "line": 1384,
           },
           "name": "pullPolicy",
           "optional": true,
@@ -8163,7 +8265,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1387,
+            "line": 1389,
           },
           "name": "registry",
           "optional": true,
@@ -8181,7 +8283,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1392,
+            "line": 1394,
           },
           "name": "repository",
           "optional": true,
@@ -8199,7 +8301,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1397,
+            "line": 1399,
           },
           "name": "tag",
           "optional": true,
@@ -8222,7 +8324,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1421,
+        "line": 1423,
       },
       "name": "HelmValuesCainjectorPodDisruptionBudget",
       "properties": Array [
@@ -8236,7 +8338,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1425,
+            "line": 1427,
           },
           "name": "enabled",
           "optional": true,
@@ -8254,7 +8356,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1430,
+            "line": 1432,
           },
           "name": "maxUnavailable",
           "optional": true,
@@ -8272,7 +8374,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1435,
+            "line": 1437,
           },
           "name": "minAvailable",
           "optional": true,
@@ -8295,7 +8397,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1457,
+        "line": 1459,
       },
       "name": "HelmValuesCainjectorServiceAccount",
       "properties": Array [
@@ -8309,7 +8411,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1461,
+            "line": 1463,
           },
           "name": "annotations",
           "optional": true,
@@ -8327,7 +8429,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1466,
+            "line": 1468,
           },
           "name": "automountServiceAccountToken",
           "optional": true,
@@ -8345,7 +8447,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1471,
+            "line": 1473,
           },
           "name": "create",
           "optional": true,
@@ -8363,7 +8465,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1476,
+            "line": 1478,
           },
           "name": "labels",
           "optional": true,
@@ -8381,7 +8483,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1481,
+            "line": 1483,
           },
           "name": "name",
           "optional": true,
@@ -8404,7 +8506,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 621,
+        "line": 623,
       },
       "name": "HelmValuesCrds",
       "properties": Array [
@@ -8418,7 +8520,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 625,
+            "line": 627,
           },
           "name": "enabled",
           "optional": true,
@@ -8436,7 +8538,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 630,
+            "line": 632,
           },
           "name": "keep",
           "optional": true,
@@ -8460,7 +8562,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 653,
+        "line": 655,
       },
       "name": "HelmValuesGlobal",
       "properties": Array [
@@ -8474,7 +8576,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 657,
+            "line": 659,
           },
           "name": "commonLabels",
           "optional": true,
@@ -8492,7 +8594,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 662,
+            "line": 664,
           },
           "name": "imagePullSecrets",
           "optional": true,
@@ -8515,7 +8617,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 667,
+            "line": 669,
           },
           "name": "leaderElection",
           "optional": true,
@@ -8533,7 +8635,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 672,
+            "line": 674,
           },
           "name": "logLevel",
           "optional": true,
@@ -8551,7 +8653,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 677,
+            "line": 679,
           },
           "name": "podSecurityPolicy",
           "optional": true,
@@ -8569,7 +8671,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 682,
+            "line": 684,
           },
           "name": "priorityClassName",
           "optional": true,
@@ -8587,7 +8689,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 687,
+            "line": 689,
           },
           "name": "rbac",
           "optional": true,
@@ -8605,7 +8707,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 692,
+            "line": 694,
           },
           "name": "revisionHistoryLimit",
           "optional": true,
@@ -8628,7 +8730,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1505,
+        "line": 1507,
       },
       "name": "HelmValuesGlobalLeaderElection",
       "properties": Array [
@@ -8642,7 +8744,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1509,
+            "line": 1511,
           },
           "name": "leaseDuration",
           "optional": true,
@@ -8660,7 +8762,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1514,
+            "line": 1516,
           },
           "name": "namespace",
           "optional": true,
@@ -8678,7 +8780,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1519,
+            "line": 1521,
           },
           "name": "renewDeadline",
           "optional": true,
@@ -8696,7 +8798,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1524,
+            "line": 1526,
           },
           "name": "retryPeriod",
           "optional": true,
@@ -8719,7 +8821,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1547,
+        "line": 1549,
       },
       "name": "HelmValuesGlobalPodSecurityPolicy",
       "properties": Array [
@@ -8733,7 +8835,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1551,
+            "line": 1553,
           },
           "name": "enabled",
           "optional": true,
@@ -8751,7 +8853,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1556,
+            "line": 1558,
           },
           "name": "useAppArmor",
           "optional": true,
@@ -8774,7 +8876,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1577,
+        "line": 1579,
       },
       "name": "HelmValuesGlobalRbac",
       "properties": Array [
@@ -8788,7 +8890,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1581,
+            "line": 1583,
           },
           "name": "aggregateClusterRoles",
           "optional": true,
@@ -8806,7 +8908,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1586,
+            "line": 1588,
           },
           "name": "create",
           "optional": true,
@@ -8829,7 +8931,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 719,
+        "line": 721,
       },
       "name": "HelmValuesImage",
       "properties": Array [
@@ -8843,7 +8945,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 723,
+            "line": 725,
           },
           "name": "digest",
           "optional": true,
@@ -8861,7 +8963,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 728,
+            "line": 730,
           },
           "name": "pullPolicy",
           "optional": true,
@@ -8879,7 +8981,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 733,
+            "line": 735,
           },
           "name": "registry",
           "optional": true,
@@ -8897,7 +8999,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 738,
+            "line": 740,
           },
           "name": "repository",
           "optional": true,
@@ -8915,7 +9017,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 743,
+            "line": 745,
           },
           "name": "tag",
           "optional": true,
@@ -8938,7 +9040,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 767,
+        "line": 769,
       },
       "name": "HelmValuesIngressShim",
       "properties": Array [
@@ -8952,7 +9054,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 771,
+            "line": 773,
           },
           "name": "defaultIssuerGroup",
           "optional": true,
@@ -8970,7 +9072,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 776,
+            "line": 778,
           },
           "name": "defaultIssuerKind",
           "optional": true,
@@ -8988,7 +9090,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 781,
+            "line": 783,
           },
           "name": "defaultIssuerName",
           "optional": true,
@@ -9011,7 +9113,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 803,
+        "line": 805,
       },
       "name": "HelmValuesPodDisruptionBudget",
       "properties": Array [
@@ -9025,7 +9127,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 807,
+            "line": 809,
           },
           "name": "enabled",
           "optional": true,
@@ -9043,7 +9145,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 812,
+            "line": 814,
           },
           "name": "maxUnavailable",
           "optional": true,
@@ -9061,7 +9163,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 817,
+            "line": 819,
           },
           "name": "minAvailable",
           "optional": true,
@@ -9084,7 +9186,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 839,
+        "line": 841,
       },
       "name": "HelmValuesPrometheus",
       "properties": Array [
@@ -9098,7 +9200,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 843,
+            "line": 845,
           },
           "name": "enabled",
           "optional": true,
@@ -9116,7 +9218,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 848,
+            "line": 850,
           },
           "name": "podmonitor",
           "optional": true,
@@ -9134,7 +9236,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 853,
+            "line": 855,
           },
           "name": "servicemonitor",
           "optional": true,
@@ -9157,7 +9259,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1607,
+        "line": 1609,
       },
       "name": "HelmValuesPrometheusPodmonitor",
       "properties": Array [
@@ -9171,7 +9273,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1611,
+            "line": 1613,
           },
           "name": "annotations",
           "optional": true,
@@ -9189,7 +9291,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1616,
+            "line": 1618,
           },
           "name": "enabled",
           "optional": true,
@@ -9207,7 +9309,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1621,
+            "line": 1623,
           },
           "name": "endpointAdditionalProperties",
           "optional": true,
@@ -9225,7 +9327,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1626,
+            "line": 1628,
           },
           "name": "honorLabels",
           "optional": true,
@@ -9243,7 +9345,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1631,
+            "line": 1633,
           },
           "name": "interval",
           "optional": true,
@@ -9261,7 +9363,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1636,
+            "line": 1638,
           },
           "name": "labels",
           "optional": true,
@@ -9279,7 +9381,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1641,
+            "line": 1643,
           },
           "name": "namespace",
           "optional": true,
@@ -9297,7 +9399,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1646,
+            "line": 1648,
           },
           "name": "path",
           "optional": true,
@@ -9315,7 +9417,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1651,
+            "line": 1653,
           },
           "name": "prometheusInstance",
           "optional": true,
@@ -9333,7 +9435,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1656,
+            "line": 1658,
           },
           "name": "scrapeTimeout",
           "optional": true,
@@ -9356,7 +9458,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1685,
+        "line": 1687,
       },
       "name": "HelmValuesPrometheusServicemonitor",
       "properties": Array [
@@ -9370,7 +9472,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1689,
+            "line": 1691,
           },
           "name": "annotations",
           "optional": true,
@@ -9388,7 +9490,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1694,
+            "line": 1696,
           },
           "name": "enabled",
           "optional": true,
@@ -9406,7 +9508,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1699,
+            "line": 1701,
           },
           "name": "endpointAdditionalProperties",
           "optional": true,
@@ -9424,7 +9526,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1704,
+            "line": 1706,
           },
           "name": "honorLabels",
           "optional": true,
@@ -9442,7 +9544,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1709,
+            "line": 1711,
           },
           "name": "interval",
           "optional": true,
@@ -9460,7 +9562,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1714,
+            "line": 1716,
           },
           "name": "labels",
           "optional": true,
@@ -9478,7 +9580,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1719,
+            "line": 1721,
           },
           "name": "namespace",
           "optional": true,
@@ -9496,7 +9598,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1724,
+            "line": 1726,
           },
           "name": "path",
           "optional": true,
@@ -9514,7 +9616,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1729,
+            "line": 1731,
           },
           "name": "prometheusInstance",
           "optional": true,
@@ -9532,7 +9634,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1734,
+            "line": 1736,
           },
           "name": "scrapeTimeout",
           "optional": true,
@@ -9550,7 +9652,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1739,
+            "line": 1741,
           },
           "name": "targetPort",
           "optional": true,
@@ -9573,7 +9675,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 875,
+        "line": 877,
       },
       "name": "HelmValuesServiceAccount",
       "properties": Array [
@@ -9587,7 +9689,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 879,
+            "line": 881,
           },
           "name": "annotations",
           "optional": true,
@@ -9605,7 +9707,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 884,
+            "line": 886,
           },
           "name": "automountServiceAccountToken",
           "optional": true,
@@ -9623,7 +9725,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 889,
+            "line": 891,
           },
           "name": "create",
           "optional": true,
@@ -9641,7 +9743,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 894,
+            "line": 896,
           },
           "name": "labels",
           "optional": true,
@@ -9659,7 +9761,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 899,
+            "line": 901,
           },
           "name": "name",
           "optional": true,
@@ -9682,7 +9784,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 923,
+        "line": 925,
       },
       "name": "HelmValuesStartupapicheck",
       "properties": Array [
@@ -9696,7 +9798,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 927,
+            "line": 929,
           },
           "name": "affinity",
           "optional": true,
@@ -9714,7 +9816,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 932,
+            "line": 934,
           },
           "name": "automountServiceAccountToken",
           "optional": true,
@@ -9732,7 +9834,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 937,
+            "line": 939,
           },
           "name": "backoffLimit",
           "optional": true,
@@ -9750,7 +9852,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 942,
+            "line": 944,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -9768,7 +9870,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 952,
+            "line": 954,
           },
           "name": "enabled",
           "optional": true,
@@ -9786,7 +9888,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 947,
+            "line": 949,
           },
           "name": "enableServiceLinks",
           "optional": true,
@@ -9804,7 +9906,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 957,
+            "line": 959,
           },
           "name": "extraArgs",
           "optional": true,
@@ -9827,7 +9929,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 962,
+            "line": 964,
           },
           "name": "extraEnv",
           "optional": true,
@@ -9850,7 +9952,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 967,
+            "line": 969,
           },
           "name": "image",
           "optional": true,
@@ -9868,7 +9970,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 972,
+            "line": 974,
           },
           "name": "jobAnnotations",
           "optional": true,
@@ -9886,7 +9988,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 977,
+            "line": 979,
           },
           "name": "nodeSelector",
           "optional": true,
@@ -9904,7 +10006,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 982,
+            "line": 984,
           },
           "name": "podAnnotations",
           "optional": true,
@@ -9922,7 +10024,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 987,
+            "line": 989,
           },
           "name": "podLabels",
           "optional": true,
@@ -9940,7 +10042,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 992,
+            "line": 994,
           },
           "name": "rbac",
           "optional": true,
@@ -9958,7 +10060,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 997,
+            "line": 999,
           },
           "name": "resources",
           "optional": true,
@@ -9976,7 +10078,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1002,
+            "line": 1004,
           },
           "name": "securityContext",
           "optional": true,
@@ -9994,7 +10096,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1007,
+            "line": 1009,
           },
           "name": "serviceAccount",
           "optional": true,
@@ -10012,7 +10114,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1012,
+            "line": 1014,
           },
           "name": "timeout",
           "optional": true,
@@ -10030,7 +10132,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1017,
+            "line": 1019,
           },
           "name": "tolerations",
           "optional": true,
@@ -10053,7 +10155,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1022,
+            "line": 1024,
           },
           "name": "volumeMounts",
           "optional": true,
@@ -10076,7 +10178,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1027,
+            "line": 1029,
           },
           "name": "volumes",
           "optional": true,
@@ -10104,7 +10206,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1769,
+        "line": 1771,
       },
       "name": "HelmValuesStartupapicheckImage",
       "properties": Array [
@@ -10118,7 +10220,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1773,
+            "line": 1775,
           },
           "name": "digest",
           "optional": true,
@@ -10136,7 +10238,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1778,
+            "line": 1780,
           },
           "name": "pullPolicy",
           "optional": true,
@@ -10154,7 +10256,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1783,
+            "line": 1785,
           },
           "name": "registry",
           "optional": true,
@@ -10172,7 +10274,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1788,
+            "line": 1790,
           },
           "name": "repository",
           "optional": true,
@@ -10190,7 +10292,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1793,
+            "line": 1795,
           },
           "name": "tag",
           "optional": true,
@@ -10213,7 +10315,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1817,
+        "line": 1819,
       },
       "name": "HelmValuesStartupapicheckRbac",
       "properties": Array [
@@ -10227,7 +10329,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1821,
+            "line": 1823,
           },
           "name": "annotations",
           "optional": true,
@@ -10250,7 +10352,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1841,
+        "line": 1843,
       },
       "name": "HelmValuesStartupapicheckServiceAccount",
       "properties": Array [
@@ -10264,7 +10366,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1845,
+            "line": 1847,
           },
           "name": "annotations",
           "optional": true,
@@ -10282,7 +10384,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1850,
+            "line": 1852,
           },
           "name": "automountServiceAccountToken",
           "optional": true,
@@ -10300,7 +10402,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1855,
+            "line": 1857,
           },
           "name": "create",
           "optional": true,
@@ -10318,7 +10420,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1860,
+            "line": 1862,
           },
           "name": "labels",
           "optional": true,
@@ -10336,7 +10438,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1865,
+            "line": 1867,
           },
           "name": "name",
           "optional": true,
@@ -10359,7 +10461,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1067,
+        "line": 1069,
       },
       "name": "HelmValuesWebhook",
       "properties": Array [
@@ -10373,7 +10475,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1071,
+            "line": 1073,
           },
           "name": "affinity",
           "optional": true,
@@ -10391,7 +10493,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1076,
+            "line": 1078,
           },
           "name": "automountServiceAccountToken",
           "optional": true,
@@ -10409,7 +10511,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1081,
+            "line": 1083,
           },
           "name": "config",
           "optional": true,
@@ -10427,7 +10529,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1086,
+            "line": 1088,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -10445,7 +10547,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1091,
+            "line": 1093,
           },
           "name": "deploymentAnnotations",
           "optional": true,
@@ -10463,7 +10565,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1096,
+            "line": 1098,
           },
           "name": "enableServiceLinks",
           "optional": true,
@@ -10481,7 +10583,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1101,
+            "line": 1103,
           },
           "name": "extraArgs",
           "optional": true,
@@ -10504,7 +10606,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1106,
+            "line": 1108,
           },
           "name": "extraEnv",
           "optional": true,
@@ -10527,7 +10629,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1111,
+            "line": 1113,
           },
           "name": "featureGates",
           "optional": true,
@@ -10545,7 +10647,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1116,
+            "line": 1118,
           },
           "name": "hostNetwork",
           "optional": true,
@@ -10563,7 +10665,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1121,
+            "line": 1123,
           },
           "name": "image",
           "optional": true,
@@ -10581,7 +10683,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1126,
+            "line": 1128,
           },
           "name": "livenessProbe",
           "optional": true,
@@ -10599,7 +10701,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1131,
+            "line": 1133,
           },
           "name": "loadBalancerIp",
           "optional": true,
@@ -10617,7 +10719,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1136,
+            "line": 1138,
           },
           "name": "mutatingWebhookConfiguration",
           "optional": true,
@@ -10635,7 +10737,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1141,
+            "line": 1143,
           },
           "name": "mutatingWebhookConfigurationAnnotations",
           "optional": true,
@@ -10653,7 +10755,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1146,
+            "line": 1148,
           },
           "name": "networkPolicy",
           "optional": true,
@@ -10671,7 +10773,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1151,
+            "line": 1153,
           },
           "name": "nodeSelector",
           "optional": true,
@@ -10689,7 +10791,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1156,
+            "line": 1158,
           },
           "name": "podAnnotations",
           "optional": true,
@@ -10707,7 +10809,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1161,
+            "line": 1163,
           },
           "name": "podDisruptionBudget",
           "optional": true,
@@ -10725,7 +10827,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1166,
+            "line": 1168,
           },
           "name": "podLabels",
           "optional": true,
@@ -10743,7 +10845,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1171,
+            "line": 1173,
           },
           "name": "readinessProbe",
           "optional": true,
@@ -10761,7 +10863,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1176,
+            "line": 1178,
           },
           "name": "replicaCount",
           "optional": true,
@@ -10779,7 +10881,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1181,
+            "line": 1183,
           },
           "name": "resources",
           "optional": true,
@@ -10797,7 +10899,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1186,
+            "line": 1188,
           },
           "name": "securePort",
           "optional": true,
@@ -10815,7 +10917,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1191,
+            "line": 1193,
           },
           "name": "securityContext",
           "optional": true,
@@ -10833,7 +10935,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1196,
+            "line": 1198,
           },
           "name": "serviceAccount",
           "optional": true,
@@ -10851,7 +10953,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1201,
+            "line": 1203,
           },
           "name": "serviceAnnotations",
           "optional": true,
@@ -10869,7 +10971,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1206,
+            "line": 1208,
           },
           "name": "serviceIpFamilies",
           "optional": true,
@@ -10892,7 +10994,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1211,
+            "line": 1213,
           },
           "name": "serviceIpFamilyPolicy",
           "optional": true,
@@ -10910,7 +11012,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1216,
+            "line": 1218,
           },
           "name": "serviceLabels",
           "optional": true,
@@ -10928,7 +11030,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1221,
+            "line": 1223,
           },
           "name": "serviceType",
           "optional": true,
@@ -10946,7 +11048,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1226,
+            "line": 1228,
           },
           "name": "strategy",
           "optional": true,
@@ -10964,7 +11066,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1231,
+            "line": 1233,
           },
           "name": "timeoutSeconds",
           "optional": true,
@@ -10982,7 +11084,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1236,
+            "line": 1238,
           },
           "name": "tolerations",
           "optional": true,
@@ -11005,7 +11107,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1241,
+            "line": 1243,
           },
           "name": "topologySpreadConstraints",
           "optional": true,
@@ -11028,7 +11130,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1246,
+            "line": 1248,
           },
           "name": "url",
           "optional": true,
@@ -11046,7 +11148,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1251,
+            "line": 1253,
           },
           "name": "validatingWebhookConfiguration",
           "optional": true,
@@ -11064,7 +11166,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1256,
+            "line": 1258,
           },
           "name": "validatingWebhookConfigurationAnnotations",
           "optional": true,
@@ -11082,7 +11184,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1261,
+            "line": 1263,
           },
           "name": "volumeMounts",
           "optional": true,
@@ -11105,7 +11207,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1266,
+            "line": 1268,
           },
           "name": "volumes",
           "optional": true,
@@ -11133,7 +11235,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1889,
+        "line": 1891,
       },
       "name": "HelmValuesWebhookImage",
       "properties": Array [
@@ -11147,7 +11249,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1893,
+            "line": 1895,
           },
           "name": "digest",
           "optional": true,
@@ -11165,7 +11267,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1898,
+            "line": 1900,
           },
           "name": "pullPolicy",
           "optional": true,
@@ -11183,7 +11285,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1903,
+            "line": 1905,
           },
           "name": "registry",
           "optional": true,
@@ -11201,7 +11303,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1908,
+            "line": 1910,
           },
           "name": "repository",
           "optional": true,
@@ -11219,7 +11321,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1913,
+            "line": 1915,
           },
           "name": "tag",
           "optional": true,
@@ -11242,7 +11344,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1937,
+        "line": 1939,
       },
       "name": "HelmValuesWebhookMutatingWebhookConfiguration",
       "properties": Array [
@@ -11256,7 +11358,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1941,
+            "line": 1943,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -11279,7 +11381,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1961,
+        "line": 1963,
       },
       "name": "HelmValuesWebhookNetworkPolicy",
       "properties": Array [
@@ -11293,7 +11395,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1965,
+            "line": 1967,
           },
           "name": "egress",
           "optional": true,
@@ -11316,7 +11418,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1970,
+            "line": 1972,
           },
           "name": "enabled",
           "optional": true,
@@ -11334,7 +11436,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1975,
+            "line": 1977,
           },
           "name": "ingress",
           "optional": true,
@@ -11362,7 +11464,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1997,
+        "line": 1999,
       },
       "name": "HelmValuesWebhookPodDisruptionBudget",
       "properties": Array [
@@ -11376,7 +11478,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2001,
+            "line": 2003,
           },
           "name": "enabled",
           "optional": true,
@@ -11394,7 +11496,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2006,
+            "line": 2008,
           },
           "name": "maxUnavailable",
           "optional": true,
@@ -11412,7 +11514,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2011,
+            "line": 2013,
           },
           "name": "minAvailable",
           "optional": true,
@@ -11435,7 +11537,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 2033,
+        "line": 2035,
       },
       "name": "HelmValuesWebhookServiceAccount",
       "properties": Array [
@@ -11449,7 +11551,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2037,
+            "line": 2039,
           },
           "name": "annotations",
           "optional": true,
@@ -11467,7 +11569,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2042,
+            "line": 2044,
           },
           "name": "automountServiceAccountToken",
           "optional": true,
@@ -11485,7 +11587,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2047,
+            "line": 2049,
           },
           "name": "create",
           "optional": true,
@@ -11503,7 +11605,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2052,
+            "line": 2054,
           },
           "name": "labels",
           "optional": true,
@@ -11521,7 +11623,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2057,
+            "line": 2059,
           },
           "name": "name",
           "optional": true,
@@ -11544,7 +11646,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 2081,
+        "line": 2083,
       },
       "name": "HelmValuesWebhookValidatingWebhookConfiguration",
       "properties": Array [
@@ -11558,7 +11660,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2085,
+            "line": 2087,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -11608,6 +11710,7 @@ def check_type(argname: str, value: object, expected_type: typing.Any) -> typing
 
 from ._jsii import *
 
+import cdk8s as _cdk8s_d3d9af27
 import constructs as _constructs_77d1e7e8
 
 
@@ -11649,6 +11752,18 @@ class Certmanager(
         )
 
         jsii.create(self.__class__, self, [scope, id, props])
+
+    @builtins.property
+    @jsii.member(jsii_name=\\"helm\\")
+    def helm(self) -> \\"_cdk8s_d3d9af27.Helm\\":
+        return typing.cast(\\"_cdk8s_d3d9af27.Helm\\", jsii.get(self, \\"helm\\"))
+
+    @helm.setter
+    def helm(self, value: \\"_cdk8s_d3d9af27.Helm\\") -> None:
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__49d55ce274b4a938b152c0c3208088911adc30540b6312f53bc1b49da08a899c)
+            check_type(argname=\\"argument value\\", value=value, expected_type=type_hints[\\"value\\"])
+        jsii.set(self, \\"helm\\", value) # pyright: ignore[reportArgumentType]
 
 
 @jsii.data_type(
@@ -16244,6 +16359,12 @@ def _typecheckingstub__89a70d238cbde564d2f86e0f0dd9cf3aa86d64fa4e2da743203149dad
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 
+def _typecheckingstub__49d55ce274b4a938b152c0c3208088911adc30540b6312f53bc1b49da08a899c(
+    value: _cdk8s_d3d9af27.Helm,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
 def _typecheckingstub__3bba575382ebd48f5845a258f563027f6d7bb063aa5933682a93cb9d800a546f(
     *,
     helm_executable: typing.Optional[builtins.str] = None,
@@ -16824,7 +16945,7 @@ Object {
       "initializer": Object {
         "locationInModule": Object {
           "filename": "cert-manager.ts",
-          "line": 14,
+          "line": 16,
         },
         "parameters": Array [
           Object {
@@ -16854,6 +16975,18 @@ Object {
         "line": 13,
       },
       "name": "Certmanager",
+      "properties": Array [
+        Object {
+          "locationInModule": Object {
+            "filename": "cert-manager.ts",
+            "line": 14,
+          },
+          "name": "helm",
+          "type": Object {
+            "fqn": "cdk8s.Helm",
+          },
+        },
+      ],
       "symbolId": "cert-manager:Certmanager",
     },
     "cert-manager.CertmanagerProps": Object {
@@ -16952,7 +17085,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 69,
+        "line": 71,
       },
       "name": "HelmValues",
       "properties": Array [
@@ -16966,7 +17099,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 73,
+            "line": 75,
           },
           "name": "acmesolver",
           "optional": true,
@@ -16984,7 +17117,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 78,
+            "line": 80,
           },
           "name": "affinity",
           "optional": true,
@@ -17002,7 +17135,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 83,
+            "line": 85,
           },
           "name": "approveSignerNames",
           "optional": true,
@@ -17025,7 +17158,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 88,
+            "line": 90,
           },
           "name": "automountServiceAccountToken",
           "optional": true,
@@ -17043,7 +17176,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 93,
+            "line": 95,
           },
           "name": "cainjector",
           "optional": true,
@@ -17061,7 +17194,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 98,
+            "line": 100,
           },
           "name": "clusterResourceNamespace",
           "optional": true,
@@ -17079,7 +17212,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 103,
+            "line": 105,
           },
           "name": "config",
           "optional": true,
@@ -17097,7 +17230,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 108,
+            "line": 110,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -17115,7 +17248,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 113,
+            "line": 115,
           },
           "name": "crds",
           "optional": true,
@@ -17133,7 +17266,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 118,
+            "line": 120,
           },
           "name": "creator",
           "optional": true,
@@ -17151,7 +17284,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 123,
+            "line": 125,
           },
           "name": "deploymentAnnotations",
           "optional": true,
@@ -17169,7 +17302,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 128,
+            "line": 130,
           },
           "name": "disableAutoApproval",
           "optional": true,
@@ -17187,7 +17320,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 133,
+            "line": 135,
           },
           "name": "dns01RecursiveNameservers",
           "optional": true,
@@ -17205,7 +17338,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 138,
+            "line": 140,
           },
           "name": "dns01RecursiveNameserversOnly",
           "optional": true,
@@ -17223,7 +17356,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 143,
+            "line": 145,
           },
           "name": "enableCertificateOwnerRef",
           "optional": true,
@@ -17241,7 +17374,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 153,
+            "line": 155,
           },
           "name": "enabled",
           "optional": true,
@@ -17259,7 +17392,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 148,
+            "line": 150,
           },
           "name": "enableServiceLinks",
           "optional": true,
@@ -17277,7 +17410,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 158,
+            "line": 160,
           },
           "name": "extraArgs",
           "optional": true,
@@ -17300,7 +17433,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 163,
+            "line": 165,
           },
           "name": "extraEnv",
           "optional": true,
@@ -17323,7 +17456,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 168,
+            "line": 170,
           },
           "name": "extraObjects",
           "optional": true,
@@ -17346,7 +17479,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 173,
+            "line": 175,
           },
           "name": "featureGates",
           "optional": true,
@@ -17364,7 +17497,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 178,
+            "line": 180,
           },
           "name": "fullnameOverride",
           "optional": true,
@@ -17382,7 +17515,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 183,
+            "line": 185,
           },
           "name": "global",
           "optional": true,
@@ -17400,7 +17533,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 188,
+            "line": 190,
           },
           "name": "hostAliases",
           "optional": true,
@@ -17423,7 +17556,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 193,
+            "line": 195,
           },
           "name": "httpProxy",
           "optional": true,
@@ -17441,7 +17574,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 198,
+            "line": 200,
           },
           "name": "httpsProxy",
           "optional": true,
@@ -17459,7 +17592,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 203,
+            "line": 205,
           },
           "name": "image",
           "optional": true,
@@ -17477,7 +17610,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 208,
+            "line": 210,
           },
           "name": "ingressShim",
           "optional": true,
@@ -17495,7 +17628,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 213,
+            "line": 215,
           },
           "name": "installCrDs",
           "optional": true,
@@ -17513,7 +17646,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 218,
+            "line": 220,
           },
           "name": "livenessProbe",
           "optional": true,
@@ -17531,7 +17664,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 223,
+            "line": 225,
           },
           "name": "maxConcurrentChallenges",
           "optional": true,
@@ -17549,7 +17682,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 228,
+            "line": 230,
           },
           "name": "nameOverride",
           "optional": true,
@@ -17567,7 +17700,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 233,
+            "line": 235,
           },
           "name": "namespace",
           "optional": true,
@@ -17585,7 +17718,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 243,
+            "line": 245,
           },
           "name": "nodeSelector",
           "optional": true,
@@ -17603,7 +17736,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 238,
+            "line": 240,
           },
           "name": "noProxy",
           "optional": true,
@@ -17621,7 +17754,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 248,
+            "line": 250,
           },
           "name": "podAnnotations",
           "optional": true,
@@ -17639,7 +17772,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 253,
+            "line": 255,
           },
           "name": "podDisruptionBudget",
           "optional": true,
@@ -17657,7 +17790,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 258,
+            "line": 260,
           },
           "name": "podDnsConfig",
           "optional": true,
@@ -17675,7 +17808,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 263,
+            "line": 265,
           },
           "name": "podDnsPolicy",
           "optional": true,
@@ -17693,7 +17826,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 268,
+            "line": 270,
           },
           "name": "podLabels",
           "optional": true,
@@ -17711,7 +17844,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 273,
+            "line": 275,
           },
           "name": "prometheus",
           "optional": true,
@@ -17729,7 +17862,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 278,
+            "line": 280,
           },
           "name": "replicaCount",
           "optional": true,
@@ -17747,7 +17880,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 283,
+            "line": 285,
           },
           "name": "resources",
           "optional": true,
@@ -17765,7 +17898,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 288,
+            "line": 290,
           },
           "name": "securityContext",
           "optional": true,
@@ -17783,7 +17916,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 293,
+            "line": 295,
           },
           "name": "serviceAccount",
           "optional": true,
@@ -17801,7 +17934,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 298,
+            "line": 300,
           },
           "name": "serviceAnnotations",
           "optional": true,
@@ -17819,7 +17952,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 303,
+            "line": 305,
           },
           "name": "serviceIpFamilies",
           "optional": true,
@@ -17842,7 +17975,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 308,
+            "line": 310,
           },
           "name": "serviceIpFamilyPolicy",
           "optional": true,
@@ -17860,7 +17993,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 313,
+            "line": 315,
           },
           "name": "serviceLabels",
           "optional": true,
@@ -17878,7 +18011,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 318,
+            "line": 320,
           },
           "name": "startupapicheck",
           "optional": true,
@@ -17896,7 +18029,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 323,
+            "line": 325,
           },
           "name": "strategy",
           "optional": true,
@@ -17914,7 +18047,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 328,
+            "line": 330,
           },
           "name": "tolerations",
           "optional": true,
@@ -17937,7 +18070,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 333,
+            "line": 335,
           },
           "name": "topologySpreadConstraints",
           "optional": true,
@@ -17960,7 +18093,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 338,
+            "line": 340,
           },
           "name": "volumeMounts",
           "optional": true,
@@ -17983,7 +18116,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 343,
+            "line": 345,
           },
           "name": "volumes",
           "optional": true,
@@ -18006,7 +18139,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 348,
+            "line": 350,
           },
           "name": "webhook",
           "optional": true,
@@ -18029,7 +18162,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 423,
+        "line": 425,
       },
       "name": "HelmValuesAcmesolver",
       "properties": Array [
@@ -18043,7 +18176,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 427,
+            "line": 429,
           },
           "name": "image",
           "optional": true,
@@ -18066,7 +18199,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1325,
+        "line": 1327,
       },
       "name": "HelmValuesAcmesolverImage",
       "properties": Array [
@@ -18080,7 +18213,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1329,
+            "line": 1331,
           },
           "name": "digest",
           "optional": true,
@@ -18098,7 +18231,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1334,
+            "line": 1336,
           },
           "name": "pullPolicy",
           "optional": true,
@@ -18116,7 +18249,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1339,
+            "line": 1341,
           },
           "name": "registry",
           "optional": true,
@@ -18134,7 +18267,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1344,
+            "line": 1346,
           },
           "name": "repository",
           "optional": true,
@@ -18152,7 +18285,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1349,
+            "line": 1351,
           },
           "name": "tag",
           "optional": true,
@@ -18175,7 +18308,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 447,
+        "line": 449,
       },
       "name": "HelmValuesCainjector",
       "properties": Array [
@@ -18189,7 +18322,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 451,
+            "line": 453,
           },
           "name": "affinity",
           "optional": true,
@@ -18207,7 +18340,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 456,
+            "line": 458,
           },
           "name": "automountServiceAccountToken",
           "optional": true,
@@ -18225,7 +18358,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 461,
+            "line": 463,
           },
           "name": "config",
           "optional": true,
@@ -18243,7 +18376,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 466,
+            "line": 468,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -18261,7 +18394,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 471,
+            "line": 473,
           },
           "name": "deploymentAnnotations",
           "optional": true,
@@ -18279,7 +18412,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 481,
+            "line": 483,
           },
           "name": "enabled",
           "optional": true,
@@ -18297,7 +18430,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 476,
+            "line": 478,
           },
           "name": "enableServiceLinks",
           "optional": true,
@@ -18315,7 +18448,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 486,
+            "line": 488,
           },
           "name": "extraArgs",
           "optional": true,
@@ -18338,7 +18471,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 491,
+            "line": 493,
           },
           "name": "extraEnv",
           "optional": true,
@@ -18361,7 +18494,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 496,
+            "line": 498,
           },
           "name": "featureGates",
           "optional": true,
@@ -18379,7 +18512,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 501,
+            "line": 503,
           },
           "name": "image",
           "optional": true,
@@ -18397,7 +18530,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 506,
+            "line": 508,
           },
           "name": "nodeSelector",
           "optional": true,
@@ -18415,7 +18548,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 511,
+            "line": 513,
           },
           "name": "podAnnotations",
           "optional": true,
@@ -18433,7 +18566,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 516,
+            "line": 518,
           },
           "name": "podDisruptionBudget",
           "optional": true,
@@ -18451,7 +18584,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 521,
+            "line": 523,
           },
           "name": "podLabels",
           "optional": true,
@@ -18469,7 +18602,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 526,
+            "line": 528,
           },
           "name": "replicaCount",
           "optional": true,
@@ -18487,7 +18620,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 531,
+            "line": 533,
           },
           "name": "resources",
           "optional": true,
@@ -18505,7 +18638,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 536,
+            "line": 538,
           },
           "name": "securityContext",
           "optional": true,
@@ -18523,7 +18656,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 541,
+            "line": 543,
           },
           "name": "serviceAccount",
           "optional": true,
@@ -18541,7 +18674,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 546,
+            "line": 548,
           },
           "name": "serviceAnnotations",
           "optional": true,
@@ -18559,7 +18692,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 551,
+            "line": 553,
           },
           "name": "serviceLabels",
           "optional": true,
@@ -18577,7 +18710,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 556,
+            "line": 558,
           },
           "name": "strategy",
           "optional": true,
@@ -18595,7 +18728,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 561,
+            "line": 563,
           },
           "name": "tolerations",
           "optional": true,
@@ -18618,7 +18751,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 566,
+            "line": 568,
           },
           "name": "topologySpreadConstraints",
           "optional": true,
@@ -18641,7 +18774,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 571,
+            "line": 573,
           },
           "name": "volumeMounts",
           "optional": true,
@@ -18664,7 +18797,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 576,
+            "line": 578,
           },
           "name": "volumes",
           "optional": true,
@@ -18692,7 +18825,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1373,
+        "line": 1375,
       },
       "name": "HelmValuesCainjectorImage",
       "properties": Array [
@@ -18706,7 +18839,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1377,
+            "line": 1379,
           },
           "name": "digest",
           "optional": true,
@@ -18724,7 +18857,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1382,
+            "line": 1384,
           },
           "name": "pullPolicy",
           "optional": true,
@@ -18742,7 +18875,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1387,
+            "line": 1389,
           },
           "name": "registry",
           "optional": true,
@@ -18760,7 +18893,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1392,
+            "line": 1394,
           },
           "name": "repository",
           "optional": true,
@@ -18778,7 +18911,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1397,
+            "line": 1399,
           },
           "name": "tag",
           "optional": true,
@@ -18801,7 +18934,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1421,
+        "line": 1423,
       },
       "name": "HelmValuesCainjectorPodDisruptionBudget",
       "properties": Array [
@@ -18815,7 +18948,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1425,
+            "line": 1427,
           },
           "name": "enabled",
           "optional": true,
@@ -18833,7 +18966,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1430,
+            "line": 1432,
           },
           "name": "maxUnavailable",
           "optional": true,
@@ -18851,7 +18984,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1435,
+            "line": 1437,
           },
           "name": "minAvailable",
           "optional": true,
@@ -18874,7 +19007,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1457,
+        "line": 1459,
       },
       "name": "HelmValuesCainjectorServiceAccount",
       "properties": Array [
@@ -18888,7 +19021,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1461,
+            "line": 1463,
           },
           "name": "annotations",
           "optional": true,
@@ -18906,7 +19039,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1466,
+            "line": 1468,
           },
           "name": "automountServiceAccountToken",
           "optional": true,
@@ -18924,7 +19057,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1471,
+            "line": 1473,
           },
           "name": "create",
           "optional": true,
@@ -18942,7 +19075,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1476,
+            "line": 1478,
           },
           "name": "labels",
           "optional": true,
@@ -18960,7 +19093,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1481,
+            "line": 1483,
           },
           "name": "name",
           "optional": true,
@@ -18983,7 +19116,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 621,
+        "line": 623,
       },
       "name": "HelmValuesCrds",
       "properties": Array [
@@ -18997,7 +19130,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 625,
+            "line": 627,
           },
           "name": "enabled",
           "optional": true,
@@ -19015,7 +19148,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 630,
+            "line": 632,
           },
           "name": "keep",
           "optional": true,
@@ -19039,7 +19172,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 653,
+        "line": 655,
       },
       "name": "HelmValuesGlobal",
       "properties": Array [
@@ -19053,7 +19186,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 657,
+            "line": 659,
           },
           "name": "commonLabels",
           "optional": true,
@@ -19071,7 +19204,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 662,
+            "line": 664,
           },
           "name": "imagePullSecrets",
           "optional": true,
@@ -19094,7 +19227,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 667,
+            "line": 669,
           },
           "name": "leaderElection",
           "optional": true,
@@ -19112,7 +19245,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 672,
+            "line": 674,
           },
           "name": "logLevel",
           "optional": true,
@@ -19130,7 +19263,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 677,
+            "line": 679,
           },
           "name": "podSecurityPolicy",
           "optional": true,
@@ -19148,7 +19281,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 682,
+            "line": 684,
           },
           "name": "priorityClassName",
           "optional": true,
@@ -19166,7 +19299,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 687,
+            "line": 689,
           },
           "name": "rbac",
           "optional": true,
@@ -19184,7 +19317,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 692,
+            "line": 694,
           },
           "name": "revisionHistoryLimit",
           "optional": true,
@@ -19207,7 +19340,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1505,
+        "line": 1507,
       },
       "name": "HelmValuesGlobalLeaderElection",
       "properties": Array [
@@ -19221,7 +19354,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1509,
+            "line": 1511,
           },
           "name": "leaseDuration",
           "optional": true,
@@ -19239,7 +19372,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1514,
+            "line": 1516,
           },
           "name": "namespace",
           "optional": true,
@@ -19257,7 +19390,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1519,
+            "line": 1521,
           },
           "name": "renewDeadline",
           "optional": true,
@@ -19275,7 +19408,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1524,
+            "line": 1526,
           },
           "name": "retryPeriod",
           "optional": true,
@@ -19298,7 +19431,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1547,
+        "line": 1549,
       },
       "name": "HelmValuesGlobalPodSecurityPolicy",
       "properties": Array [
@@ -19312,7 +19445,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1551,
+            "line": 1553,
           },
           "name": "enabled",
           "optional": true,
@@ -19330,7 +19463,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1556,
+            "line": 1558,
           },
           "name": "useAppArmor",
           "optional": true,
@@ -19353,7 +19486,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1577,
+        "line": 1579,
       },
       "name": "HelmValuesGlobalRbac",
       "properties": Array [
@@ -19367,7 +19500,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1581,
+            "line": 1583,
           },
           "name": "aggregateClusterRoles",
           "optional": true,
@@ -19385,7 +19518,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1586,
+            "line": 1588,
           },
           "name": "create",
           "optional": true,
@@ -19408,7 +19541,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 719,
+        "line": 721,
       },
       "name": "HelmValuesImage",
       "properties": Array [
@@ -19422,7 +19555,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 723,
+            "line": 725,
           },
           "name": "digest",
           "optional": true,
@@ -19440,7 +19573,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 728,
+            "line": 730,
           },
           "name": "pullPolicy",
           "optional": true,
@@ -19458,7 +19591,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 733,
+            "line": 735,
           },
           "name": "registry",
           "optional": true,
@@ -19476,7 +19609,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 738,
+            "line": 740,
           },
           "name": "repository",
           "optional": true,
@@ -19494,7 +19627,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 743,
+            "line": 745,
           },
           "name": "tag",
           "optional": true,
@@ -19517,7 +19650,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 767,
+        "line": 769,
       },
       "name": "HelmValuesIngressShim",
       "properties": Array [
@@ -19531,7 +19664,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 771,
+            "line": 773,
           },
           "name": "defaultIssuerGroup",
           "optional": true,
@@ -19549,7 +19682,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 776,
+            "line": 778,
           },
           "name": "defaultIssuerKind",
           "optional": true,
@@ -19567,7 +19700,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 781,
+            "line": 783,
           },
           "name": "defaultIssuerName",
           "optional": true,
@@ -19590,7 +19723,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 803,
+        "line": 805,
       },
       "name": "HelmValuesPodDisruptionBudget",
       "properties": Array [
@@ -19604,7 +19737,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 807,
+            "line": 809,
           },
           "name": "enabled",
           "optional": true,
@@ -19622,7 +19755,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 812,
+            "line": 814,
           },
           "name": "maxUnavailable",
           "optional": true,
@@ -19640,7 +19773,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 817,
+            "line": 819,
           },
           "name": "minAvailable",
           "optional": true,
@@ -19663,7 +19796,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 839,
+        "line": 841,
       },
       "name": "HelmValuesPrometheus",
       "properties": Array [
@@ -19677,7 +19810,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 843,
+            "line": 845,
           },
           "name": "enabled",
           "optional": true,
@@ -19695,7 +19828,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 848,
+            "line": 850,
           },
           "name": "podmonitor",
           "optional": true,
@@ -19713,7 +19846,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 853,
+            "line": 855,
           },
           "name": "servicemonitor",
           "optional": true,
@@ -19736,7 +19869,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1607,
+        "line": 1609,
       },
       "name": "HelmValuesPrometheusPodmonitor",
       "properties": Array [
@@ -19750,7 +19883,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1611,
+            "line": 1613,
           },
           "name": "annotations",
           "optional": true,
@@ -19768,7 +19901,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1616,
+            "line": 1618,
           },
           "name": "enabled",
           "optional": true,
@@ -19786,7 +19919,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1621,
+            "line": 1623,
           },
           "name": "endpointAdditionalProperties",
           "optional": true,
@@ -19804,7 +19937,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1626,
+            "line": 1628,
           },
           "name": "honorLabels",
           "optional": true,
@@ -19822,7 +19955,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1631,
+            "line": 1633,
           },
           "name": "interval",
           "optional": true,
@@ -19840,7 +19973,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1636,
+            "line": 1638,
           },
           "name": "labels",
           "optional": true,
@@ -19858,7 +19991,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1641,
+            "line": 1643,
           },
           "name": "namespace",
           "optional": true,
@@ -19876,7 +20009,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1646,
+            "line": 1648,
           },
           "name": "path",
           "optional": true,
@@ -19894,7 +20027,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1651,
+            "line": 1653,
           },
           "name": "prometheusInstance",
           "optional": true,
@@ -19912,7 +20045,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1656,
+            "line": 1658,
           },
           "name": "scrapeTimeout",
           "optional": true,
@@ -19935,7 +20068,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1685,
+        "line": 1687,
       },
       "name": "HelmValuesPrometheusServicemonitor",
       "properties": Array [
@@ -19949,7 +20082,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1689,
+            "line": 1691,
           },
           "name": "annotations",
           "optional": true,
@@ -19967,7 +20100,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1694,
+            "line": 1696,
           },
           "name": "enabled",
           "optional": true,
@@ -19985,7 +20118,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1699,
+            "line": 1701,
           },
           "name": "endpointAdditionalProperties",
           "optional": true,
@@ -20003,7 +20136,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1704,
+            "line": 1706,
           },
           "name": "honorLabels",
           "optional": true,
@@ -20021,7 +20154,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1709,
+            "line": 1711,
           },
           "name": "interval",
           "optional": true,
@@ -20039,7 +20172,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1714,
+            "line": 1716,
           },
           "name": "labels",
           "optional": true,
@@ -20057,7 +20190,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1719,
+            "line": 1721,
           },
           "name": "namespace",
           "optional": true,
@@ -20075,7 +20208,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1724,
+            "line": 1726,
           },
           "name": "path",
           "optional": true,
@@ -20093,7 +20226,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1729,
+            "line": 1731,
           },
           "name": "prometheusInstance",
           "optional": true,
@@ -20111,7 +20244,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1734,
+            "line": 1736,
           },
           "name": "scrapeTimeout",
           "optional": true,
@@ -20129,7 +20262,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1739,
+            "line": 1741,
           },
           "name": "targetPort",
           "optional": true,
@@ -20152,7 +20285,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 875,
+        "line": 877,
       },
       "name": "HelmValuesServiceAccount",
       "properties": Array [
@@ -20166,7 +20299,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 879,
+            "line": 881,
           },
           "name": "annotations",
           "optional": true,
@@ -20184,7 +20317,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 884,
+            "line": 886,
           },
           "name": "automountServiceAccountToken",
           "optional": true,
@@ -20202,7 +20335,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 889,
+            "line": 891,
           },
           "name": "create",
           "optional": true,
@@ -20220,7 +20353,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 894,
+            "line": 896,
           },
           "name": "labels",
           "optional": true,
@@ -20238,7 +20371,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 899,
+            "line": 901,
           },
           "name": "name",
           "optional": true,
@@ -20261,7 +20394,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 923,
+        "line": 925,
       },
       "name": "HelmValuesStartupapicheck",
       "properties": Array [
@@ -20275,7 +20408,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 927,
+            "line": 929,
           },
           "name": "affinity",
           "optional": true,
@@ -20293,7 +20426,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 932,
+            "line": 934,
           },
           "name": "automountServiceAccountToken",
           "optional": true,
@@ -20311,7 +20444,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 937,
+            "line": 939,
           },
           "name": "backoffLimit",
           "optional": true,
@@ -20329,7 +20462,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 942,
+            "line": 944,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -20347,7 +20480,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 952,
+            "line": 954,
           },
           "name": "enabled",
           "optional": true,
@@ -20365,7 +20498,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 947,
+            "line": 949,
           },
           "name": "enableServiceLinks",
           "optional": true,
@@ -20383,7 +20516,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 957,
+            "line": 959,
           },
           "name": "extraArgs",
           "optional": true,
@@ -20406,7 +20539,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 962,
+            "line": 964,
           },
           "name": "extraEnv",
           "optional": true,
@@ -20429,7 +20562,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 967,
+            "line": 969,
           },
           "name": "image",
           "optional": true,
@@ -20447,7 +20580,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 972,
+            "line": 974,
           },
           "name": "jobAnnotations",
           "optional": true,
@@ -20465,7 +20598,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 977,
+            "line": 979,
           },
           "name": "nodeSelector",
           "optional": true,
@@ -20483,7 +20616,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 982,
+            "line": 984,
           },
           "name": "podAnnotations",
           "optional": true,
@@ -20501,7 +20634,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 987,
+            "line": 989,
           },
           "name": "podLabels",
           "optional": true,
@@ -20519,7 +20652,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 992,
+            "line": 994,
           },
           "name": "rbac",
           "optional": true,
@@ -20537,7 +20670,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 997,
+            "line": 999,
           },
           "name": "resources",
           "optional": true,
@@ -20555,7 +20688,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1002,
+            "line": 1004,
           },
           "name": "securityContext",
           "optional": true,
@@ -20573,7 +20706,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1007,
+            "line": 1009,
           },
           "name": "serviceAccount",
           "optional": true,
@@ -20591,7 +20724,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1012,
+            "line": 1014,
           },
           "name": "timeout",
           "optional": true,
@@ -20609,7 +20742,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1017,
+            "line": 1019,
           },
           "name": "tolerations",
           "optional": true,
@@ -20632,7 +20765,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1022,
+            "line": 1024,
           },
           "name": "volumeMounts",
           "optional": true,
@@ -20655,7 +20788,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1027,
+            "line": 1029,
           },
           "name": "volumes",
           "optional": true,
@@ -20683,7 +20816,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1769,
+        "line": 1771,
       },
       "name": "HelmValuesStartupapicheckImage",
       "properties": Array [
@@ -20697,7 +20830,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1773,
+            "line": 1775,
           },
           "name": "digest",
           "optional": true,
@@ -20715,7 +20848,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1778,
+            "line": 1780,
           },
           "name": "pullPolicy",
           "optional": true,
@@ -20733,7 +20866,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1783,
+            "line": 1785,
           },
           "name": "registry",
           "optional": true,
@@ -20751,7 +20884,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1788,
+            "line": 1790,
           },
           "name": "repository",
           "optional": true,
@@ -20769,7 +20902,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1793,
+            "line": 1795,
           },
           "name": "tag",
           "optional": true,
@@ -20792,7 +20925,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1817,
+        "line": 1819,
       },
       "name": "HelmValuesStartupapicheckRbac",
       "properties": Array [
@@ -20806,7 +20939,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1821,
+            "line": 1823,
           },
           "name": "annotations",
           "optional": true,
@@ -20829,7 +20962,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1841,
+        "line": 1843,
       },
       "name": "HelmValuesStartupapicheckServiceAccount",
       "properties": Array [
@@ -20843,7 +20976,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1845,
+            "line": 1847,
           },
           "name": "annotations",
           "optional": true,
@@ -20861,7 +20994,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1850,
+            "line": 1852,
           },
           "name": "automountServiceAccountToken",
           "optional": true,
@@ -20879,7 +21012,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1855,
+            "line": 1857,
           },
           "name": "create",
           "optional": true,
@@ -20897,7 +21030,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1860,
+            "line": 1862,
           },
           "name": "labels",
           "optional": true,
@@ -20915,7 +21048,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1865,
+            "line": 1867,
           },
           "name": "name",
           "optional": true,
@@ -20938,7 +21071,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1067,
+        "line": 1069,
       },
       "name": "HelmValuesWebhook",
       "properties": Array [
@@ -20952,7 +21085,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1071,
+            "line": 1073,
           },
           "name": "affinity",
           "optional": true,
@@ -20970,7 +21103,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1076,
+            "line": 1078,
           },
           "name": "automountServiceAccountToken",
           "optional": true,
@@ -20988,7 +21121,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1081,
+            "line": 1083,
           },
           "name": "config",
           "optional": true,
@@ -21006,7 +21139,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1086,
+            "line": 1088,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -21024,7 +21157,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1091,
+            "line": 1093,
           },
           "name": "deploymentAnnotations",
           "optional": true,
@@ -21042,7 +21175,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1096,
+            "line": 1098,
           },
           "name": "enableServiceLinks",
           "optional": true,
@@ -21060,7 +21193,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1101,
+            "line": 1103,
           },
           "name": "extraArgs",
           "optional": true,
@@ -21083,7 +21216,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1106,
+            "line": 1108,
           },
           "name": "extraEnv",
           "optional": true,
@@ -21106,7 +21239,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1111,
+            "line": 1113,
           },
           "name": "featureGates",
           "optional": true,
@@ -21124,7 +21257,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1116,
+            "line": 1118,
           },
           "name": "hostNetwork",
           "optional": true,
@@ -21142,7 +21275,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1121,
+            "line": 1123,
           },
           "name": "image",
           "optional": true,
@@ -21160,7 +21293,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1126,
+            "line": 1128,
           },
           "name": "livenessProbe",
           "optional": true,
@@ -21178,7 +21311,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1131,
+            "line": 1133,
           },
           "name": "loadBalancerIp",
           "optional": true,
@@ -21196,7 +21329,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1136,
+            "line": 1138,
           },
           "name": "mutatingWebhookConfiguration",
           "optional": true,
@@ -21214,7 +21347,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1141,
+            "line": 1143,
           },
           "name": "mutatingWebhookConfigurationAnnotations",
           "optional": true,
@@ -21232,7 +21365,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1146,
+            "line": 1148,
           },
           "name": "networkPolicy",
           "optional": true,
@@ -21250,7 +21383,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1151,
+            "line": 1153,
           },
           "name": "nodeSelector",
           "optional": true,
@@ -21268,7 +21401,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1156,
+            "line": 1158,
           },
           "name": "podAnnotations",
           "optional": true,
@@ -21286,7 +21419,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1161,
+            "line": 1163,
           },
           "name": "podDisruptionBudget",
           "optional": true,
@@ -21304,7 +21437,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1166,
+            "line": 1168,
           },
           "name": "podLabels",
           "optional": true,
@@ -21322,7 +21455,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1171,
+            "line": 1173,
           },
           "name": "readinessProbe",
           "optional": true,
@@ -21340,7 +21473,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1176,
+            "line": 1178,
           },
           "name": "replicaCount",
           "optional": true,
@@ -21358,7 +21491,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1181,
+            "line": 1183,
           },
           "name": "resources",
           "optional": true,
@@ -21376,7 +21509,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1186,
+            "line": 1188,
           },
           "name": "securePort",
           "optional": true,
@@ -21394,7 +21527,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1191,
+            "line": 1193,
           },
           "name": "securityContext",
           "optional": true,
@@ -21412,7 +21545,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1196,
+            "line": 1198,
           },
           "name": "serviceAccount",
           "optional": true,
@@ -21430,7 +21563,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1201,
+            "line": 1203,
           },
           "name": "serviceAnnotations",
           "optional": true,
@@ -21448,7 +21581,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1206,
+            "line": 1208,
           },
           "name": "serviceIpFamilies",
           "optional": true,
@@ -21471,7 +21604,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1211,
+            "line": 1213,
           },
           "name": "serviceIpFamilyPolicy",
           "optional": true,
@@ -21489,7 +21622,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1216,
+            "line": 1218,
           },
           "name": "serviceLabels",
           "optional": true,
@@ -21507,7 +21640,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1221,
+            "line": 1223,
           },
           "name": "serviceType",
           "optional": true,
@@ -21525,7 +21658,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1226,
+            "line": 1228,
           },
           "name": "strategy",
           "optional": true,
@@ -21543,7 +21676,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1231,
+            "line": 1233,
           },
           "name": "timeoutSeconds",
           "optional": true,
@@ -21561,7 +21694,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1236,
+            "line": 1238,
           },
           "name": "tolerations",
           "optional": true,
@@ -21584,7 +21717,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1241,
+            "line": 1243,
           },
           "name": "topologySpreadConstraints",
           "optional": true,
@@ -21607,7 +21740,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1246,
+            "line": 1248,
           },
           "name": "url",
           "optional": true,
@@ -21625,7 +21758,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1251,
+            "line": 1253,
           },
           "name": "validatingWebhookConfiguration",
           "optional": true,
@@ -21643,7 +21776,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1256,
+            "line": 1258,
           },
           "name": "validatingWebhookConfigurationAnnotations",
           "optional": true,
@@ -21661,7 +21794,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1261,
+            "line": 1263,
           },
           "name": "volumeMounts",
           "optional": true,
@@ -21684,7 +21817,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1266,
+            "line": 1268,
           },
           "name": "volumes",
           "optional": true,
@@ -21712,7 +21845,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1889,
+        "line": 1891,
       },
       "name": "HelmValuesWebhookImage",
       "properties": Array [
@@ -21726,7 +21859,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1893,
+            "line": 1895,
           },
           "name": "digest",
           "optional": true,
@@ -21744,7 +21877,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1898,
+            "line": 1900,
           },
           "name": "pullPolicy",
           "optional": true,
@@ -21762,7 +21895,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1903,
+            "line": 1905,
           },
           "name": "registry",
           "optional": true,
@@ -21780,7 +21913,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1908,
+            "line": 1910,
           },
           "name": "repository",
           "optional": true,
@@ -21798,7 +21931,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1913,
+            "line": 1915,
           },
           "name": "tag",
           "optional": true,
@@ -21821,7 +21954,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1937,
+        "line": 1939,
       },
       "name": "HelmValuesWebhookMutatingWebhookConfiguration",
       "properties": Array [
@@ -21835,7 +21968,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1941,
+            "line": 1943,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -21858,7 +21991,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1961,
+        "line": 1963,
       },
       "name": "HelmValuesWebhookNetworkPolicy",
       "properties": Array [
@@ -21872,7 +22005,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1965,
+            "line": 1967,
           },
           "name": "egress",
           "optional": true,
@@ -21895,7 +22028,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1970,
+            "line": 1972,
           },
           "name": "enabled",
           "optional": true,
@@ -21913,7 +22046,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 1975,
+            "line": 1977,
           },
           "name": "ingress",
           "optional": true,
@@ -21941,7 +22074,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 1997,
+        "line": 1999,
       },
       "name": "HelmValuesWebhookPodDisruptionBudget",
       "properties": Array [
@@ -21955,7 +22088,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2001,
+            "line": 2003,
           },
           "name": "enabled",
           "optional": true,
@@ -21973,7 +22106,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2006,
+            "line": 2008,
           },
           "name": "maxUnavailable",
           "optional": true,
@@ -21991,7 +22124,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2011,
+            "line": 2013,
           },
           "name": "minAvailable",
           "optional": true,
@@ -22014,7 +22147,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 2033,
+        "line": 2035,
       },
       "name": "HelmValuesWebhookServiceAccount",
       "properties": Array [
@@ -22028,7 +22161,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2037,
+            "line": 2039,
           },
           "name": "annotations",
           "optional": true,
@@ -22046,7 +22179,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2042,
+            "line": 2044,
           },
           "name": "automountServiceAccountToken",
           "optional": true,
@@ -22064,7 +22197,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2047,
+            "line": 2049,
           },
           "name": "create",
           "optional": true,
@@ -22082,7 +22215,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2052,
+            "line": 2054,
           },
           "name": "labels",
           "optional": true,
@@ -22100,7 +22233,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2057,
+            "line": 2059,
           },
           "name": "name",
           "optional": true,
@@ -22123,7 +22256,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "cert-manager.ts",
-        "line": 2081,
+        "line": 2083,
       },
       "name": "HelmValuesWebhookValidatingWebhookConfiguration",
       "properties": Array [
@@ -22137,7 +22270,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "cert-manager.ts",
-            "line": 2085,
+            "line": 2087,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -22168,6 +22301,8 @@ export interface CertmanagerProps {
 }
 
 export class Certmanager extends Construct {
+  public helm: Helm;
+
   public constructor(scope: Construct, id: string, props: CertmanagerProps = {}) {
     super(scope, id);
     let updatedProps = {};
@@ -22193,7 +22328,7 @@ export class Certmanager extends Construct {
       ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
     };
 
-    new Helm(this, 'Helm', finalProps);
+    this.helm = new Helm(this, 'Helm', finalProps);
   }
 
   private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
@@ -24356,7 +24491,7 @@ Object {
       "initializer": Object {
         "locationInModule": Object {
           "filename": "loki.ts",
-          "line": 14,
+          "line": 16,
         },
         "parameters": Array [
           Object {
@@ -24386,6 +24521,18 @@ Object {
         "line": 13,
       },
       "name": "Loki",
+      "properties": Array [
+        Object {
+          "locationInModule": Object {
+            "filename": "loki.ts",
+            "line": 14,
+          },
+          "name": "helm",
+          "type": Object {
+            "fqn": "cdk8s.Helm",
+          },
+        },
+      ],
       "symbolId": "loki:Loki",
     },
     "loki.LokiProps": Object {
@@ -24516,6 +24663,7 @@ def check_type(argname: str, value: object, expected_type: typing.Any) -> typing
 
 from ._jsii import *
 
+import cdk8s as _cdk8s_d3d9af27
 import constructs as _constructs_77d1e7e8
 
 
@@ -24557,6 +24705,18 @@ class Loki(
         )
 
         jsii.create(self.__class__, self, [scope, id, props])
+
+    @builtins.property
+    @jsii.member(jsii_name=\\"helm\\")
+    def helm(self) -> \\"_cdk8s_d3d9af27.Helm\\":
+        return typing.cast(\\"_cdk8s_d3d9af27.Helm\\", jsii.get(self, \\"helm\\"))
+
+    @helm.setter
+    def helm(self, value: \\"_cdk8s_d3d9af27.Helm\\") -> None:
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__4ce0a4b600b5e431f59726607b0807de8b928a7439cb3603d7a5e16a725b53e1)
+            check_type(argname=\\"argument value\\", value=value, expected_type=type_hints[\\"value\\"])
+        jsii.set(self, \\"helm\\", value) # pyright: ignore[reportArgumentType]
 
 
 @jsii.data_type(
@@ -24659,6 +24819,12 @@ def _typecheckingstub__f1d23af9ace606bd925629648645169df04574e2a303e09d4fcaf42d6
     namespace: typing.Optional[builtins.str] = None,
     release_name: typing.Optional[builtins.str] = None,
     values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__4ce0a4b600b5e431f59726607b0807de8b928a7439cb3603d7a5e16a725b53e1(
+    value: _cdk8s_d3d9af27.Helm,
 ) -> None:
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
@@ -24814,7 +24980,7 @@ Object {
       "initializer": Object {
         "locationInModule": Object {
           "filename": "loki.ts",
-          "line": 14,
+          "line": 16,
         },
         "parameters": Array [
           Object {
@@ -24844,6 +25010,18 @@ Object {
         "line": 13,
       },
       "name": "Loki",
+      "properties": Array [
+        Object {
+          "locationInModule": Object {
+            "filename": "loki.ts",
+            "line": 14,
+          },
+          "name": "helm",
+          "type": Object {
+            "fqn": "cdk8s.Helm",
+          },
+        },
+      ],
       "symbolId": "loki:Loki",
     },
     "loki.LokiProps": Object {
@@ -24955,6 +25133,8 @@ export interface LokiProps {
 }
 
 export class Loki extends Construct {
+  public helm: Helm;
+
   public constructor(scope: Construct, id: string, props: LokiProps = {}) {
     super(scope, id);
     let updatedProps = {};
@@ -24980,7 +25160,7 @@ export class Loki extends Construct {
       ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
     };
 
-    new Helm(this, 'Helm', finalProps);
+    this.helm = new Helm(this, 'Helm', finalProps);
   }
 
   private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
@@ -25107,7 +25287,7 @@ Object {
       "initializer": Object {
         "locationInModule": Object {
           "filename": "ingress-nginx.ts",
-          "line": 14,
+          "line": 16,
         },
         "parameters": Array [
           Object {
@@ -25137,6 +25317,18 @@ Object {
         "line": 13,
       },
       "name": "Ingressnginx",
+      "properties": Array [
+        Object {
+          "locationInModule": Object {
+            "filename": "ingress-nginx.ts",
+            "line": 14,
+          },
+          "name": "helm",
+          "type": Object {
+            "fqn": "cdk8s.Helm",
+          },
+        },
+      ],
       "symbolId": "ingress-nginx:Ingressnginx",
     },
     "ingress-nginx.IngressnginxProps": Object {
@@ -25267,6 +25459,7 @@ def check_type(argname: str, value: object, expected_type: typing.Any) -> typing
 
 from ._jsii import *
 
+import cdk8s as _cdk8s_d3d9af27
 import constructs as _constructs_77d1e7e8
 
 
@@ -25308,6 +25501,18 @@ class Ingressnginx(
         )
 
         jsii.create(self.__class__, self, [scope, id, props])
+
+    @builtins.property
+    @jsii.member(jsii_name=\\"helm\\")
+    def helm(self) -> \\"_cdk8s_d3d9af27.Helm\\":
+        return typing.cast(\\"_cdk8s_d3d9af27.Helm\\", jsii.get(self, \\"helm\\"))
+
+    @helm.setter
+    def helm(self, value: \\"_cdk8s_d3d9af27.Helm\\") -> None:
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__bf4e38d82d6ec512d25f7746a82eabc0d602261aa2aeeab89a5d0933455140d4)
+            check_type(argname=\\"argument value\\", value=value, expected_type=type_hints[\\"value\\"])
+        jsii.set(self, \\"helm\\", value) # pyright: ignore[reportArgumentType]
 
 
 @jsii.data_type(
@@ -25410,6 +25615,12 @@ def _typecheckingstub__85396a67490dbbfcd10c31b9f9ce68b754adb55bb50faf2fe76992886
     namespace: typing.Optional[builtins.str] = None,
     release_name: typing.Optional[builtins.str] = None,
     values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__bf4e38d82d6ec512d25f7746a82eabc0d602261aa2aeeab89a5d0933455140d4(
+    value: _cdk8s_d3d9af27.Helm,
 ) -> None:
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
@@ -25565,7 +25776,7 @@ Object {
       "initializer": Object {
         "locationInModule": Object {
           "filename": "ingress-nginx.ts",
-          "line": 14,
+          "line": 16,
         },
         "parameters": Array [
           Object {
@@ -25595,6 +25806,18 @@ Object {
         "line": 13,
       },
       "name": "Ingressnginx",
+      "properties": Array [
+        Object {
+          "locationInModule": Object {
+            "filename": "ingress-nginx.ts",
+            "line": 14,
+          },
+          "name": "helm",
+          "type": Object {
+            "fqn": "cdk8s.Helm",
+          },
+        },
+      ],
       "symbolId": "ingress-nginx:Ingressnginx",
     },
     "ingress-nginx.IngressnginxProps": Object {
@@ -25706,6 +25929,8 @@ export interface IngressnginxProps {
 }
 
 export class Ingressnginx extends Construct {
+  public helm: Helm;
+
   public constructor(scope: Construct, id: string, props: IngressnginxProps = {}) {
     super(scope, id);
     let updatedProps = {};
@@ -25731,7 +25956,7 @@ export class Ingressnginx extends Construct {
       ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
     };
 
-    new Helm(this, 'Helm', finalProps);
+    this.helm = new Helm(this, 'Helm', finalProps);
   }
 
   private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
@@ -25864,7 +26089,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 787,
+        "line": 789,
       },
       "name": "IoK8SApiCoreV1Affinity",
       "properties": Array [
@@ -25879,7 +26104,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 793,
+            "line": 795,
           },
           "name": "nodeAffinity",
           "optional": true,
@@ -25898,7 +26123,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 800,
+            "line": 802,
           },
           "name": "podAffinity",
           "optional": true,
@@ -25917,7 +26142,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 807,
+            "line": 809,
           },
           "name": "podAntiAffinity",
           "optional": true,
@@ -25941,7 +26166,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1318,
+        "line": 1320,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinity",
       "properties": Array [
@@ -25957,7 +26182,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1324,
+            "line": 1326,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -25982,7 +26207,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1331,
+            "line": 1333,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -26006,7 +26231,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1495,
+        "line": 1497,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -26022,7 +26247,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1501,
+            "line": 1503,
           },
           "name": "preference",
           "optional": true,
@@ -26041,7 +26266,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1508,
+            "line": 1510,
           },
           "name": "weight",
           "optional": true,
@@ -26066,7 +26291,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1735,
+        "line": 1737,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
       "properties": Array [
@@ -26081,7 +26306,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1741,
+            "line": 1743,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -26105,7 +26330,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1748,
+            "line": 1750,
           },
           "name": "matchFields",
           "optional": true,
@@ -26134,7 +26359,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2055,
+        "line": 2057,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
       "properties": Array [
@@ -26149,7 +26374,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2061,
+            "line": 2063,
           },
           "name": "key",
           "optional": true,
@@ -26175,7 +26400,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2076,
+            "line": 2078,
           },
           "name": "operator",
           "optional": true,
@@ -26195,7 +26420,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2083,
+            "line": 2085,
           },
           "name": "values",
           "optional": true,
@@ -26230,7 +26455,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2591,
+        "line": 2593,
       },
       "members": Array [
         Object {
@@ -26286,7 +26511,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2107,
+        "line": 2109,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
       "properties": Array [
@@ -26301,7 +26526,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2113,
+            "line": 2115,
           },
           "name": "key",
           "optional": true,
@@ -26327,7 +26552,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2128,
+            "line": 2130,
           },
           "name": "operator",
           "optional": true,
@@ -26347,7 +26572,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2135,
+            "line": 2137,
           },
           "name": "values",
           "optional": true,
@@ -26382,7 +26607,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2619,
+        "line": 2621,
       },
       "members": Array [
         Object {
@@ -26439,7 +26664,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1531,
+        "line": 1533,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -26455,7 +26680,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1537,
+            "line": 1539,
           },
           "name": "nodeSelectorTerms",
           "optional": true,
@@ -26485,7 +26710,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1771,
+        "line": 1773,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
       "properties": Array [
@@ -26500,7 +26725,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1777,
+            "line": 1779,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -26524,7 +26749,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1784,
+            "line": 1786,
           },
           "name": "matchFields",
           "optional": true,
@@ -26553,7 +26778,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2159,
+        "line": 2161,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
       "properties": Array [
@@ -26568,7 +26793,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2165,
+            "line": 2167,
           },
           "name": "key",
           "optional": true,
@@ -26594,7 +26819,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2180,
+            "line": 2182,
           },
           "name": "operator",
           "optional": true,
@@ -26614,7 +26839,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2187,
+            "line": 2189,
           },
           "name": "values",
           "optional": true,
@@ -26649,7 +26874,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2647,
+        "line": 2649,
       },
       "members": Array [
         Object {
@@ -26705,7 +26930,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2211,
+        "line": 2213,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
       "properties": Array [
@@ -26720,7 +26945,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2217,
+            "line": 2219,
           },
           "name": "key",
           "optional": true,
@@ -26746,7 +26971,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2232,
+            "line": 2234,
           },
           "name": "operator",
           "optional": true,
@@ -26766,7 +26991,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2239,
+            "line": 2241,
           },
           "name": "values",
           "optional": true,
@@ -26801,7 +27026,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2675,
+        "line": 2677,
       },
       "members": Array [
         Object {
@@ -26857,7 +27082,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1354,
+        "line": 1356,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinity",
       "properties": Array [
@@ -26873,7 +27098,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1360,
+            "line": 1362,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -26898,7 +27123,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1367,
+            "line": 1369,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -26927,7 +27152,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1559,
+        "line": 1561,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -26942,7 +27167,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1565,
+            "line": 1567,
           },
           "name": "podAffinityTerm",
           "optional": true,
@@ -26961,7 +27186,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1572,
+            "line": 1574,
           },
           "name": "weight",
           "optional": true,
@@ -26985,7 +27210,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1807,
+        "line": 1809,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "properties": Array [
@@ -27001,7 +27226,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1834,
+            "line": 1836,
           },
           "name": "topologyKey",
           "type": Object {
@@ -27020,7 +27245,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1813,
+            "line": 1815,
           },
           "name": "labelSelector",
           "optional": true,
@@ -27040,7 +27265,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1827,
+            "line": 1829,
           },
           "name": "namespaces",
           "optional": true,
@@ -27065,7 +27290,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1820,
+            "line": 1822,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -27090,7 +27315,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2263,
+        "line": 2265,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "properties": Array [
@@ -27106,7 +27331,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2269,
+            "line": 2271,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -27131,7 +27356,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2276,
+            "line": 2278,
           },
           "name": "matchLabels",
           "optional": true,
@@ -27160,7 +27385,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2695,
+        "line": 2697,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "properties": Array [
@@ -27175,7 +27400,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2701,
+            "line": 2703,
           },
           "name": "key",
           "optional": true,
@@ -27195,7 +27420,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2708,
+            "line": 2710,
           },
           "name": "operator",
           "optional": true,
@@ -27215,7 +27440,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2715,
+            "line": 2717,
           },
           "name": "values",
           "optional": true,
@@ -27245,7 +27470,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2299,
+        "line": 2301,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
       "properties": Array [
@@ -27261,7 +27486,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2305,
+            "line": 2307,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -27286,7 +27511,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2312,
+            "line": 2314,
           },
           "name": "matchLabels",
           "optional": true,
@@ -27315,7 +27540,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2739,
+        "line": 2741,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -27330,7 +27555,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2745,
+            "line": 2747,
           },
           "name": "key",
           "optional": true,
@@ -27350,7 +27575,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2752,
+            "line": 2754,
           },
           "name": "operator",
           "optional": true,
@@ -27370,7 +27595,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2759,
+            "line": 2761,
           },
           "name": "values",
           "optional": true,
@@ -27399,7 +27624,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1595,
+        "line": 1597,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -27415,7 +27640,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1601,
+            "line": 1603,
           },
           "name": "labelSelector",
           "optional": true,
@@ -27435,7 +27660,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1615,
+            "line": 1617,
           },
           "name": "namespaces",
           "optional": true,
@@ -27460,7 +27685,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1608,
+            "line": 1610,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -27480,7 +27705,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1622,
+            "line": 1624,
           },
           "name": "topologyKey",
           "optional": true,
@@ -27505,7 +27730,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1859,
+        "line": 1861,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "properties": Array [
@@ -27521,7 +27746,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1865,
+            "line": 1867,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -27546,7 +27771,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1872,
+            "line": 1874,
           },
           "name": "matchLabels",
           "optional": true,
@@ -27575,7 +27800,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2335,
+        "line": 2337,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "properties": Array [
@@ -27590,7 +27815,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2341,
+            "line": 2343,
           },
           "name": "key",
           "optional": true,
@@ -27610,7 +27835,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2348,
+            "line": 2350,
           },
           "name": "operator",
           "optional": true,
@@ -27630,7 +27855,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2355,
+            "line": 2357,
           },
           "name": "values",
           "optional": true,
@@ -27660,7 +27885,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1895,
+        "line": 1897,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
       "properties": Array [
@@ -27676,7 +27901,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1901,
+            "line": 1903,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -27701,7 +27926,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1908,
+            "line": 1910,
           },
           "name": "matchLabels",
           "optional": true,
@@ -27730,7 +27955,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2379,
+        "line": 2381,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -27745,7 +27970,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2385,
+            "line": 2387,
           },
           "name": "key",
           "optional": true,
@@ -27765,7 +27990,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2392,
+            "line": 2394,
           },
           "name": "operator",
           "optional": true,
@@ -27785,7 +28010,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2399,
+            "line": 2401,
           },
           "name": "values",
           "optional": true,
@@ -27814,7 +28039,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1390,
+        "line": 1392,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinity",
       "properties": Array [
@@ -27830,7 +28055,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1396,
+            "line": 1398,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -27855,7 +28080,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1403,
+            "line": 1405,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -27884,7 +28109,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1647,
+        "line": 1649,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -27899,7 +28124,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1653,
+            "line": 1655,
           },
           "name": "podAffinityTerm",
           "optional": true,
@@ -27918,7 +28143,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1660,
+            "line": 1662,
           },
           "name": "weight",
           "optional": true,
@@ -27942,7 +28167,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1931,
+        "line": 1933,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "properties": Array [
@@ -27958,7 +28183,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1958,
+            "line": 1960,
           },
           "name": "topologyKey",
           "type": Object {
@@ -27977,7 +28202,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1937,
+            "line": 1939,
           },
           "name": "labelSelector",
           "optional": true,
@@ -27997,7 +28222,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1951,
+            "line": 1953,
           },
           "name": "namespaces",
           "optional": true,
@@ -28022,7 +28247,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1944,
+            "line": 1946,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -28047,7 +28272,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2423,
+        "line": 2425,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "properties": Array [
@@ -28063,7 +28288,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2429,
+            "line": 2431,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -28088,7 +28313,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2436,
+            "line": 2438,
           },
           "name": "matchLabels",
           "optional": true,
@@ -28117,7 +28342,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2783,
+        "line": 2785,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "properties": Array [
@@ -28132,7 +28357,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2789,
+            "line": 2791,
           },
           "name": "key",
           "optional": true,
@@ -28152,7 +28377,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2796,
+            "line": 2798,
           },
           "name": "operator",
           "optional": true,
@@ -28172,7 +28397,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2803,
+            "line": 2805,
           },
           "name": "values",
           "optional": true,
@@ -28202,7 +28427,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2459,
+        "line": 2461,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
       "properties": Array [
@@ -28218,7 +28443,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2465,
+            "line": 2467,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -28243,7 +28468,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2472,
+            "line": 2474,
           },
           "name": "matchLabels",
           "optional": true,
@@ -28272,7 +28497,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2827,
+        "line": 2829,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -28287,7 +28512,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2833,
+            "line": 2835,
           },
           "name": "key",
           "optional": true,
@@ -28307,7 +28532,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2840,
+            "line": 2842,
           },
           "name": "operator",
           "optional": true,
@@ -28327,7 +28552,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2847,
+            "line": 2849,
           },
           "name": "values",
           "optional": true,
@@ -28356,7 +28581,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1683,
+        "line": 1685,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -28372,7 +28597,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1689,
+            "line": 1691,
           },
           "name": "labelSelector",
           "optional": true,
@@ -28392,7 +28617,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1703,
+            "line": 1705,
           },
           "name": "namespaces",
           "optional": true,
@@ -28417,7 +28642,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1696,
+            "line": 1698,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -28437,7 +28662,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1710,
+            "line": 1712,
           },
           "name": "topologyKey",
           "optional": true,
@@ -28462,7 +28687,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1983,
+        "line": 1985,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "properties": Array [
@@ -28478,7 +28703,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1989,
+            "line": 1991,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -28503,7 +28728,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1996,
+            "line": 1998,
           },
           "name": "matchLabels",
           "optional": true,
@@ -28532,7 +28757,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2495,
+        "line": 2497,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "properties": Array [
@@ -28547,7 +28772,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2501,
+            "line": 2503,
           },
           "name": "key",
           "optional": true,
@@ -28567,7 +28792,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2508,
+            "line": 2510,
           },
           "name": "operator",
           "optional": true,
@@ -28587,7 +28812,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2515,
+            "line": 2517,
           },
           "name": "values",
           "optional": true,
@@ -28617,7 +28842,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2019,
+        "line": 2021,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
       "properties": Array [
@@ -28633,7 +28858,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2025,
+            "line": 2027,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -28658,7 +28883,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2032,
+            "line": 2034,
           },
           "name": "matchLabels",
           "optional": true,
@@ -28687,7 +28912,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2539,
+        "line": 2541,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -28702,7 +28927,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2545,
+            "line": 2547,
           },
           "name": "key",
           "optional": true,
@@ -28722,7 +28947,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2552,
+            "line": 2554,
           },
           "name": "operator",
           "optional": true,
@@ -28742,7 +28967,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2559,
+            "line": 2561,
           },
           "name": "values",
           "optional": true,
@@ -28771,7 +28996,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 831,
+        "line": 833,
       },
       "name": "IoK8SApiCoreV1DaemonSetUpdateStrategy",
       "properties": Array [
@@ -28786,7 +29011,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 837,
+            "line": 839,
           },
           "name": "rollingUpdate",
           "optional": true,
@@ -28809,7 +29034,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 849,
+            "line": 851,
           },
           "name": "type",
           "optional": true,
@@ -28833,7 +29058,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1426,
+        "line": 1428,
       },
       "name": "IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
       "properties": Array [
@@ -28847,7 +29072,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1430,
+            "line": 1432,
           },
           "name": "maxSurge",
           "optional": true,
@@ -28865,7 +29090,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1435,
+            "line": 1437,
           },
           "name": "maxUnavailable",
           "optional": true,
@@ -28892,7 +29117,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1463,
+        "line": 1465,
       },
       "members": Array [
         Object {
@@ -28924,7 +29149,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 896,
+        "line": 898,
       },
       "name": "IoK8SApiCoreV1LocalObjectReference",
       "properties": Array [
@@ -28940,7 +29165,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 902,
+            "line": 904,
           },
           "name": "name",
           "optional": true,
@@ -28964,7 +29189,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 681,
+        "line": 683,
       },
       "name": "IoK8SApiCoreV1ResourceRequirements",
       "properties": Array [
@@ -28980,7 +29205,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 687,
+            "line": 689,
           },
           "name": "limits",
           "optional": true,
@@ -29005,7 +29230,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 694,
+            "line": 696,
           },
           "name": "requests",
           "optional": true,
@@ -29034,7 +29259,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 717,
+        "line": 719,
       },
       "name": "IoK8SApiCoreV1Toleration",
       "properties": Array [
@@ -29055,7 +29280,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 728,
+            "line": 730,
           },
           "name": "effect",
           "optional": true,
@@ -29075,7 +29300,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 735,
+            "line": 737,
           },
           "name": "key",
           "optional": true,
@@ -29100,7 +29325,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 747,
+            "line": 749,
           },
           "name": "operator",
           "optional": true,
@@ -29120,7 +29345,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 754,
+            "line": 756,
           },
           "name": "tolerationSeconds",
           "optional": true,
@@ -29140,7 +29365,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 761,
+            "line": 763,
           },
           "name": "value",
           "optional": true,
@@ -29169,7 +29394,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1287,
+        "line": 1289,
       },
       "members": Array [
         Object {
@@ -29212,7 +29437,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1306,
+        "line": 1308,
       },
       "members": Array [
         Object {
@@ -29243,7 +29468,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 307,
+        "line": 309,
       },
       "name": "LaceworkAgentCloudservice",
       "properties": Array [
@@ -29257,7 +29482,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 311,
+            "line": 313,
           },
           "name": "gke",
           "optional": true,
@@ -29280,7 +29505,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 870,
+        "line": 872,
       },
       "name": "LaceworkAgentCloudserviceGke",
       "properties": Array [
@@ -29294,7 +29519,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 874,
+            "line": 876,
           },
           "name": "autopilot",
           "optional": true,
@@ -29317,7 +29542,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 437,
+        "line": 439,
       },
       "name": "LaceworkAgentClusterAgent",
       "properties": Array [
@@ -29332,7 +29557,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 448,
+            "line": 450,
           },
           "name": "enable",
           "type": Object {
@@ -29349,7 +29574,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 441,
+            "line": 443,
           },
           "name": "image",
           "type": Object {
@@ -29367,7 +29592,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 483,
+            "line": 485,
           },
           "name": "additionalValues",
           "optional": true,
@@ -29391,7 +29616,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 462,
+            "line": 464,
           },
           "name": "clusterRegion",
           "optional": true,
@@ -29410,7 +29635,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 455,
+            "line": 457,
           },
           "name": "clusterType",
           "optional": true,
@@ -29429,7 +29654,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 469,
+            "line": 471,
           },
           "name": "scrapeInitialDelayMins",
           "optional": true,
@@ -29448,7 +29673,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 476,
+            "line": 478,
           },
           "name": "scrapeIntervalMins",
           "optional": true,
@@ -29471,7 +29696,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1010,
+        "line": 1012,
       },
       "members": Array [
         Object {
@@ -29508,7 +29733,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 942,
+        "line": 944,
       },
       "name": "LaceworkAgentClusterAgentImage",
       "properties": Array [
@@ -29530,7 +29755,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 961,
+            "line": 963,
           },
           "name": "pullPolicy",
           "type": Object {
@@ -29547,7 +29772,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 966,
+            "line": 968,
           },
           "name": "registry",
           "type": Object {
@@ -29564,7 +29789,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 971,
+            "line": 973,
           },
           "name": "repository",
           "type": Object {
@@ -29581,7 +29806,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 976,
+            "line": 978,
           },
           "name": "tag",
           "type": Object {
@@ -29599,7 +29824,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 983,
+            "line": 985,
           },
           "name": "additionalValues",
           "optional": true,
@@ -29624,7 +29849,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 948,
+            "line": 950,
           },
           "name": "imagePullSecrets",
           "optional": true,
@@ -29659,7 +29884,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1481,
+        "line": 1483,
       },
       "members": Array [
         Object {
@@ -29696,7 +29921,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 191,
+        "line": 193,
       },
       "name": "LaceworkAgentDaemonset",
       "properties": Array [
@@ -29711,7 +29936,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 197,
+            "line": 199,
           },
           "name": "affinity",
           "type": Object {
@@ -29729,7 +29954,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 204,
+            "line": 206,
           },
           "name": "updateStrategy",
           "type": Object {
@@ -29751,7 +29976,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 331,
+        "line": 333,
       },
       "name": "LaceworkAgentDatacollector",
       "properties": Array [
@@ -29766,7 +29991,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 344,
+            "line": 346,
           },
           "name": "additionalValues",
           "optional": true,
@@ -29790,7 +30015,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 337,
+            "line": 339,
           },
           "name": "enable",
           "optional": true,
@@ -29813,7 +30038,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 225,
+        "line": 227,
       },
       "name": "LaceworkAgentDeployment",
       "properties": Array [
@@ -29828,7 +30053,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 231,
+            "line": 233,
           },
           "name": "affinity",
           "type": Object {
@@ -29846,7 +30071,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 238,
+            "line": 240,
           },
           "name": "updateStrategy",
           "type": Object {
@@ -29864,7 +30089,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 259,
+            "line": 261,
           },
           "name": "priorityClassCreate",
           "optional": true,
@@ -29884,7 +30109,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 252,
+            "line": 254,
           },
           "name": "priorityClassName",
           "optional": true,
@@ -29903,7 +30128,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 266,
+            "line": 268,
           },
           "name": "priorityClassPreemptionPolicy",
           "optional": true,
@@ -29922,7 +30147,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 273,
+            "line": 275,
           },
           "name": "priorityClassValue",
           "optional": true,
@@ -29942,7 +30167,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 245,
+            "line": 247,
           },
           "name": "resources",
           "optional": true,
@@ -29961,7 +30186,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 280,
+            "line": 282,
           },
           "name": "tolerations",
           "optional": true,
@@ -29989,7 +30214,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 365,
+        "line": 367,
       },
       "name": "LaceworkAgentImage",
       "properties": Array [
@@ -30011,7 +30236,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 384,
+            "line": 386,
           },
           "name": "pullPolicy",
           "type": Object {
@@ -30028,7 +30253,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 389,
+            "line": 391,
           },
           "name": "registry",
           "type": Object {
@@ -30045,7 +30270,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 394,
+            "line": 396,
           },
           "name": "repository",
           "type": Object {
@@ -30062,7 +30287,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 399,
+            "line": 401,
           },
           "name": "tag",
           "type": Object {
@@ -30080,7 +30305,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 411,
+            "line": 413,
           },
           "name": "additionalValues",
           "optional": true,
@@ -30105,7 +30330,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 371,
+            "line": 373,
           },
           "name": "imagePullSecrets",
           "optional": true,
@@ -30128,7 +30353,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 404,
+            "line": 406,
           },
           "name": "overrideValue",
           "optional": true,
@@ -30158,7 +30383,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 930,
+        "line": 932,
       },
       "members": Array [
         Object {
@@ -30195,7 +30420,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 509,
+        "line": 511,
       },
       "name": "LaceworkAgentLaceworkConfig",
       "properties": Array [
@@ -30209,7 +30434,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 513,
+            "line": 515,
           },
           "name": "accessToken",
           "type": Object {
@@ -30227,7 +30452,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 636,
+            "line": 638,
           },
           "name": "additionalValues",
           "optional": true,
@@ -30252,7 +30477,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 525,
+            "line": 527,
           },
           "name": "annotations",
           "optional": true,
@@ -30275,7 +30500,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 518,
+            "line": 520,
           },
           "name": "anonymizeIncoming",
           "optional": true,
@@ -30293,7 +30518,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 530,
+            "line": 532,
           },
           "name": "autoUpgrade",
           "optional": true,
@@ -30311,7 +30536,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 535,
+            "line": 537,
           },
           "name": "cmdlinefilter",
           "optional": true,
@@ -30329,7 +30554,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 540,
+            "line": 542,
           },
           "name": "codeaware",
           "optional": true,
@@ -30347,7 +30572,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 545,
+            "line": 547,
           },
           "name": "containerEngineEndpoint",
           "optional": true,
@@ -30365,7 +30590,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 550,
+            "line": 552,
           },
           "name": "containerRuntime",
           "optional": true,
@@ -30383,7 +30608,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 555,
+            "line": 557,
           },
           "name": "datacollector",
           "optional": true,
@@ -30401,7 +30626,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 584,
+            "line": 586,
           },
           "name": "env",
           "optional": true,
@@ -30419,7 +30644,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 589,
+            "line": 591,
           },
           "name": "fim",
           "optional": true,
@@ -30438,7 +30663,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 562,
+            "line": 564,
           },
           "name": "k8SNodeScrapeIntervalMins",
           "optional": true,
@@ -30456,7 +30681,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 567,
+            "line": 569,
           },
           "name": "kubernetesCluster",
           "optional": true,
@@ -30476,7 +30701,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 574,
+            "line": 576,
           },
           "name": "labels",
           "optional": true,
@@ -30499,7 +30724,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 579,
+            "line": 581,
           },
           "name": "metadataRequestInterval",
           "optional": true,
@@ -30517,7 +30742,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 594,
+            "line": 596,
           },
           "name": "packagescan",
           "optional": true,
@@ -30535,7 +30760,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 629,
+            "line": 631,
           },
           "name": "perfmode",
           "optional": true,
@@ -30553,7 +30778,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 599,
+            "line": 601,
           },
           "name": "procscan",
           "optional": true,
@@ -30571,7 +30796,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 604,
+            "line": 606,
           },
           "name": "proxyUrl",
           "optional": true,
@@ -30589,7 +30814,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 609,
+            "line": 611,
           },
           "name": "serverUrl",
           "optional": true,
@@ -30607,7 +30832,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 614,
+            "line": 616,
           },
           "name": "serviceAccountName",
           "optional": true,
@@ -30625,7 +30850,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 619,
+            "line": 621,
           },
           "name": "stdoutLogging",
           "optional": true,
@@ -30643,7 +30868,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 624,
+            "line": 626,
           },
           "name": "tags",
           "optional": true,
@@ -30671,7 +30896,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1022,
+        "line": 1024,
       },
       "name": "LaceworkAgentLaceworkConfigAnonymizeIncoming",
       "properties": Array [
@@ -30686,7 +30911,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1033,
+            "line": 1035,
           },
           "name": "additionalValues",
           "optional": true,
@@ -30709,7 +30934,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1026,
+            "line": 1028,
           },
           "name": "netmask",
           "optional": true,
@@ -30731,7 +30956,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1054,
+        "line": 1056,
       },
       "members": Array [
         Object {
@@ -30762,7 +30987,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1064,
+        "line": 1066,
       },
       "name": "LaceworkAgentLaceworkConfigCmdlinefilter",
       "properties": Array [
@@ -30776,7 +31001,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1068,
+            "line": 1070,
           },
           "name": "allow",
           "optional": true,
@@ -30794,7 +31019,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1073,
+            "line": 1075,
           },
           "name": "disallow",
           "optional": true,
@@ -30817,7 +31042,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1094,
+        "line": 1096,
       },
       "name": "LaceworkAgentLaceworkConfigCodeaware",
       "properties": Array [
@@ -30831,7 +31056,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1098,
+            "line": 1100,
           },
           "name": "enable",
           "optional": true,
@@ -30853,7 +31078,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1118,
+        "line": 1120,
       },
       "members": Array [
         Object {
@@ -30889,7 +31114,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1130,
+        "line": 1132,
       },
       "members": Array [
         Object {
@@ -30920,7 +31145,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1140,
+        "line": 1142,
       },
       "name": "LaceworkAgentLaceworkConfigFim",
       "properties": Array [
@@ -30934,7 +31159,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1154,
+            "line": 1156,
           },
           "name": "enable",
           "type": Object {
@@ -30951,7 +31176,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1159,
+            "line": 1161,
           },
           "name": "fileIgnore",
           "type": Object {
@@ -30973,7 +31198,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1164,
+            "line": 1166,
           },
           "name": "filePath",
           "type": Object {
@@ -30996,7 +31221,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1181,
+            "line": 1183,
           },
           "name": "additionalValues",
           "optional": true,
@@ -31019,7 +31244,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1144,
+            "line": 1146,
           },
           "name": "coolingPeriod",
           "optional": true,
@@ -31037,7 +31262,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1149,
+            "line": 1151,
           },
           "name": "crawlInterval",
           "optional": true,
@@ -31055,7 +31280,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1169,
+            "line": 1171,
           },
           "name": "noAtime",
           "optional": true,
@@ -31073,7 +31298,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1174,
+            "line": 1176,
           },
           "name": "runAt",
           "optional": true,
@@ -31096,7 +31321,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1208,
+        "line": 1210,
       },
       "name": "LaceworkAgentLaceworkConfigPackagescan",
       "properties": Array [
@@ -31110,7 +31335,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1212,
+            "line": 1214,
           },
           "name": "enable",
           "optional": true,
@@ -31128,7 +31353,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1217,
+            "line": 1219,
           },
           "name": "interval",
           "optional": true,
@@ -31150,7 +31375,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1268,
+        "line": 1270,
       },
       "members": Array [
         Object {
@@ -31187,7 +31412,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1238,
+        "line": 1240,
       },
       "name": "LaceworkAgentLaceworkConfigProcscan",
       "properties": Array [
@@ -31201,7 +31426,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1242,
+            "line": 1244,
           },
           "name": "enable",
           "optional": true,
@@ -31219,7 +31444,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1247,
+            "line": 1249,
           },
           "name": "interval",
           "optional": true,
@@ -31237,7 +31462,7 @@ Possible enum values:
       "initializer": Object {
         "locationInModule": Object {
           "filename": "lacework-agent.ts",
-          "line": 14,
+          "line": 16,
         },
         "parameters": Array [
           Object {
@@ -31266,6 +31491,18 @@ Possible enum values:
         "line": 13,
       },
       "name": "Laceworkagent",
+      "properties": Array [
+        Object {
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 14,
+          },
+          "name": "helm",
+          "type": Object {
+            "fqn": "cdk8s.Helm",
+          },
+        },
+      ],
       "symbolId": "lacework-agent:Laceworkagent",
     },
     "lacework-agent.LaceworkagentProps": Object {
@@ -31363,7 +31600,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 69,
+        "line": 71,
       },
       "name": "LaceworkagentValues",
       "properties": Array [
@@ -31377,7 +31614,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 108,
+            "line": 110,
           },
           "name": "laceworkConfig",
           "type": Object {
@@ -31395,7 +31632,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 157,
+            "line": 159,
           },
           "name": "additionalValues",
           "optional": true,
@@ -31418,7 +31655,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 88,
+            "line": 90,
           },
           "name": "cloudservice",
           "optional": true,
@@ -31436,7 +31673,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 103,
+            "line": 105,
           },
           "name": "clusterAgent",
           "optional": true,
@@ -31454,7 +31691,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 78,
+            "line": 80,
           },
           "name": "daemonset",
           "optional": true,
@@ -31472,7 +31709,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 93,
+            "line": 95,
           },
           "name": "datacollector",
           "optional": true,
@@ -31490,7 +31727,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 83,
+            "line": 85,
           },
           "name": "deployment",
           "optional": true,
@@ -31508,7 +31745,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 73,
+            "line": 75,
           },
           "name": "global",
           "optional": true,
@@ -31531,7 +31768,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 98,
+            "line": 100,
           },
           "name": "image",
           "optional": true,
@@ -31550,7 +31787,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 129,
+            "line": 131,
           },
           "name": "priorityClassCreate",
           "optional": true,
@@ -31570,7 +31807,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 122,
+            "line": 124,
           },
           "name": "priorityClassName",
           "optional": true,
@@ -31589,7 +31826,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 136,
+            "line": 138,
           },
           "name": "priorityClassPreemptionPolicy",
           "optional": true,
@@ -31608,7 +31845,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 143,
+            "line": 145,
           },
           "name": "priorityClassValue",
           "optional": true,
@@ -31628,7 +31865,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 115,
+            "line": 117,
           },
           "name": "resources",
           "optional": true,
@@ -31647,7 +31884,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 150,
+            "line": 152,
           },
           "name": "tolerations",
           "optional": true,
@@ -31702,6 +31939,7 @@ def check_type(argname: str, value: object, expected_type: typing.Any) -> typing
 
 from ._jsii import *
 
+import cdk8s as _cdk8s_d3d9af27
 import constructs as _constructs_77d1e7e8
 
 
@@ -36676,6 +36914,18 @@ class Laceworkagent(
 
         jsii.create(self.__class__, self, [scope, id, props])
 
+    @builtins.property
+    @jsii.member(jsii_name=\\"helm\\")
+    def helm(self) -> \\"_cdk8s_d3d9af27.Helm\\":
+        return typing.cast(\\"_cdk8s_d3d9af27.Helm\\", jsii.get(self, \\"helm\\"))
+
+    @helm.setter
+    def helm(self, value: \\"_cdk8s_d3d9af27.Helm\\") -> None:
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__4de5e2d6c1dabef373e4f83822b3144b820f13526e9749be7796a38a2675a8ce)
+            check_type(argname=\\"argument value\\", value=value, expected_type=type_hints[\\"value\\"])
+        jsii.set(self, \\"helm\\", value) # pyright: ignore[reportArgumentType]
+
 
 @jsii.data_type(
     jsii_type=\\"lacework-agent.LaceworkagentProps\\",
@@ -37623,6 +37873,12 @@ def _typecheckingstub__114ea5fe7e7841a5303933808db33ffb935e37c0ef8577589791a696f
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 
+def _typecheckingstub__4de5e2d6c1dabef373e4f83822b3144b820f13526e9749be7796a38a2675a8ce(
+    value: _cdk8s_d3d9af27.Helm,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
 def _typecheckingstub__42b286772f6a0399931871ddfc86cb3edc039392ac6d0608f2b4d7f1d1dc28fb(
     *,
     values: typing.Union[LaceworkagentValues, typing.Dict[builtins.str, typing.Any]],
@@ -37801,7 +38057,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 787,
+        "line": 789,
       },
       "name": "IoK8SApiCoreV1Affinity",
       "properties": Array [
@@ -37816,7 +38072,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 793,
+            "line": 795,
           },
           "name": "nodeAffinity",
           "optional": true,
@@ -37835,7 +38091,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 800,
+            "line": 802,
           },
           "name": "podAffinity",
           "optional": true,
@@ -37854,7 +38110,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 807,
+            "line": 809,
           },
           "name": "podAntiAffinity",
           "optional": true,
@@ -37878,7 +38134,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1318,
+        "line": 1320,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinity",
       "properties": Array [
@@ -37894,7 +38150,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1324,
+            "line": 1326,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -37919,7 +38175,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1331,
+            "line": 1333,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -37943,7 +38199,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1495,
+        "line": 1497,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -37959,7 +38215,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1501,
+            "line": 1503,
           },
           "name": "preference",
           "optional": true,
@@ -37978,7 +38234,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1508,
+            "line": 1510,
           },
           "name": "weight",
           "optional": true,
@@ -38003,7 +38259,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1735,
+        "line": 1737,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreference",
       "properties": Array [
@@ -38018,7 +38274,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1741,
+            "line": 1743,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -38042,7 +38298,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1748,
+            "line": 1750,
           },
           "name": "matchFields",
           "optional": true,
@@ -38071,7 +38327,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2055,
+        "line": 2057,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchExpressions",
       "properties": Array [
@@ -38086,7 +38342,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2061,
+            "line": 2063,
           },
           "name": "key",
           "optional": true,
@@ -38112,7 +38368,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2076,
+            "line": 2078,
           },
           "name": "operator",
           "optional": true,
@@ -38132,7 +38388,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2083,
+            "line": 2085,
           },
           "name": "values",
           "optional": true,
@@ -38167,7 +38423,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2591,
+        "line": 2593,
       },
       "members": Array [
         Object {
@@ -38223,7 +38479,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2107,
+        "line": 2109,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionPreferenceMatchFields",
       "properties": Array [
@@ -38238,7 +38494,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2113,
+            "line": 2115,
           },
           "name": "key",
           "optional": true,
@@ -38264,7 +38520,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2128,
+            "line": 2130,
           },
           "name": "operator",
           "optional": true,
@@ -38284,7 +38540,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2135,
+            "line": 2137,
           },
           "name": "values",
           "optional": true,
@@ -38319,7 +38575,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2619,
+        "line": 2621,
       },
       "members": Array [
         Object {
@@ -38376,7 +38632,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1531,
+        "line": 1533,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -38392,7 +38648,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1537,
+            "line": 1539,
           },
           "name": "nodeSelectorTerms",
           "optional": true,
@@ -38422,7 +38678,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1771,
+        "line": 1773,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTerms",
       "properties": Array [
@@ -38437,7 +38693,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1777,
+            "line": 1779,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -38461,7 +38717,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1784,
+            "line": 1786,
           },
           "name": "matchFields",
           "optional": true,
@@ -38490,7 +38746,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2159,
+        "line": 2161,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchExpressions",
       "properties": Array [
@@ -38505,7 +38761,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2165,
+            "line": 2167,
           },
           "name": "key",
           "optional": true,
@@ -38531,7 +38787,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2180,
+            "line": 2182,
           },
           "name": "operator",
           "optional": true,
@@ -38551,7 +38807,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2187,
+            "line": 2189,
           },
           "name": "values",
           "optional": true,
@@ -38586,7 +38842,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2647,
+        "line": 2649,
       },
       "members": Array [
         Object {
@@ -38642,7 +38898,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2211,
+        "line": 2213,
       },
       "name": "IoK8SApiCoreV1AffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecutionNodeSelectorTermsMatchFields",
       "properties": Array [
@@ -38657,7 +38913,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2217,
+            "line": 2219,
           },
           "name": "key",
           "optional": true,
@@ -38683,7 +38939,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2232,
+            "line": 2234,
           },
           "name": "operator",
           "optional": true,
@@ -38703,7 +38959,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2239,
+            "line": 2241,
           },
           "name": "values",
           "optional": true,
@@ -38738,7 +38994,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2675,
+        "line": 2677,
       },
       "members": Array [
         Object {
@@ -38794,7 +39050,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1354,
+        "line": 1356,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinity",
       "properties": Array [
@@ -38810,7 +39066,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1360,
+            "line": 1362,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -38835,7 +39091,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1367,
+            "line": 1369,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -38864,7 +39120,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1559,
+        "line": 1561,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -38879,7 +39135,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1565,
+            "line": 1567,
           },
           "name": "podAffinityTerm",
           "optional": true,
@@ -38898,7 +39154,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1572,
+            "line": 1574,
           },
           "name": "weight",
           "optional": true,
@@ -38922,7 +39178,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1807,
+        "line": 1809,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "properties": Array [
@@ -38938,7 +39194,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1834,
+            "line": 1836,
           },
           "name": "topologyKey",
           "type": Object {
@@ -38957,7 +39213,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1813,
+            "line": 1815,
           },
           "name": "labelSelector",
           "optional": true,
@@ -38977,7 +39233,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1827,
+            "line": 1829,
           },
           "name": "namespaces",
           "optional": true,
@@ -39002,7 +39258,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1820,
+            "line": 1822,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -39027,7 +39283,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2263,
+        "line": 2265,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "properties": Array [
@@ -39043,7 +39299,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2269,
+            "line": 2271,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -39068,7 +39324,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2276,
+            "line": 2278,
           },
           "name": "matchLabels",
           "optional": true,
@@ -39097,7 +39353,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2695,
+        "line": 2697,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "properties": Array [
@@ -39112,7 +39368,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2701,
+            "line": 2703,
           },
           "name": "key",
           "optional": true,
@@ -39132,7 +39388,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2708,
+            "line": 2710,
           },
           "name": "operator",
           "optional": true,
@@ -39152,7 +39408,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2715,
+            "line": 2717,
           },
           "name": "values",
           "optional": true,
@@ -39182,7 +39438,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2299,
+        "line": 2301,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
       "properties": Array [
@@ -39198,7 +39454,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2305,
+            "line": 2307,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -39223,7 +39479,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2312,
+            "line": 2314,
           },
           "name": "matchLabels",
           "optional": true,
@@ -39252,7 +39508,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2739,
+        "line": 2741,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -39267,7 +39523,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2745,
+            "line": 2747,
           },
           "name": "key",
           "optional": true,
@@ -39287,7 +39543,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2752,
+            "line": 2754,
           },
           "name": "operator",
           "optional": true,
@@ -39307,7 +39563,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2759,
+            "line": 2761,
           },
           "name": "values",
           "optional": true,
@@ -39336,7 +39592,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1595,
+        "line": 1597,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -39352,7 +39608,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1601,
+            "line": 1603,
           },
           "name": "labelSelector",
           "optional": true,
@@ -39372,7 +39628,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1615,
+            "line": 1617,
           },
           "name": "namespaces",
           "optional": true,
@@ -39397,7 +39653,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1608,
+            "line": 1610,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -39417,7 +39673,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1622,
+            "line": 1624,
           },
           "name": "topologyKey",
           "optional": true,
@@ -39442,7 +39698,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1859,
+        "line": 1861,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "properties": Array [
@@ -39458,7 +39714,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1865,
+            "line": 1867,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -39483,7 +39739,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1872,
+            "line": 1874,
           },
           "name": "matchLabels",
           "optional": true,
@@ -39512,7 +39768,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2335,
+        "line": 2337,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "properties": Array [
@@ -39527,7 +39783,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2341,
+            "line": 2343,
           },
           "name": "key",
           "optional": true,
@@ -39547,7 +39803,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2348,
+            "line": 2350,
           },
           "name": "operator",
           "optional": true,
@@ -39567,7 +39823,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2355,
+            "line": 2357,
           },
           "name": "values",
           "optional": true,
@@ -39597,7 +39853,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1895,
+        "line": 1897,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
       "properties": Array [
@@ -39613,7 +39869,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1901,
+            "line": 1903,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -39638,7 +39894,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1908,
+            "line": 1910,
           },
           "name": "matchLabels",
           "optional": true,
@@ -39667,7 +39923,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2379,
+        "line": 2381,
       },
       "name": "IoK8SApiCoreV1AffinityPodAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -39682,7 +39938,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2385,
+            "line": 2387,
           },
           "name": "key",
           "optional": true,
@@ -39702,7 +39958,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2392,
+            "line": 2394,
           },
           "name": "operator",
           "optional": true,
@@ -39722,7 +39978,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2399,
+            "line": 2401,
           },
           "name": "values",
           "optional": true,
@@ -39751,7 +40007,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1390,
+        "line": 1392,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinity",
       "properties": Array [
@@ -39767,7 +40023,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1396,
+            "line": 1398,
           },
           "name": "preferredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -39792,7 +40048,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1403,
+            "line": 1405,
           },
           "name": "requiredDuringSchedulingIgnoredDuringExecution",
           "optional": true,
@@ -39821,7 +40077,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1647,
+        "line": 1649,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -39836,7 +40092,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1653,
+            "line": 1655,
           },
           "name": "podAffinityTerm",
           "optional": true,
@@ -39855,7 +40111,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1660,
+            "line": 1662,
           },
           "name": "weight",
           "optional": true,
@@ -39879,7 +40135,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1931,
+        "line": 1933,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTerm",
       "properties": Array [
@@ -39895,7 +40151,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1958,
+            "line": 1960,
           },
           "name": "topologyKey",
           "type": Object {
@@ -39914,7 +40170,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1937,
+            "line": 1939,
           },
           "name": "labelSelector",
           "optional": true,
@@ -39934,7 +40190,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1951,
+            "line": 1953,
           },
           "name": "namespaces",
           "optional": true,
@@ -39959,7 +40215,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1944,
+            "line": 1946,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -39984,7 +40240,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2423,
+        "line": 2425,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelector",
       "properties": Array [
@@ -40000,7 +40256,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2429,
+            "line": 2431,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -40025,7 +40281,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2436,
+            "line": 2438,
           },
           "name": "matchLabels",
           "optional": true,
@@ -40054,7 +40310,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2783,
+        "line": 2785,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermLabelSelectorMatchExpressions",
       "properties": Array [
@@ -40069,7 +40325,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2789,
+            "line": 2791,
           },
           "name": "key",
           "optional": true,
@@ -40089,7 +40345,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2796,
+            "line": 2798,
           },
           "name": "operator",
           "optional": true,
@@ -40109,7 +40365,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2803,
+            "line": 2805,
           },
           "name": "values",
           "optional": true,
@@ -40139,7 +40395,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2459,
+        "line": 2461,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelector",
       "properties": Array [
@@ -40155,7 +40411,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2465,
+            "line": 2467,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -40180,7 +40436,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2472,
+            "line": 2474,
           },
           "name": "matchLabels",
           "optional": true,
@@ -40209,7 +40465,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2827,
+        "line": 2829,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionPodAffinityTermNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -40224,7 +40480,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2833,
+            "line": 2835,
           },
           "name": "key",
           "optional": true,
@@ -40244,7 +40500,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2840,
+            "line": 2842,
           },
           "name": "operator",
           "optional": true,
@@ -40264,7 +40520,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2847,
+            "line": 2849,
           },
           "name": "values",
           "optional": true,
@@ -40293,7 +40549,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1683,
+        "line": 1685,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecution",
       "properties": Array [
@@ -40309,7 +40565,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1689,
+            "line": 1691,
           },
           "name": "labelSelector",
           "optional": true,
@@ -40329,7 +40585,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1703,
+            "line": 1705,
           },
           "name": "namespaces",
           "optional": true,
@@ -40354,7 +40610,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1696,
+            "line": 1698,
           },
           "name": "namespaceSelector",
           "optional": true,
@@ -40374,7 +40630,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1710,
+            "line": 1712,
           },
           "name": "topologyKey",
           "optional": true,
@@ -40399,7 +40655,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1983,
+        "line": 1985,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelector",
       "properties": Array [
@@ -40415,7 +40671,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1989,
+            "line": 1991,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -40440,7 +40696,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1996,
+            "line": 1998,
           },
           "name": "matchLabels",
           "optional": true,
@@ -40469,7 +40725,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2495,
+        "line": 2497,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionLabelSelectorMatchExpressions",
       "properties": Array [
@@ -40484,7 +40740,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2501,
+            "line": 2503,
           },
           "name": "key",
           "optional": true,
@@ -40504,7 +40760,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2508,
+            "line": 2510,
           },
           "name": "operator",
           "optional": true,
@@ -40524,7 +40780,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2515,
+            "line": 2517,
           },
           "name": "values",
           "optional": true,
@@ -40554,7 +40810,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2019,
+        "line": 2021,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelector",
       "properties": Array [
@@ -40570,7 +40826,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2025,
+            "line": 2027,
           },
           "name": "matchExpressions",
           "optional": true,
@@ -40595,7 +40851,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2032,
+            "line": 2034,
           },
           "name": "matchLabels",
           "optional": true,
@@ -40624,7 +40880,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 2539,
+        "line": 2541,
       },
       "name": "IoK8SApiCoreV1AffinityPodAntiAffinityRequiredDuringSchedulingIgnoredDuringExecutionNamespaceSelectorMatchExpressions",
       "properties": Array [
@@ -40639,7 +40895,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2545,
+            "line": 2547,
           },
           "name": "key",
           "optional": true,
@@ -40659,7 +40915,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2552,
+            "line": 2554,
           },
           "name": "operator",
           "optional": true,
@@ -40679,7 +40935,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 2559,
+            "line": 2561,
           },
           "name": "values",
           "optional": true,
@@ -40708,7 +40964,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 831,
+        "line": 833,
       },
       "name": "IoK8SApiCoreV1DaemonSetUpdateStrategy",
       "properties": Array [
@@ -40723,7 +40979,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 837,
+            "line": 839,
           },
           "name": "rollingUpdate",
           "optional": true,
@@ -40746,7 +41002,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 849,
+            "line": 851,
           },
           "name": "type",
           "optional": true,
@@ -40770,7 +41026,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1426,
+        "line": 1428,
       },
       "name": "IoK8SApiCoreV1DaemonSetUpdateStrategyRollingUpdate",
       "properties": Array [
@@ -40784,7 +41040,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1430,
+            "line": 1432,
           },
           "name": "maxSurge",
           "optional": true,
@@ -40802,7 +41058,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1435,
+            "line": 1437,
           },
           "name": "maxUnavailable",
           "optional": true,
@@ -40829,7 +41085,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1463,
+        "line": 1465,
       },
       "members": Array [
         Object {
@@ -40861,7 +41117,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 896,
+        "line": 898,
       },
       "name": "IoK8SApiCoreV1LocalObjectReference",
       "properties": Array [
@@ -40877,7 +41133,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 902,
+            "line": 904,
           },
           "name": "name",
           "optional": true,
@@ -40901,7 +41157,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 681,
+        "line": 683,
       },
       "name": "IoK8SApiCoreV1ResourceRequirements",
       "properties": Array [
@@ -40917,7 +41173,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 687,
+            "line": 689,
           },
           "name": "limits",
           "optional": true,
@@ -40942,7 +41198,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 694,
+            "line": 696,
           },
           "name": "requests",
           "optional": true,
@@ -40971,7 +41227,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 717,
+        "line": 719,
       },
       "name": "IoK8SApiCoreV1Toleration",
       "properties": Array [
@@ -40992,7 +41248,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 728,
+            "line": 730,
           },
           "name": "effect",
           "optional": true,
@@ -41012,7 +41268,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 735,
+            "line": 737,
           },
           "name": "key",
           "optional": true,
@@ -41037,7 +41293,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 747,
+            "line": 749,
           },
           "name": "operator",
           "optional": true,
@@ -41057,7 +41313,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 754,
+            "line": 756,
           },
           "name": "tolerationSeconds",
           "optional": true,
@@ -41077,7 +41333,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 761,
+            "line": 763,
           },
           "name": "value",
           "optional": true,
@@ -41106,7 +41362,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1287,
+        "line": 1289,
       },
       "members": Array [
         Object {
@@ -41149,7 +41405,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1306,
+        "line": 1308,
       },
       "members": Array [
         Object {
@@ -41180,7 +41436,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 307,
+        "line": 309,
       },
       "name": "LaceworkAgentCloudservice",
       "properties": Array [
@@ -41194,7 +41450,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 311,
+            "line": 313,
           },
           "name": "gke",
           "optional": true,
@@ -41217,7 +41473,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 870,
+        "line": 872,
       },
       "name": "LaceworkAgentCloudserviceGke",
       "properties": Array [
@@ -41231,7 +41487,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 874,
+            "line": 876,
           },
           "name": "autopilot",
           "optional": true,
@@ -41254,7 +41510,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 437,
+        "line": 439,
       },
       "name": "LaceworkAgentClusterAgent",
       "properties": Array [
@@ -41269,7 +41525,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 448,
+            "line": 450,
           },
           "name": "enable",
           "type": Object {
@@ -41286,7 +41542,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 441,
+            "line": 443,
           },
           "name": "image",
           "type": Object {
@@ -41304,7 +41560,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 483,
+            "line": 485,
           },
           "name": "additionalValues",
           "optional": true,
@@ -41328,7 +41584,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 462,
+            "line": 464,
           },
           "name": "clusterRegion",
           "optional": true,
@@ -41347,7 +41603,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 455,
+            "line": 457,
           },
           "name": "clusterType",
           "optional": true,
@@ -41366,7 +41622,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 469,
+            "line": 471,
           },
           "name": "scrapeInitialDelayMins",
           "optional": true,
@@ -41385,7 +41641,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 476,
+            "line": 478,
           },
           "name": "scrapeIntervalMins",
           "optional": true,
@@ -41408,7 +41664,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1010,
+        "line": 1012,
       },
       "members": Array [
         Object {
@@ -41445,7 +41701,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 942,
+        "line": 944,
       },
       "name": "LaceworkAgentClusterAgentImage",
       "properties": Array [
@@ -41467,7 +41723,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 961,
+            "line": 963,
           },
           "name": "pullPolicy",
           "type": Object {
@@ -41484,7 +41740,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 966,
+            "line": 968,
           },
           "name": "registry",
           "type": Object {
@@ -41501,7 +41757,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 971,
+            "line": 973,
           },
           "name": "repository",
           "type": Object {
@@ -41518,7 +41774,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 976,
+            "line": 978,
           },
           "name": "tag",
           "type": Object {
@@ -41536,7 +41792,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 983,
+            "line": 985,
           },
           "name": "additionalValues",
           "optional": true,
@@ -41561,7 +41817,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 948,
+            "line": 950,
           },
           "name": "imagePullSecrets",
           "optional": true,
@@ -41596,7 +41852,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1481,
+        "line": 1483,
       },
       "members": Array [
         Object {
@@ -41633,7 +41889,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 191,
+        "line": 193,
       },
       "name": "LaceworkAgentDaemonset",
       "properties": Array [
@@ -41648,7 +41904,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 197,
+            "line": 199,
           },
           "name": "affinity",
           "type": Object {
@@ -41666,7 +41922,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 204,
+            "line": 206,
           },
           "name": "updateStrategy",
           "type": Object {
@@ -41688,7 +41944,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 331,
+        "line": 333,
       },
       "name": "LaceworkAgentDatacollector",
       "properties": Array [
@@ -41703,7 +41959,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 344,
+            "line": 346,
           },
           "name": "additionalValues",
           "optional": true,
@@ -41727,7 +41983,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 337,
+            "line": 339,
           },
           "name": "enable",
           "optional": true,
@@ -41750,7 +42006,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 225,
+        "line": 227,
       },
       "name": "LaceworkAgentDeployment",
       "properties": Array [
@@ -41765,7 +42021,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 231,
+            "line": 233,
           },
           "name": "affinity",
           "type": Object {
@@ -41783,7 +42039,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 238,
+            "line": 240,
           },
           "name": "updateStrategy",
           "type": Object {
@@ -41801,7 +42057,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 259,
+            "line": 261,
           },
           "name": "priorityClassCreate",
           "optional": true,
@@ -41821,7 +42077,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 252,
+            "line": 254,
           },
           "name": "priorityClassName",
           "optional": true,
@@ -41840,7 +42096,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 266,
+            "line": 268,
           },
           "name": "priorityClassPreemptionPolicy",
           "optional": true,
@@ -41859,7 +42115,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 273,
+            "line": 275,
           },
           "name": "priorityClassValue",
           "optional": true,
@@ -41879,7 +42135,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 245,
+            "line": 247,
           },
           "name": "resources",
           "optional": true,
@@ -41898,7 +42154,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 280,
+            "line": 282,
           },
           "name": "tolerations",
           "optional": true,
@@ -41926,7 +42182,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 365,
+        "line": 367,
       },
       "name": "LaceworkAgentImage",
       "properties": Array [
@@ -41948,7 +42204,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 384,
+            "line": 386,
           },
           "name": "pullPolicy",
           "type": Object {
@@ -41965,7 +42221,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 389,
+            "line": 391,
           },
           "name": "registry",
           "type": Object {
@@ -41982,7 +42238,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 394,
+            "line": 396,
           },
           "name": "repository",
           "type": Object {
@@ -41999,7 +42255,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 399,
+            "line": 401,
           },
           "name": "tag",
           "type": Object {
@@ -42017,7 +42273,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 411,
+            "line": 413,
           },
           "name": "additionalValues",
           "optional": true,
@@ -42042,7 +42298,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 371,
+            "line": 373,
           },
           "name": "imagePullSecrets",
           "optional": true,
@@ -42065,7 +42321,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 404,
+            "line": 406,
           },
           "name": "overrideValue",
           "optional": true,
@@ -42095,7 +42351,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 930,
+        "line": 932,
       },
       "members": Array [
         Object {
@@ -42132,7 +42388,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 509,
+        "line": 511,
       },
       "name": "LaceworkAgentLaceworkConfig",
       "properties": Array [
@@ -42146,7 +42402,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 513,
+            "line": 515,
           },
           "name": "accessToken",
           "type": Object {
@@ -42164,7 +42420,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 636,
+            "line": 638,
           },
           "name": "additionalValues",
           "optional": true,
@@ -42189,7 +42445,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 525,
+            "line": 527,
           },
           "name": "annotations",
           "optional": true,
@@ -42212,7 +42468,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 518,
+            "line": 520,
           },
           "name": "anonymizeIncoming",
           "optional": true,
@@ -42230,7 +42486,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 530,
+            "line": 532,
           },
           "name": "autoUpgrade",
           "optional": true,
@@ -42248,7 +42504,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 535,
+            "line": 537,
           },
           "name": "cmdlinefilter",
           "optional": true,
@@ -42266,7 +42522,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 540,
+            "line": 542,
           },
           "name": "codeaware",
           "optional": true,
@@ -42284,7 +42540,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 545,
+            "line": 547,
           },
           "name": "containerEngineEndpoint",
           "optional": true,
@@ -42302,7 +42558,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 550,
+            "line": 552,
           },
           "name": "containerRuntime",
           "optional": true,
@@ -42320,7 +42576,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 555,
+            "line": 557,
           },
           "name": "datacollector",
           "optional": true,
@@ -42338,7 +42594,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 584,
+            "line": 586,
           },
           "name": "env",
           "optional": true,
@@ -42356,7 +42612,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 589,
+            "line": 591,
           },
           "name": "fim",
           "optional": true,
@@ -42375,7 +42631,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 562,
+            "line": 564,
           },
           "name": "k8SNodeScrapeIntervalMins",
           "optional": true,
@@ -42393,7 +42649,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 567,
+            "line": 569,
           },
           "name": "kubernetesCluster",
           "optional": true,
@@ -42413,7 +42669,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 574,
+            "line": 576,
           },
           "name": "labels",
           "optional": true,
@@ -42436,7 +42692,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 579,
+            "line": 581,
           },
           "name": "metadataRequestInterval",
           "optional": true,
@@ -42454,7 +42710,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 594,
+            "line": 596,
           },
           "name": "packagescan",
           "optional": true,
@@ -42472,7 +42728,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 629,
+            "line": 631,
           },
           "name": "perfmode",
           "optional": true,
@@ -42490,7 +42746,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 599,
+            "line": 601,
           },
           "name": "procscan",
           "optional": true,
@@ -42508,7 +42764,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 604,
+            "line": 606,
           },
           "name": "proxyUrl",
           "optional": true,
@@ -42526,7 +42782,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 609,
+            "line": 611,
           },
           "name": "serverUrl",
           "optional": true,
@@ -42544,7 +42800,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 614,
+            "line": 616,
           },
           "name": "serviceAccountName",
           "optional": true,
@@ -42562,7 +42818,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 619,
+            "line": 621,
           },
           "name": "stdoutLogging",
           "optional": true,
@@ -42580,7 +42836,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 624,
+            "line": 626,
           },
           "name": "tags",
           "optional": true,
@@ -42608,7 +42864,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1022,
+        "line": 1024,
       },
       "name": "LaceworkAgentLaceworkConfigAnonymizeIncoming",
       "properties": Array [
@@ -42623,7 +42879,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1033,
+            "line": 1035,
           },
           "name": "additionalValues",
           "optional": true,
@@ -42646,7 +42902,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1026,
+            "line": 1028,
           },
           "name": "netmask",
           "optional": true,
@@ -42668,7 +42924,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1054,
+        "line": 1056,
       },
       "members": Array [
         Object {
@@ -42699,7 +42955,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1064,
+        "line": 1066,
       },
       "name": "LaceworkAgentLaceworkConfigCmdlinefilter",
       "properties": Array [
@@ -42713,7 +42969,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1068,
+            "line": 1070,
           },
           "name": "allow",
           "optional": true,
@@ -42731,7 +42987,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1073,
+            "line": 1075,
           },
           "name": "disallow",
           "optional": true,
@@ -42754,7 +43010,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1094,
+        "line": 1096,
       },
       "name": "LaceworkAgentLaceworkConfigCodeaware",
       "properties": Array [
@@ -42768,7 +43024,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1098,
+            "line": 1100,
           },
           "name": "enable",
           "optional": true,
@@ -42790,7 +43046,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1118,
+        "line": 1120,
       },
       "members": Array [
         Object {
@@ -42826,7 +43082,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1130,
+        "line": 1132,
       },
       "members": Array [
         Object {
@@ -42857,7 +43113,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1140,
+        "line": 1142,
       },
       "name": "LaceworkAgentLaceworkConfigFim",
       "properties": Array [
@@ -42871,7 +43127,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1154,
+            "line": 1156,
           },
           "name": "enable",
           "type": Object {
@@ -42888,7 +43144,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1159,
+            "line": 1161,
           },
           "name": "fileIgnore",
           "type": Object {
@@ -42910,7 +43166,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1164,
+            "line": 1166,
           },
           "name": "filePath",
           "type": Object {
@@ -42933,7 +43189,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1181,
+            "line": 1183,
           },
           "name": "additionalValues",
           "optional": true,
@@ -42956,7 +43212,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1144,
+            "line": 1146,
           },
           "name": "coolingPeriod",
           "optional": true,
@@ -42974,7 +43230,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1149,
+            "line": 1151,
           },
           "name": "crawlInterval",
           "optional": true,
@@ -42992,7 +43248,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1169,
+            "line": 1171,
           },
           "name": "noAtime",
           "optional": true,
@@ -43010,7 +43266,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1174,
+            "line": 1176,
           },
           "name": "runAt",
           "optional": true,
@@ -43033,7 +43289,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1208,
+        "line": 1210,
       },
       "name": "LaceworkAgentLaceworkConfigPackagescan",
       "properties": Array [
@@ -43047,7 +43303,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1212,
+            "line": 1214,
           },
           "name": "enable",
           "optional": true,
@@ -43065,7 +43321,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1217,
+            "line": 1219,
           },
           "name": "interval",
           "optional": true,
@@ -43087,7 +43343,7 @@ Possible enum values:
       "kind": "enum",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1268,
+        "line": 1270,
       },
       "members": Array [
         Object {
@@ -43124,7 +43380,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 1238,
+        "line": 1240,
       },
       "name": "LaceworkAgentLaceworkConfigProcscan",
       "properties": Array [
@@ -43138,7 +43394,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1242,
+            "line": 1244,
           },
           "name": "enable",
           "optional": true,
@@ -43156,7 +43412,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 1247,
+            "line": 1249,
           },
           "name": "interval",
           "optional": true,
@@ -43174,7 +43430,7 @@ Possible enum values:
       "initializer": Object {
         "locationInModule": Object {
           "filename": "lacework-agent.ts",
-          "line": 14,
+          "line": 16,
         },
         "parameters": Array [
           Object {
@@ -43203,6 +43459,18 @@ Possible enum values:
         "line": 13,
       },
       "name": "Laceworkagent",
+      "properties": Array [
+        Object {
+          "locationInModule": Object {
+            "filename": "lacework-agent.ts",
+            "line": 14,
+          },
+          "name": "helm",
+          "type": Object {
+            "fqn": "cdk8s.Helm",
+          },
+        },
+      ],
       "symbolId": "lacework-agent:Laceworkagent",
     },
     "lacework-agent.LaceworkagentProps": Object {
@@ -43300,7 +43568,7 @@ Possible enum values:
       "kind": "interface",
       "locationInModule": Object {
         "filename": "lacework-agent.ts",
-        "line": 69,
+        "line": 71,
       },
       "name": "LaceworkagentValues",
       "properties": Array [
@@ -43314,7 +43582,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 108,
+            "line": 110,
           },
           "name": "laceworkConfig",
           "type": Object {
@@ -43332,7 +43600,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 157,
+            "line": 159,
           },
           "name": "additionalValues",
           "optional": true,
@@ -43355,7 +43623,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 88,
+            "line": 90,
           },
           "name": "cloudservice",
           "optional": true,
@@ -43373,7 +43641,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 103,
+            "line": 105,
           },
           "name": "clusterAgent",
           "optional": true,
@@ -43391,7 +43659,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 78,
+            "line": 80,
           },
           "name": "daemonset",
           "optional": true,
@@ -43409,7 +43677,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 93,
+            "line": 95,
           },
           "name": "datacollector",
           "optional": true,
@@ -43427,7 +43695,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 83,
+            "line": 85,
           },
           "name": "deployment",
           "optional": true,
@@ -43445,7 +43713,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 73,
+            "line": 75,
           },
           "name": "global",
           "optional": true,
@@ -43468,7 +43736,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 98,
+            "line": 100,
           },
           "name": "image",
           "optional": true,
@@ -43487,7 +43755,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 129,
+            "line": 131,
           },
           "name": "priorityClassCreate",
           "optional": true,
@@ -43507,7 +43775,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 122,
+            "line": 124,
           },
           "name": "priorityClassName",
           "optional": true,
@@ -43526,7 +43794,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 136,
+            "line": 138,
           },
           "name": "priorityClassPreemptionPolicy",
           "optional": true,
@@ -43545,7 +43813,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 143,
+            "line": 145,
           },
           "name": "priorityClassValue",
           "optional": true,
@@ -43565,7 +43833,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 115,
+            "line": 117,
           },
           "name": "resources",
           "optional": true,
@@ -43584,7 +43852,7 @@ Possible enum values:
           "immutable": true,
           "locationInModule": Object {
             "filename": "lacework-agent.ts",
-            "line": 150,
+            "line": 152,
           },
           "name": "tolerations",
           "optional": true,
@@ -43620,6 +43888,8 @@ export interface LaceworkagentProps {
 }
 
 export class Laceworkagent extends Construct {
+  public helm: Helm;
+
   public constructor(scope: Construct, id: string, props: LaceworkagentProps) {
     super(scope, id);
     let updatedProps = {};
@@ -43645,7 +43915,7 @@ export class Laceworkagent extends Construct {
       ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
     };
 
-    new Helm(this, 'Helm', finalProps);
+    this.helm = new Helm(this, 'Helm', finalProps);
   }
 
   private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
@@ -46572,7 +46842,7 @@ Object {
       "initializer": Object {
         "locationInModule": Object {
           "filename": "mysql.ts",
-          "line": 14,
+          "line": 16,
         },
         "parameters": Array [
           Object {
@@ -46602,6 +46872,18 @@ Object {
         "line": 13,
       },
       "name": "Mysql",
+      "properties": Array [
+        Object {
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 14,
+          },
+          "name": "helm",
+          "type": Object {
+            "fqn": "cdk8s.Helm",
+          },
+        },
+      ],
       "symbolId": "mysql:Mysql",
     },
     "mysql.MysqlArchitecture": Object {
@@ -46616,7 +46898,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 134,
+        "line": 136,
       },
       "members": Array [
         Object {
@@ -46647,7 +46929,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 144,
+        "line": 146,
       },
       "name": "MysqlAuth",
       "properties": Array [
@@ -46661,7 +46943,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 166,
+            "line": 168,
           },
           "name": "password",
           "type": Object {
@@ -46678,7 +46960,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 161,
+            "line": 163,
           },
           "name": "username",
           "type": Object {
@@ -46696,7 +46978,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 188,
+            "line": 190,
           },
           "name": "additionalValues",
           "optional": true,
@@ -46719,7 +47001,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 181,
+            "line": 183,
           },
           "name": "createDatabase",
           "optional": true,
@@ -46737,7 +47019,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 156,
+            "line": 158,
           },
           "name": "database",
           "optional": true,
@@ -46755,7 +47037,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 176,
+            "line": 178,
           },
           "name": "replicationPassword",
           "optional": true,
@@ -46773,7 +47055,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 171,
+            "line": 173,
           },
           "name": "replicationUser",
           "optional": true,
@@ -46793,7 +47075,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 151,
+            "line": 153,
           },
           "name": "rootPassword",
           "optional": true,
@@ -46816,7 +47098,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 215,
+        "line": 217,
       },
       "name": "MysqlPrimary",
       "properties": Array [
@@ -46831,7 +47113,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 236,
+            "line": 238,
           },
           "name": "additionalValues",
           "optional": true,
@@ -46854,7 +47136,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 224,
+            "line": 226,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -46872,7 +47154,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 229,
+            "line": 231,
           },
           "name": "persistence",
           "optional": true,
@@ -46890,7 +47172,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 219,
+            "line": 221,
           },
           "name": "podSecurityContext",
           "optional": true,
@@ -46913,7 +47195,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 341,
+        "line": 343,
       },
       "name": "MysqlPrimaryContainerSecurityContext",
       "properties": Array [
@@ -46928,7 +47210,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 357,
+            "line": 359,
           },
           "name": "additionalValues",
           "optional": true,
@@ -46951,7 +47233,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 345,
+            "line": 347,
           },
           "name": "enabled",
           "optional": true,
@@ -46969,7 +47251,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 350,
+            "line": 352,
           },
           "name": "runAsUser",
           "optional": true,
@@ -46992,7 +47274,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 379,
+        "line": 381,
       },
       "name": "MysqlPrimaryPersistence",
       "properties": Array [
@@ -47007,7 +47289,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 395,
+            "line": 397,
           },
           "name": "additionalValues",
           "optional": true,
@@ -47030,7 +47312,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 383,
+            "line": 385,
           },
           "name": "enabled",
           "optional": true,
@@ -47048,7 +47330,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 388,
+            "line": 390,
           },
           "name": "size",
           "optional": true,
@@ -47071,7 +47353,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 303,
+        "line": 305,
       },
       "name": "MysqlPrimaryPodSecurityContext",
       "properties": Array [
@@ -47086,7 +47368,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 319,
+            "line": 321,
           },
           "name": "additionalValues",
           "optional": true,
@@ -47109,7 +47391,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 307,
+            "line": 309,
           },
           "name": "enabled",
           "optional": true,
@@ -47127,7 +47409,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 312,
+            "line": 314,
           },
           "name": "fsGroup",
           "optional": true,
@@ -47234,7 +47516,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 259,
+        "line": 261,
       },
       "name": "MysqlSecondary",
       "properties": Array [
@@ -47249,7 +47531,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 280,
+            "line": 282,
           },
           "name": "additionalValues",
           "optional": true,
@@ -47272,7 +47554,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 268,
+            "line": 270,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -47290,7 +47572,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 273,
+            "line": 275,
           },
           "name": "persistence",
           "optional": true,
@@ -47308,7 +47590,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 263,
+            "line": 265,
           },
           "name": "podSecurityContext",
           "optional": true,
@@ -47331,7 +47613,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 455,
+        "line": 457,
       },
       "name": "MysqlSecondaryContainerSecurityContext",
       "properties": Array [
@@ -47346,7 +47628,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 471,
+            "line": 473,
           },
           "name": "additionalValues",
           "optional": true,
@@ -47369,7 +47651,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 459,
+            "line": 461,
           },
           "name": "enabled",
           "optional": true,
@@ -47387,7 +47669,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 464,
+            "line": 466,
           },
           "name": "runAsUser",
           "optional": true,
@@ -47410,7 +47692,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 493,
+        "line": 495,
       },
       "name": "MysqlSecondaryPersistence",
       "properties": Array [
@@ -47425,7 +47707,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 509,
+            "line": 511,
           },
           "name": "additionalValues",
           "optional": true,
@@ -47448,7 +47730,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 497,
+            "line": 499,
           },
           "name": "enabled",
           "optional": true,
@@ -47466,7 +47748,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 502,
+            "line": 504,
           },
           "name": "size",
           "optional": true,
@@ -47489,7 +47771,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 417,
+        "line": 419,
       },
       "name": "MysqlSecondaryPodSecurityContext",
       "properties": Array [
@@ -47504,7 +47786,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 433,
+            "line": 435,
           },
           "name": "additionalValues",
           "optional": true,
@@ -47527,7 +47809,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 421,
+            "line": 423,
           },
           "name": "enabled",
           "optional": true,
@@ -47545,7 +47827,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 426,
+            "line": 428,
           },
           "name": "fsGroup",
           "optional": true,
@@ -47568,7 +47850,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 68,
+        "line": 70,
       },
       "name": "MysqlValues",
       "properties": Array [
@@ -47583,7 +47865,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 106,
+            "line": 108,
           },
           "name": "additionalValues",
           "optional": true,
@@ -47607,7 +47889,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 74,
+            "line": 76,
           },
           "name": "architecture",
           "optional": true,
@@ -47625,7 +47907,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 79,
+            "line": 81,
           },
           "name": "auth",
           "optional": true,
@@ -47643,7 +47925,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 94,
+            "line": 96,
           },
           "name": "common",
           "optional": true,
@@ -47666,7 +47948,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 99,
+            "line": 101,
           },
           "name": "global",
           "optional": true,
@@ -47689,7 +47971,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 84,
+            "line": 86,
           },
           "name": "primary",
           "optional": true,
@@ -47707,7 +47989,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 89,
+            "line": 91,
           },
           "name": "secondary",
           "optional": true,
@@ -47757,6 +48039,7 @@ def check_type(argname: str, value: object, expected_type: typing.Any) -> typing
 
 from ._jsii import *
 
+import cdk8s as _cdk8s_d3d9af27
 import constructs as _constructs_77d1e7e8
 
 
@@ -47798,6 +48081,18 @@ class Mysql(
         )
 
         jsii.create(self.__class__, self, [scope, id, props])
+
+    @builtins.property
+    @jsii.member(jsii_name=\\"helm\\")
+    def helm(self) -> \\"_cdk8s_d3d9af27.Helm\\":
+        return typing.cast(\\"_cdk8s_d3d9af27.Helm\\", jsii.get(self, \\"helm\\"))
+
+    @helm.setter
+    def helm(self, value: \\"_cdk8s_d3d9af27.Helm\\") -> None:
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__6a97335aab88f219ab5d33fb1f96a2580c2e2edc13fd76a090b1f7ebb25cbd52)
+            check_type(argname=\\"argument value\\", value=value, expected_type=type_hints[\\"value\\"])
+        jsii.set(self, \\"helm\\", value) # pyright: ignore[reportArgumentType]
 
 
 @jsii.enum(jsii_type=\\"mysql.MysqlArchitecture\\")
@@ -48873,6 +49168,12 @@ def _typecheckingstub__95a811b01af67eee2d8e2ae24fcefa9fa2ac995a1f9685f3e921af533
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
 
+def _typecheckingstub__6a97335aab88f219ab5d33fb1f96a2580c2e2edc13fd76a090b1f7ebb25cbd52(
+    value: _cdk8s_d3d9af27.Helm,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
 def _typecheckingstub__ee06bc5fa81868398bad26c41946af017c8765bcca5abe66e5d88d360a20e315(
     *,
     password: builtins.str,
@@ -49125,7 +49426,7 @@ Object {
       "initializer": Object {
         "locationInModule": Object {
           "filename": "mysql.ts",
-          "line": 14,
+          "line": 16,
         },
         "parameters": Array [
           Object {
@@ -49155,6 +49456,18 @@ Object {
         "line": 13,
       },
       "name": "Mysql",
+      "properties": Array [
+        Object {
+          "locationInModule": Object {
+            "filename": "mysql.ts",
+            "line": 14,
+          },
+          "name": "helm",
+          "type": Object {
+            "fqn": "cdk8s.Helm",
+          },
+        },
+      ],
       "symbolId": "mysql:Mysql",
     },
     "mysql.MysqlArchitecture": Object {
@@ -49169,7 +49482,7 @@ Object {
       "kind": "enum",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 134,
+        "line": 136,
       },
       "members": Array [
         Object {
@@ -49200,7 +49513,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 144,
+        "line": 146,
       },
       "name": "MysqlAuth",
       "properties": Array [
@@ -49214,7 +49527,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 166,
+            "line": 168,
           },
           "name": "password",
           "type": Object {
@@ -49231,7 +49544,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 161,
+            "line": 163,
           },
           "name": "username",
           "type": Object {
@@ -49249,7 +49562,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 188,
+            "line": 190,
           },
           "name": "additionalValues",
           "optional": true,
@@ -49272,7 +49585,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 181,
+            "line": 183,
           },
           "name": "createDatabase",
           "optional": true,
@@ -49290,7 +49603,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 156,
+            "line": 158,
           },
           "name": "database",
           "optional": true,
@@ -49308,7 +49621,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 176,
+            "line": 178,
           },
           "name": "replicationPassword",
           "optional": true,
@@ -49326,7 +49639,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 171,
+            "line": 173,
           },
           "name": "replicationUser",
           "optional": true,
@@ -49346,7 +49659,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 151,
+            "line": 153,
           },
           "name": "rootPassword",
           "optional": true,
@@ -49369,7 +49682,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 215,
+        "line": 217,
       },
       "name": "MysqlPrimary",
       "properties": Array [
@@ -49384,7 +49697,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 236,
+            "line": 238,
           },
           "name": "additionalValues",
           "optional": true,
@@ -49407,7 +49720,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 224,
+            "line": 226,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -49425,7 +49738,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 229,
+            "line": 231,
           },
           "name": "persistence",
           "optional": true,
@@ -49443,7 +49756,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 219,
+            "line": 221,
           },
           "name": "podSecurityContext",
           "optional": true,
@@ -49466,7 +49779,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 341,
+        "line": 343,
       },
       "name": "MysqlPrimaryContainerSecurityContext",
       "properties": Array [
@@ -49481,7 +49794,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 357,
+            "line": 359,
           },
           "name": "additionalValues",
           "optional": true,
@@ -49504,7 +49817,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 345,
+            "line": 347,
           },
           "name": "enabled",
           "optional": true,
@@ -49522,7 +49835,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 350,
+            "line": 352,
           },
           "name": "runAsUser",
           "optional": true,
@@ -49545,7 +49858,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 379,
+        "line": 381,
       },
       "name": "MysqlPrimaryPersistence",
       "properties": Array [
@@ -49560,7 +49873,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 395,
+            "line": 397,
           },
           "name": "additionalValues",
           "optional": true,
@@ -49583,7 +49896,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 383,
+            "line": 385,
           },
           "name": "enabled",
           "optional": true,
@@ -49601,7 +49914,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 388,
+            "line": 390,
           },
           "name": "size",
           "optional": true,
@@ -49624,7 +49937,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 303,
+        "line": 305,
       },
       "name": "MysqlPrimaryPodSecurityContext",
       "properties": Array [
@@ -49639,7 +49952,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 319,
+            "line": 321,
           },
           "name": "additionalValues",
           "optional": true,
@@ -49662,7 +49975,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 307,
+            "line": 309,
           },
           "name": "enabled",
           "optional": true,
@@ -49680,7 +49993,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 312,
+            "line": 314,
           },
           "name": "fsGroup",
           "optional": true,
@@ -49787,7 +50100,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 259,
+        "line": 261,
       },
       "name": "MysqlSecondary",
       "properties": Array [
@@ -49802,7 +50115,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 280,
+            "line": 282,
           },
           "name": "additionalValues",
           "optional": true,
@@ -49825,7 +50138,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 268,
+            "line": 270,
           },
           "name": "containerSecurityContext",
           "optional": true,
@@ -49843,7 +50156,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 273,
+            "line": 275,
           },
           "name": "persistence",
           "optional": true,
@@ -49861,7 +50174,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 263,
+            "line": 265,
           },
           "name": "podSecurityContext",
           "optional": true,
@@ -49884,7 +50197,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 455,
+        "line": 457,
       },
       "name": "MysqlSecondaryContainerSecurityContext",
       "properties": Array [
@@ -49899,7 +50212,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 471,
+            "line": 473,
           },
           "name": "additionalValues",
           "optional": true,
@@ -49922,7 +50235,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 459,
+            "line": 461,
           },
           "name": "enabled",
           "optional": true,
@@ -49940,7 +50253,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 464,
+            "line": 466,
           },
           "name": "runAsUser",
           "optional": true,
@@ -49963,7 +50276,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 493,
+        "line": 495,
       },
       "name": "MysqlSecondaryPersistence",
       "properties": Array [
@@ -49978,7 +50291,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 509,
+            "line": 511,
           },
           "name": "additionalValues",
           "optional": true,
@@ -50001,7 +50314,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 497,
+            "line": 499,
           },
           "name": "enabled",
           "optional": true,
@@ -50019,7 +50332,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 502,
+            "line": 504,
           },
           "name": "size",
           "optional": true,
@@ -50042,7 +50355,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 417,
+        "line": 419,
       },
       "name": "MysqlSecondaryPodSecurityContext",
       "properties": Array [
@@ -50057,7 +50370,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 433,
+            "line": 435,
           },
           "name": "additionalValues",
           "optional": true,
@@ -50080,7 +50393,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 421,
+            "line": 423,
           },
           "name": "enabled",
           "optional": true,
@@ -50098,7 +50411,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 426,
+            "line": 428,
           },
           "name": "fsGroup",
           "optional": true,
@@ -50121,7 +50434,7 @@ Object {
       "kind": "interface",
       "locationInModule": Object {
         "filename": "mysql.ts",
-        "line": 68,
+        "line": 70,
       },
       "name": "MysqlValues",
       "properties": Array [
@@ -50136,7 +50449,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 106,
+            "line": 108,
           },
           "name": "additionalValues",
           "optional": true,
@@ -50160,7 +50473,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 74,
+            "line": 76,
           },
           "name": "architecture",
           "optional": true,
@@ -50178,7 +50491,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 79,
+            "line": 81,
           },
           "name": "auth",
           "optional": true,
@@ -50196,7 +50509,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 94,
+            "line": 96,
           },
           "name": "common",
           "optional": true,
@@ -50219,7 +50532,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 99,
+            "line": 101,
           },
           "name": "global",
           "optional": true,
@@ -50242,7 +50555,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 84,
+            "line": 86,
           },
           "name": "primary",
           "optional": true,
@@ -50260,7 +50573,7 @@ Object {
           "immutable": true,
           "locationInModule": Object {
             "filename": "mysql.ts",
-            "line": 89,
+            "line": 91,
           },
           "name": "secondary",
           "optional": true,
@@ -50291,6 +50604,8 @@ export interface MysqlProps {
 }
 
 export class Mysql extends Construct {
+  public helm: Helm;
+
   public constructor(scope: Construct, id: string, props: MysqlProps = {}) {
     super(scope, id);
     let updatedProps = {};
@@ -50315,7 +50630,7 @@ export class Mysql extends Construct {
       ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
     };
 
-    new Helm(this, 'Helm', finalProps);
+    this.helm = new Helm(this, 'Helm', finalProps);
   }
 
   private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {
@@ -50905,7 +51220,7 @@ Object {
       "initializer": Object {
         "locationInModule": Object {
           "filename": "operator.ts",
-          "line": 14,
+          "line": 16,
         },
         "parameters": Array [
           Object {
@@ -50935,6 +51250,18 @@ Object {
         "line": 13,
       },
       "name": "Operator",
+      "properties": Array [
+        Object {
+          "locationInModule": Object {
+            "filename": "operator.ts",
+            "line": 14,
+          },
+          "name": "helm",
+          "type": Object {
+            "fqn": "cdk8s.Helm",
+          },
+        },
+      ],
       "symbolId": "operator:Operator",
     },
     "operator.OperatorProps": Object {
@@ -51065,6 +51392,7 @@ def check_type(argname: str, value: object, expected_type: typing.Any) -> typing
 
 from ._jsii import *
 
+import cdk8s as _cdk8s_d3d9af27
 import constructs as _constructs_77d1e7e8
 
 
@@ -51106,6 +51434,18 @@ class Operator(
         )
 
         jsii.create(self.__class__, self, [scope, id, props])
+
+    @builtins.property
+    @jsii.member(jsii_name=\\"helm\\")
+    def helm(self) -> \\"_cdk8s_d3d9af27.Helm\\":
+        return typing.cast(\\"_cdk8s_d3d9af27.Helm\\", jsii.get(self, \\"helm\\"))
+
+    @helm.setter
+    def helm(self, value: \\"_cdk8s_d3d9af27.Helm\\") -> None:
+        if __debug__:
+            type_hints = typing.get_type_hints(_typecheckingstub__bbe1b5f7f477ccaaae9562435a3e43413b51ac77fa72bfc34d370f1284d8f1e1)
+            check_type(argname=\\"argument value\\", value=value, expected_type=type_hints[\\"value\\"])
+        jsii.set(self, \\"helm\\", value) # pyright: ignore[reportArgumentType]
 
 
 @jsii.data_type(
@@ -51208,6 +51548,12 @@ def _typecheckingstub__11493dc2fc191cbb73ceb199e0facf7edcc58bf9f85942664ecc4614b
     namespace: typing.Optional[builtins.str] = None,
     release_name: typing.Optional[builtins.str] = None,
     values: typing.Optional[typing.Mapping[builtins.str, typing.Any]] = None,
+) -> None:
+    \\"\\"\\"Type checking stubs\\"\\"\\"
+    pass
+
+def _typecheckingstub__bbe1b5f7f477ccaaae9562435a3e43413b51ac77fa72bfc34d370f1284d8f1e1(
+    value: _cdk8s_d3d9af27.Helm,
 ) -> None:
     \\"\\"\\"Type checking stubs\\"\\"\\"
     pass
@@ -51363,7 +51709,7 @@ Object {
       "initializer": Object {
         "locationInModule": Object {
           "filename": "operator.ts",
-          "line": 14,
+          "line": 16,
         },
         "parameters": Array [
           Object {
@@ -51393,6 +51739,18 @@ Object {
         "line": 13,
       },
       "name": "Operator",
+      "properties": Array [
+        Object {
+          "locationInModule": Object {
+            "filename": "operator.ts",
+            "line": 14,
+          },
+          "name": "helm",
+          "type": Object {
+            "fqn": "cdk8s.Helm",
+          },
+        },
+      ],
       "symbolId": "operator:Operator",
     },
     "operator.OperatorProps": Object {
@@ -51504,6 +51862,8 @@ export interface OperatorProps {
 }
 
 export class Operator extends Construct {
+  public helm: Helm;
+
   public constructor(scope: Construct, id: string, props: OperatorProps = {}) {
     super(scope, id);
     let updatedProps = {};
@@ -51529,7 +51889,7 @@ export class Operator extends Construct {
       ...(Object.keys(updatedProps).length !== 0 ? updatedProps : props),
     };
 
-    new Helm(this, 'Helm', finalProps);
+    this.helm = new Helm(this, 'Helm', finalProps);
   }
 
   private flattenAdditionalValues(props: { [key: string]: any }): { [key: string]: any } {


### PR DESCRIPTION
The `Helm` class extends `Include` and expose `apiObjects`, which is useful for [patching](https://cdk8s.io/docs/latest/basics/escape-hatches/#target-programming-language-language) the synthesized output using JSON Patch.

Expose the `Helm` object so Helm chart class can be patched too.
