### PR TITLE
chore: bump setup-go to v6

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install uv
         run: pip install uv
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: "1.18"
       - name: Run integration tests

--- a/projenrc/integ.ts
+++ b/projenrc/integ.ts
@@ -100,7 +100,7 @@ function runSteps(tasks: string[], nodeVersion: string, python: boolean, go: boo
   if (go) {
     steps.push({
       name: 'Set up Go',
-      uses: 'actions/setup-go@v4',
+      uses: 'actions/setup-go@v6',
       with: {
         'go-version': '1.18',
       },


### PR DESCRIPTION
Fix CI failure downloading Go with setup-go.

https://github.com/cdk8s-team/cdk8s-cli/actions/runs/20021121839/job/57408042593

See https://github.com/actions/setup-go/pull/665, https://github.com/actions/setup-go/releases/tag/v6.1.0.



