### PR TITLE
chore: update go version in the integ workflow to 1.24

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.18"
+          go-version: "1.24"
       - name: Run integration tests
         run: yarn run integ:init
     strategy:

--- a/projenrc/integ.ts
+++ b/projenrc/integ.ts
@@ -102,7 +102,7 @@ function runSteps(tasks: string[], nodeVersion: string, python: boolean, go: boo
       name: 'Set up Go',
       uses: 'actions/setup-go@v4',
       with: {
-        'go-version': '1.18',
+        'go-version': '1.24',
       },
     });
   }


### PR DESCRIPTION
At the time of writing, 1.24.11 and 1.25.5 are the stable versions.

Unless we specify one of these versions explicitly, we'll get the following error when running the `integ.yml` workflow:

```
Acquiring go1.17.13 from https://storage.googleapis.com/golang/go1.17.13.linux-arm64.tar.gz
Error: Failed to download version 1.17: Error: Unexpected HTTP response: 403
```