### PR TITLE
feat(cli): bump default `cdk8s-plus` dependency to 33

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Run integration tests
         run: yarn run integ:init
     strategy:

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -106,7 +106,7 @@
       "type": "runtime"
     },
     {
-      "name": "cdk8s-plus-28",
+      "name": "cdk8s-plus-33",
       "type": "runtime"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -485,13 +485,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=prod,optional --filter=ajv,cdk8s,cdk8s-plus-28,codemaker,colors,constructs,jsii-pacmak,jsii-rosetta,semver,sscaff,table,yaml"
+          "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=prod,optional --filter=ajv,cdk8s,cdk8s-plus-33,codemaker,colors,constructs,jsii-pacmak,jsii-rosetta,semver,sscaff,table,yaml"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @types/node ajv cdk8s cdk8s-plus-28 codemaker colors constructs fs-extra jsii-pacmak jsii-rosetta jsii-srcmak json2jsii semver sscaff table yaml yargs"
+          "exec": "yarn upgrade @types/node ajv cdk8s cdk8s-plus-33 codemaker colors constructs fs-extra jsii-pacmak jsii-rosetta jsii-srcmak json2jsii semver sscaff table yaml yargs"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -30,7 +30,7 @@ const project = new Cdk8sTeamTypeScriptProject({
   // upgrading them may introduce breaking changes to our API.
   deps: [
     'cdk8s',
-    'cdk8s-plus-28',
+    'cdk8s-plus-33',
     'codemaker',
     'constructs',
     'fs-extra@^8',

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@types/node": "^16",
     "ajv": "^8.18.0",
     "cdk8s": "^2.70.47",
-    "cdk8s-plus-28": "^2.5.6",
+    "cdk8s-plus-33": "^2.4.38",
     "codemaker": "^1.126.0",
     "colors": "1.4.0",
     "constructs": "^10.4.5",

--- a/projenrc/integ.ts
+++ b/projenrc/integ.ts
@@ -102,7 +102,7 @@ function runSteps(tasks: string[], nodeVersion: string, python: boolean, go: boo
       name: 'Set up Go',
       uses: 'actions/setup-go@v6',
       with: {
-        'go-version': '1.24',
+        'go-version': '1.25',
       },
     });
   }

--- a/src/cli/cmds/init.ts
+++ b/src/cli/cmds/init.ts
@@ -42,7 +42,7 @@ class Command implements yargs.CommandModule {
 
 async function determineDeps(): Promise<Deps> {
   const cdk8s = new ModuleVersion('cdk8s', { jsii: true });
-  const cdk8sPlus = new ModuleVersion('cdk8s-plus-28', { jsii: true });
+  const cdk8sPlus = new ModuleVersion('cdk8s-plus-33', { jsii: true });
   const cdk8sCli = new ModuleVersion('cdk8s-cli');
   const jsii = new ModuleVersion('jsii-pacmak');
 

--- a/templates/java-app/.hooks.sscaff.js
+++ b/templates/java-app/.hooks.sscaff.js
@@ -31,7 +31,7 @@ exports.post = options => {
   }
 
   if (mvn_cdk8s_plus.endsWith('.jar')) {
-    execSync(`mvn install:install-file -Dfile=${mvn_cdk8s_plus} -DgroupId=org.cdk8s -DartifactId=cdk8s-plus-28 -Dversion=${cdk8s_plus_version} -Dpackaging=jar`)
+    execSync(`mvn install:install-file -Dfile=${mvn_cdk8s_plus} -DgroupId=org.cdk8s -DartifactId=cdk8s-plus-33 -Dversion=${cdk8s_plus_version} -Dpackaging=jar`)
   }
 
   execSync(`mvn install`);

--- a/templates/java-app/pom.xml
+++ b/templates/java-app/pom.xml
@@ -15,7 +15,7 @@
     </dependency>
     <dependency>
       <groupId>org.cdk8s</groupId>
-      <artifactId>cdk8s-plus-28</artifactId>
+      <artifactId>cdk8s-plus-33</artifactId>
       <version>{{ cdk8s_plus_version }}</version>
     </dependency>
     <dependency>

--- a/templates/typescript-app/package.json
+++ b/templates/typescript-app/package.json
@@ -22,11 +22,11 @@
   },
   "devDependencies": {
     "cdk8s-cli": "{{ cdk8s_cli_spec }}",
-    "@types/node": "^14",
-    "@types/jest": "^27",
-    "jest": "^27",
-    "ts-jest": "^27",
-    "typescript": "^4.9.5",
+    "@types/node": "^20",
+    "@types/jest": "^29",
+    "jest": "^29",
+    "ts-jest": "^29",
+    "typescript": "5.9.x",
     "ts-node": "^10"
   }
 }

--- a/templates/typescript-app/package.json
+++ b/templates/typescript-app/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "cdk8s-cli": "{{ cdk8s_cli_spec }}",
-    "@types/node": "^20",
+    "@types/node": "^14",
     "@types/jest": "^29",
     "jest": "^29",
     "ts-jest": "^29",

--- a/templates/typescript-app/package.json
+++ b/templates/typescript-app/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "cdk8s": "^{{ cdk8s_core_version }}",
-    "cdk8s-plus-28": "^{{ cdk8s_plus_version }}",
+    "cdk8s-plus-33": "^{{ cdk8s_plus_version }}",
     "constructs": "^{{ constructs_version }}"
   },
   "devDependencies": {

--- a/templates/typescript-app/tsconfig.json
+++ b/templates/typescript-app/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "alwaysStrict": true,
-    "charset": "utf8",
     "declaration": true,
     "experimentalDecorators": true,
     "inlineSourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1300,7 +1300,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace-expansion@^2.0.1:
+brace-expansion@^2.0.1, brace-expansion@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
   integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
@@ -1409,12 +1409,12 @@ case@^1.6.3:
   resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
   integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
-cdk8s-plus-28@^2.5.6:
-  version "2.5.6"
-  resolved "https://registry.yarnpkg.com/cdk8s-plus-28/-/cdk8s-plus-28-2.5.6.tgz#7927bbe8add0c66ca5a6033d0574f8ebfa8bc7e0"
-  integrity sha512-ghANDg6Qmsr3vQlEig7ZDWD03ZPXkjae7ks0HaRy2clIW553mCSTjcZirvuJGaIHDN2OV2S1dLXjdIYuMq3qOA==
+cdk8s-plus-33@^2.4.38:
+  version "2.4.38"
+  resolved "https://registry.yarnpkg.com/cdk8s-plus-33/-/cdk8s-plus-33-2.4.38.tgz#c080279552b304434d3e7c1cf4a47ee03074c51c"
+  integrity sha512-Cjy8UV2Sb+blZiEMt8148gFJITN7Qw2S58YnLeOYqZ1zuPgnD/HfzGH0nFnuoMu5Cdedrs06lnt2LXOTxdnZrA==
   dependencies:
-    minimatch "^3.1.2"
+    minimatch "^9.0.9"
 
 cdk8s@^2.70.47:
   version "2.70.47"
@@ -4113,6 +4113,13 @@ minimatch@^9.0.5:
   integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
   dependencies:
     brace-expansion "^2.0.1"
+
+minimatch@^9.0.9:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+  dependencies:
+    brace-expansion "^2.0.2"
 
 minimist-options@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
Version 28 is EOL long ago, 33 is the lowest version still supported. 

https://endoflife.date/kubernetes

This also resolves a transitive mnimatch vulnerability. 